### PR TITLE
Fix ReferenceError in CPTabView selectTabViewItemAtIndex

### DIFF
--- a/AppKit/CPTabView.j
+++ b/AppKit/CPTabView.j
@@ -244,6 +244,8 @@ var HEIGHT_OF_SEGMENTED_CONTROL = 24;
 */
 - (void)selectTabViewItemAtIndex:(unsigned)anIndex
 {
+    var aTabViewItem = [items objectAtIndex:anIndex];
+
     if (anIndex === selectedIndex)
         return;
     


### PR DESCRIPTION
There's no aTabViewItem in selectTabViewItemAtIndex right now. This commit adds it.
