### PR TITLE
CGGradientCreateWithColorComponents location fix

### DIFF
--- a/AppKit/CoreGraphics/CGGradient.j
+++ b/AppKit/CoreGraphics/CGGradient.j
@@ -29,17 +29,20 @@ kCGGradientDrawsAfterEndLocation    = 1 << 1;
 
 function CGGradientCreateWithColorComponents(aColorSpace, components, locations, count)
 {
+    if (arguments["locations"] == NULL)
+        var locations = [0.0, 1.0];
+
     if (arguments["count"] == NULL)
         var count = locations.length;
 
     var colors = [];
-    
+
     while (count--)
     {
         var offset = count * 4;
         colors[count] = CGColorCreate(aColorSpace, components.slice(offset, offset + 4));
     }
-    
+
     return CGGradientCreateWithColors(aColorSpace, colors, locations);
 }
 


### PR DESCRIPTION
Adjusts the implementation of CGGradientCreateWithColorComponents to be more in line with the Quartz 2D documentation, specifically this part: "If you pass NULL for the locations array, Quartz uses 0 for the first location and 1 for the second."
