### PR TITLE
Fixed a regression to setBorderType in CPBox

### DIFF
--- a/AppKit/CPBox.j
+++ b/AppKit/CPBox.j
@@ -104,7 +104,7 @@ CPGrooveBorder  = 3;
     if (_borderType === aBorderType)
         return;
 
-    _borderType = value;
+    _borderType = aBorderType;
     [self setNeedsDisplay:YES];
 }
 


### PR DESCRIPTION
A bug was introduced in CPBox's setBorderType that causes applications that call it to crash.  The bug was introduced in commit fcbf87858b902dba970ca67a3fb17076f0b420a and is fixed by the change in this pull request.
