### PR TITLE
CPButton copy bounds fix

### DIFF
--- a/AppKit/CPButton.j
+++ b/AppKit/CPButton.j
@@ -435,6 +435,7 @@ CPButtonImageOffset   = 3.0;
     if (_CGInsetIsEmpty(contentInset))
         return bounds;
 
+    bounds = _CGRectMakeCopy(bounds);
     bounds.origin.x += contentInset.left;
     bounds.origin.y += contentInset.top;
     bounds.size.width -= contentInset.left + contentInset.right;
@@ -453,6 +454,7 @@ CPButtonImageOffset   = 3.0;
     if (_CGInsetIsEmpty(bezelInset))
         return bounds;
 
+    bounds = _CGRectMakeCopy(bounds);
     bounds.origin.x += bezelInset.left;
     bounds.origin.y += bezelInset.top;
     bounds.size.width -= bezelInset.left + bezelInset.right;


### PR DESCRIPTION
CPButton bezelRectForBounds and contentRectForBounds were modifying the bounds parameter in place without copying it.
