### PR TITLE
Fix a bunch of missing @imports

### DIFF
--- a/AppKit/CPAccordionView.j
+++ b/AppKit/CPAccordionView.j
@@ -27,6 +27,7 @@
 @import <Foundation/CPString.j>
 
 @import <AppKit/CPView.j>
+@import <AppKit/CPButton.j>
 
 #import "CoreGraphics/CGGeometry.h"
 

--- a/AppKit/CPArrayController.j
+++ b/AppKit/CPArrayController.j
@@ -23,6 +23,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+@import <Foundation/CPIndexSet.j>
+
 @import <AppKit/CPObjectController.j>
 @import <AppKit/CPKeyValueBinding.j>
 

--- a/AppKit/CPBrowser.j
+++ b/AppKit/CPBrowser.j
@@ -20,9 +20,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+@import <Foundation/CPIndexSet.j>
+
 @import "CPControl.j"
 @import "CPImage.j"
 @import "CPTableView.j"
+@import "CPTextField.j"
 @import "CPScrollView.j"
 
 /*!
@@ -807,6 +810,8 @@ var _CPBrowserResizeControlBackgroundImage = nil;
 }
 
 @end
+
+@import <Foundation/CPObject.j>
 
 @implementation _CPBrowserTableDelegate : CPObject
 {

--- a/AppKit/CPColorPanel.j
+++ b/AppKit/CPColorPanel.j
@@ -20,6 +20,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+@import "CPApplication.j"
 @import "CPButton.j"
 @import "CPCookie.j"
 @import "CPPanel.j"

--- a/AppKit/CPColorPicker.j
+++ b/AppKit/CPColorPicker.j
@@ -21,7 +21,7 @@
  */
 
 @import <Foundation/CPObject.j>
-@import "CPColorPanel.j"
+@import <AppKit/CPView.j>
 
 #include "Platform/Platform.h"
 

--- a/AppKit/CPController.j
+++ b/AppKit/CPController.j
@@ -11,6 +11,8 @@
 // 
 
 
+@import <Foundation/CPObject.j>
+
 var CPControllerDeclaredKeysKey = @"CPControllerDeclaredKeysKey";
 
 @implementation CPController : CPObject

--- a/AppKit/CPCursor.j
+++ b/AppKit/CPCursor.j
@@ -14,6 +14,8 @@ Implemented class methods:
 
 #include "Platform/Platform.h"
 
+@import <Foundation/CPObject.j>
+
 var currentCursor = nil,
     cursorStack = [],
     cursors = {},

--- a/AppKit/CPDocument.j
+++ b/AppKit/CPDocument.j
@@ -23,6 +23,7 @@
 @import <Foundation/CPString.j>
 @import <Foundation/CPArray.j>
 
+@import "CPApplication.j"
 @import "CPResponder.j"
 @import "CPSavePanel.j"
 @import "CPViewController.j"

--- a/AppKit/CPDragServer.j
+++ b/AppKit/CPDragServer.j
@@ -20,10 +20,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-@import <AppKit/CPView.j>
+@import <AppKit/CPApplication.j>
 @import <AppKit/CPEvent.j>
-@import <AppKit/CPPasteboard.j>
 @import <AppKit/CPImageView.j>
+@import <AppKit/CPPasteboard.j>
+@import <AppKit/CPView.j>
+@import <AppKit/CPWindow.j>
 
 #import "CoreGraphics/CGGeometry.h"
 #import "Platform/Platform.h"

--- a/AppKit/CPFont.j
+++ b/AppKit/CPFont.j
@@ -20,6 +20,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+@import <Foundation/CPObject.j>
+@import <Foundation/CPBundle.j>
+
+@import <AppKit/CPView.j>
+
 var _CPFonts                = {},
     _CPFontSystemFontFace   = @"Arial, sans-serif",
     _CPWrapRegExp           = new RegExp("\\s*,\\s*", "g");

--- a/AppKit/CPGraphicsContext.j
+++ b/AppKit/CPGraphicsContext.j
@@ -20,6 +20,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+@import <Foundation/CPObject.j>
+@import <AppKit/CGContext.j>
+
 var CPGraphicsContextCurrent    = nil;
 
 /*!

--- a/AppKit/CPKeyBinding.j
+++ b/AppKit/CPKeyBinding.j
@@ -21,6 +21,7 @@
  */
 
 @import <Foundation/CPObject.j>
+@import <AppKit/CPEvent.j>
 
 
 CPStandardKeyBindings = {

--- a/AppKit/CPMenu/_CPMenuBarWindow.j
+++ b/AppKit/CPMenu/_CPMenuBarWindow.j
@@ -2,6 +2,7 @@
 #include "../CoreGraphics/CGGeometry.h"
 #include "../Platform/Platform.h"
 
+@import "CPPanel.j"
 @import "_CPMenuWindow.j"
 
 

--- a/AppKit/CPMenu/_CPMenuWindow.j
+++ b/AppKit/CPMenu/_CPMenuWindow.j
@@ -1,6 +1,7 @@
 
 #include "../CoreGraphics/CGGeometry.h"
 
+@import <AppKit/CPWindow.j>
 
 var _CPMenuWindowPool                       = [],
     _CPMenuWindowPoolCapacity               = 5,

--- a/AppKit/CPMenuItem/_CPMenuItemMenuBarView.j
+++ b/AppKit/CPMenuItem/_CPMenuItemMenuBarView.j
@@ -1,3 +1,5 @@
+@import <AppKit/CPView.j>
+
 var HORIZONTAL_MARGIN           = 8.0,
     SUBMENU_INDICATOR_MARGIN    = 3.0,
     VERTICAL_MARGIN             = 4.0;

--- a/AppKit/CPMenuItem/_CPMenuItemStandardView.j
+++ b/AppKit/CPMenuItem/_CPMenuItemStandardView.j
@@ -1,3 +1,5 @@
+@import <AppKit/CPControl.j>
+
 var LEFT_MARGIN                 = 3.0,
     RIGHT_MARGIN                = 14.0 + 3.0,
     STATE_COLUMN_WIDTH          = 14.0,

--- a/AppKit/CPMenuItem/_CPMenuItemView.j
+++ b/AppKit/CPMenuItem/_CPMenuItemView.j
@@ -1,4 +1,6 @@
 
+@import <AppKit/CPControl.j>
+
 @import "_CPMenuItemSeparatorView.j"
 @import "_CPMenuItemStandardView.j"
 @import "_CPMenuItemMenuBarView.j"

--- a/AppKit/CPScrollView.j
+++ b/AppKit/CPScrollView.j
@@ -20,9 +20,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-@import "CPView.j"
+@import "CPBox.j"
 @import "CPClipView.j"
 @import "CPScroller.j"
+@import "CPView.j"
 
 #include "CoreGraphics/CGGeometry.h"
 

--- a/AppKit/CPSearchField.j
+++ b/AppKit/CPSearchField.j
@@ -20,6 +20,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+@import "CPButton.j"
 @import "CPTextField.j"
 
 #include "CoreGraphics/CGGeometry.h"

--- a/AppKit/CPSliderColorPicker.j
+++ b/AppKit/CPSliderColorPicker.j
@@ -20,6 +20,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+@import "CPView.j"
 @import "CPColorPicker.j"
 
 #include "Platform/Platform.h"

--- a/AppKit/CPTabView.j
+++ b/AppKit/CPTabView.j
@@ -1,5 +1,7 @@
-@import <AppKit/CPView.j>
+@import <AppKit/CPBox.j>
+@import <AppKit/CPSegmentedControl.j>
 @import <AppKit/CPTabViewItem.j>
+@import <AppKit/CPView.j>
 
 /*
     Places tabs on top with a bezeled border.

--- a/AppKit/CPTableColumn.j
+++ b/AppKit/CPTableColumn.j
@@ -22,6 +22,7 @@
 
 @import <Foundation/CPDictionary.j>
 @import <Foundation/CPObject.j>
+@import <Foundation/CPIndexSet.j>
 @import <Foundation/CPSortDescriptor.j>
 @import <Foundation/CPString.j>
 

--- a/AppKit/CPTableHeaderView.j
+++ b/AppKit/CPTableHeaderView.j
@@ -20,6 +20,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+@import <Foundation/CPIndexSet.j>
+
 @import "CPTableColumn.j"
 @import "CPTableView.j"
 @import "CPView.j"

--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -21,6 +21,7 @@
  */
 
 @import <Foundation/CPArray.j>
+@import <Foundation/CPIndexSet.j>
 @import <AppKit/CGGradient.j>
 
 @import "CPControl.j"

--- a/AppKit/CPText.j
+++ b/AppKit/CPText.j
@@ -20,8 +20,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-@import "CPView.j"
-
 CPEnterCharacter                = "\u0003";
 CPBackspaceCharacter            = "\u0008";
 CPTabCharacter                  = "\u0009";

--- a/AppKit/CPTokenField.j
+++ b/AppKit/CPTokenField.j
@@ -20,7 +20,14 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+@import <Foundation/CPCharacterSet.j>
+@import <Foundation/CPIndexSet.j>
+
+@import <AppKit/CPButton.j>
+@import <AppKit/_CPMenuWindow.j>
+@import <AppKit/CPScrollView.j>
 @import <AppKit/CPTextField.j>
+@import <AppKit/CPWindow.j>
 
 #include "Platform/Platform.h"
 

--- a/AppKit/CPView.j
+++ b/AppKit/CPView.j
@@ -22,6 +22,7 @@
 
 @import <Foundation/CPArray.j>
 @import <Foundation/CPObjJRuntime.j>
+@import <Foundation/CPSet.j>
 
 @import "CGAffineTransform.j"
 @import "CGGeometry.j"

--- a/AppKit/CPViewController.j
+++ b/AppKit/CPViewController.j
@@ -20,6 +20,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+@import <Foundation/CPArray.j>
+
+@import <AppKit/CPApplication.j>
+@import <AppKit/CPCib.j>
 @import <AppKit/CPResponder.j>
 
 var CPViewControllerCachedCibs;

--- a/AppKit/CPWebView.j
+++ b/AppKit/CPWebView.j
@@ -21,6 +21,7 @@
  */
 
 @import <AppKit/CPView.j>
+@import <AppKit/CPScrollView.j>
 
 #include "Platform/Platform.h"
 

--- a/AppKit/CPWindow/CPWindow.j
+++ b/AppKit/CPWindow/CPWindow.j
@@ -26,9 +26,9 @@
 
 @import "CGGeometry.j"
 @import "CPAnimation.j"
+@import "CPPlatformWindow.j"
 @import "CPResponder.j"
 @import "CPScreen.j"
-@import "CPPlatformWindow.j"
 
 #include "../Platform/Platform.h"
 #include "../Platform/DOM/CPDOMDisplayServer.h"

--- a/AppKit/CPWindow/_CPWindowView.j
+++ b/AppKit/CPWindow/_CPWindowView.j
@@ -20,8 +20,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-@import "CPView.j"
 @import "CPImageView.j"
+@import "CPView.j"
 
 #include "../CoreGraphics/CGGeometry.h"
 

--- a/AppKit/Cib/_CPCibWindowTemplate.j
+++ b/AppKit/Cib/_CPCibWindowTemplate.j
@@ -1,6 +1,9 @@
 
 @import <Foundation/CPObject.j>
 
+@import <AppKit/CGGeometry.j>
+@import <AppKit/CPWindow.j>
+
 
 var _CPCibWindowTemplateMinSizeKey                  = @"_CPCibWindowTemplateMinSizeKey",
     _CPCibWindowTemplateMaxSizeKey                  = @"_CPCibWindowTemplateMaxSizeKey",

--- a/AppKit/CoreGraphics/CGContext.j
+++ b/AppKit/CoreGraphics/CGContext.j
@@ -23,8 +23,9 @@
 #include "CGGeometry.h"
 #include "CGAffineTransform.h"
 
-@import "CGGeometry.j"
 @import "CGAffineTransform.j"
+@import "CPCompatibility.j"
+@import "CGGeometry.j"
 @import "CGPath.j"
 
 kCGLineCapButt              = 0;

--- a/AppKit/_CPDisplayServer.j
+++ b/AppKit/_CPDisplayServer.j
@@ -24,6 +24,8 @@
 #include "CoreGraphics/CGAffineTransform.h"
 #include "Platform/DOM/CPDOMDisplayServer.h"
 
+@import <Foundation/CPRunLoop.j>
+
 PREPARE_DOM_OPTIMIZATION();
 
 var displayObjects      = [],

--- a/AppKit/_CPToolbarShowColorsItem.j
+++ b/AppKit/_CPToolbarShowColorsItem.j
@@ -20,6 +20,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+@import "CPApplication.j"
 @import "CPToolbarItem.j"
 
 

--- a/Foundation/CPCharacterSet.j
+++ b/Foundation/CPCharacterSet.j
@@ -6,6 +6,7 @@
 // Please see Cappuccino's LICENSE file for details.
 
 @import <Foundation/CPObject.j>
+@import <Foundation/CPString.j>
 
 // CPCharacterSet is a class cluster. Concrete implementations
 // follow after the main abstract class.

--- a/Foundation/CPKeyedUnarchiver.j
+++ b/Foundation/CPKeyedUnarchiver.j
@@ -20,8 +20,14 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+@import "CPArray.j"
+@import "CPData.j"
+@import "CPDictionary.j"
 @import "CPCoder.j"
+@import "CPKeyedArchiver.j"
 @import "CPNull.j"
+@import "CPNumber.j"
+@import "CPString.j"
 
 
 CPInvalidUnarchiveOperationException    = @"CPInvalidUnarchiveOperationException";

--- a/Foundation/CPOperation.j
+++ b/Foundation/CPOperation.j
@@ -20,6 +20,7 @@
  */
 
 @import "CPObject.j"
+@import "CPArray.j"
 
 /*!
     Operations receive very low priority for execution.

--- a/Foundation/CPOperationQueue.j
+++ b/Foundation/CPOperationQueue.j
@@ -23,6 +23,7 @@
 @import "CPInvocationOperation.j"
 @import "CPObject.j"
 @import "CPOperation.j"
+@import "CPTimer.j"
 
 // the global queue (mainQueue)
 var cpOperationMainQueue = nil;

--- a/Foundation/CPUndoManager.j
+++ b/Foundation/CPUndoManager.j
@@ -23,6 +23,7 @@
 @import "CPInvocation.j"
 @import "CPObject.j"
 @import "CPProxy.j"
+@import "CPRunLoop.j"
 
 
 var CPUndoManagerNormal     = 0,

--- a/Foundation/CPWebDAVManager.j
+++ b/Foundation/CPWebDAVManager.j
@@ -20,6 +20,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+@import <Foundation/CPObject.j>
+@import <Foundation/CPDictionary.j>
+@import <Foundation/CPURL.j>
+
 var setURLResourceValuesForKeysFromProperties = function(aURL, keys, properties)
 {
     var resourceType = [properties objectForKey:@"resourcetype"];


### PR DESCRIPTION
All classes (excluding the ones prefixed with underscores) in Foundation
and AppKit can now be loaded individually except CPOpenPanel and
CPSavePanel. These two classes have some sort of dependency cycle
that seems impossible to resolve without forward declarations (which
we don't have).

Here's a handy "one-liner" to test for missing @imports:

```
find . -name "*.j" | grep -v "+" | while read line; do class=$(basename $line | tr -d '.j'); echo -e "@import <$(basename $PWD)/$(basename $line)>\n[[$class alloc] init];" > test.j; error=$(objj test.j | grep -v "Error on line"); ref_error=$(echo $error | grep ReferenceError | cut -d' ' -f5); (([ ! -z "$ref_error" ] && [ ! "$ref_error" = "$class" ] && egrep "[^\w]$ref_error[^\w]" "$line" &>/dev/null) || ([ -z "$ref_error" ] && [ ! -z "$error" ])) && echo "Error in \"$line\": \"$error\"" | grep -v "Could not load file" | grep -v "Result of expression"; rm test.j; done
```

Run it from within the Foundation/ or AppKit/ dirs. Probably only works on JSC.
