### PR TITLE
Fix deprecation warnings

### DIFF
--- a/AppKit/Themes/CommonJS/blendtask.j
+++ b/AppKit/Themes/CommonJS/blendtask.j
@@ -6,7 +6,7 @@
 
 
 var FILE = require("file"),
-    TERM = require("term"),
+    TERM = require("narwhal/term"),
     task = require("jake").task,
     filedir = require("jake").filedir,
     BundleTask = require("objective-j/jake/bundletask").BundleTask;
@@ -32,7 +32,7 @@ BlendTask.prototype.infoPlist = function()
 {
     var infoPlist = BundleTask.prototype.infoPlist.apply(this, arguments);
 
-    infoPlist.setValueForKey("CPKeyedThemes", require("util").unique(this._keyedThemes));
+    infoPlist.setValueForKey("CPKeyedThemes", require("narwhal/util").unique(this._keyedThemes));
 
     return infoPlist;
 }

--- a/CommonJS/bin/flatten
+++ b/CommonJS/bin/flatten
@@ -8,12 +8,12 @@ require("narwhal").ensureEngine("rhino");
 
 var FILE = require("file");
 var OS = require("os");
-var UTIL = require("util");
+var UTIL = require("narwhal/util");
 
 var CACHEMANIFEST = require("objective-j/cache-manifest");
 
-var stream = require("term").stream;
-var parser = new (require("args").Parser)();
+var stream = require("narwhal/term").stream;
+var parser = new (require("narwhal/args").Parser)();
 
 parser.usage("INPUT_PROJECT OUTPUT_PROJECT");
 parser.help("Combine a Cappuccino application into a single JavaScript file.");

--- a/CommonJS/bin/ojdepcheck
+++ b/CommonJS/bin/ojdepcheck
@@ -8,8 +8,8 @@ require("narwhal").ensureEngine("rhino");
 
 var FILE = require("file");
 
-var stream = require("term").stream
-var parser = new (require("args").Parser)();
+var stream = require("narwhal/term").stream
+var parser = new (require("narwhal/args").Parser)();
 
 parser.usage("INPUT_PROJECT");
 parser.help("Checks a project for missing imports.");

--- a/CommonJS/bin/press
+++ b/CommonJS/bin/press
@@ -12,8 +12,8 @@ var OS = require("os");
 
 var CACHEMANIFEST = require("objective-j/cache-manifest");
 
-var stream = require("term").stream;
-var parser = new (require("args").Parser)();
+var stream = require("narwhal/term").stream;
+var parser = new (require("narwhal/args").Parser)();
 
 parser.usage("INPUT_PROJECT OUTPUT_PROJECT");
 parser.help("Analyze and strip unused files from a Cappuccino project's .sj bundles.");

--- a/Jakefile
+++ b/Jakefile
@@ -4,9 +4,9 @@ require("./common.jake");
 var FILE = require("file"),
     SYSTEM = require("system"),
     OS = require("os"),
-    UTIL = require("util"),
+    UTIL = require("narwhal/util"),
     jake = require("jake"),
-    stream = require("term").stream;
+    stream = require("narwhal/term").stream;
 
 var subprojects = ["Objective-J", "CommonJS", "Foundation", "AppKit", "Tools"];
 

--- a/Objective-J/CPLog.js
+++ b/Objective-J/CPLog.js
@@ -182,7 +182,7 @@ GLOBAL(CPLogPrint) = function(aString, aLevel, aTitle, aFormatter)
 {
     if (stream === undefined) {
         try {
-            stream = require("term").stream;
+            stream = require("narwhal/term").stream;
         } catch (e) {
             stream = null;
         }

--- a/Objective-J/CommonJS/bin/cplutil
+++ b/Objective-J/CommonJS/bin/cplutil
@@ -5,7 +5,7 @@ var FILE = require("file"),
     OS = require("os"),
     ObjectiveJ = require("objective-j");
 
-var parser = new (require("args").Parser)();
+var parser = new (require("narwhal/args").Parser)();
 
 parser.usage("file...");
 parser.help("Cappuccino plist converter.");

--- a/Objective-J/CommonJS/lib/objective-j.js
+++ b/Objective-J/CommonJS/lib/objective-j.js
@@ -23,7 +23,7 @@ var OBJJ_INCLUDE_PATHS = global.OBJJ_INCLUDE_PATHS = exports.OBJJ_INCLUDE_PATHS 
 exports.objj_frameworks = [];
 exports.objj_debug_frameworks = [];
 
-var catalog = require("packages").catalog;
+var catalog = require("narwhal/packages").catalog;
 for (var name in catalog)
 {
     if (!catalog.hasOwnProperty(name))

--- a/Objective-J/CommonJS/lib/objective-j/jake/bundletask.js
+++ b/Objective-J/CommonJS/lib/objective-j/jake/bundletask.js
@@ -1,8 +1,8 @@
 
 var FILE = require("file"),
     OS = require("os"),
-    UTIL = require("util"),
-    TERM = require("term"),
+    UTIL = require("narwhal/util"),
+    TERM = require("narwhal/term"),
     Jake = require("jake"),
     CLEAN = require("jake/clean").CLEAN,
     CLOBBER = require("jake/clean").CLOBBER,

--- a/Objective-J/Jakefile
+++ b/Objective-J/Jakefile
@@ -24,7 +24,7 @@ require("../common.jake");
 
 var FILE = require("file"),
     OS = require("os"),
-    stream = require("term").stream;
+    stream = require("narwhal/term").stream;
 
 //$BUILD_CONFIGURATION_DIR = "../Build"
 $BROWSER_FILE       = FILE.join("Browser", "Objective-J.js");

--- a/Tools/capp/Generate.j
+++ b/Tools/capp/Generate.j
@@ -6,9 +6,9 @@ var OS = require("os"),
     FILE = require("file"),
     OBJJ = require("objective-j");
 
-var stream = require("term").stream;
+var stream = require("narwhal/term").stream;
 
-var parser = new (require("args").Parser)();
+var parser = new (require("narwhal/args").Parser)();
 
 parser.usage("DESTINATION_DIRECTORY");
 
@@ -63,7 +63,7 @@ parser.option("--list-frameworks", "listFrameworks")
 parser.helpful();
 
 // FIXME: better way to do this:
-var CAPP_HOME = require("packages").catalog["cappuccino"].directory;
+var CAPP_HOME = require("narwhal/packages").catalog["cappuccino"].directory;
 var templatesDirectory = FILE.join(CAPP_HOME, "lib", "capp", "Resources", "Templates");
 
 function gen(/*va_args*/)

--- a/Tools/nib2cib/main.j
+++ b/Tools/nib2cib/main.j
@@ -33,7 +33,7 @@
 var FILE = require("file");
 var OS = require("os");
 
-var parser = new (require("args").Parser)();
+var parser = new (require("narwhal/args").Parser)();
 
 parser.usage("INPUT_FILE [OUTPUT_FILE]");
 

--- a/common.jake
+++ b/common.jake
@@ -1,8 +1,8 @@
 var SYSTEM = require("system");
 var FILE = require("file");
 var OS = require("os");
-var UTIL = require("util");
-var stream = require("term").stream;
+var UTIL = require("narwhal/util");
+var stream = require("narwhal/term").stream;
 
 var requiresSudo = false;
 
@@ -15,7 +15,7 @@ function ensurePackageUpToDate(packageName, requiredVersion, options)
 {
     options = options || {};
     
-    var packageInfo = require("packages").catalog[packageName];
+    var packageInfo = require("narwhal/packages").catalog[packageName];
     if (!packageInfo)
     {
         if (options.optional)
@@ -163,7 +163,7 @@ function additionalPackages()
 // checks to see if a path is in the package catalog
 function packageInCatalog(path)
 {
-    var catalog = require("packages").catalog;
+    var catalog = require("narwhal/packages").catalog;
     for (var name in catalog)
         if (String(catalog[name].directory) === String(path))
             return true;


### PR DESCRIPTION
Update requires() to use new narwhal/ namespace.

If anybody wants to do this on their own code, this might be helpful:

```
find . -type f -name "*" -print0 | xargs -0 perl -pi -e "s/require\\(['\"](args|loader|packages|promise|sandbox|term|util)['\"]\\)/require(\"narwhal\/\$1\")/g"
```
