### PR TITLE
CPIndexSet shiftIndexesStartingAtIndex:by: fix

### DIFF
--- a/Foundation/CPIndexSet.j
+++ b/Foundation/CPIndexSet.j
@@ -745,6 +745,7 @@
         // Shift the range, and normalize it if the result is negative.
         if ((range.location += aDelta) < 0)
         {
+            _count -= range.length - CPMaxRange(range);
             range.length = CPMaxRange(range);
             range.location = 0;
         }

--- a/Tests/Foundation/CPIndexSetTest.j
+++ b/Tests/Foundation/CPIndexSetTest.j
@@ -387,6 +387,12 @@ function descriptionWithoutEntity(aString)
     
     [_set shiftIndexesStartingAtIndex:[_set lastIndex] + 1 by:1];
     [self assertTrue:[_set lastIndex] === 0];
+
+    // make sure shifting past the lower bound works
+    _set = [CPIndexSet indexSetWithIndex:0];
+    [_set shiftIndexesStartingAtIndex:0 by:-1];
+    [self assert:[_set lastIndex] equals:CPNotFound];
+    [self assert:[_set count] equals:0];
 }
 
 - (void)testIsEqual


### PR DESCRIPTION
When clipping a range (i.e. some or all of it went below the lower bound) as a result of
calling shiftIndexesStartingAtIndex:by: with a negative delta, the CPIndexSet did not adjust
the index count, which caused calls to -lastIndex to fail. See the added test case for an example.

This caused -[CPArrayController removeObject:] to fail when the object removed was at index 0.
