### PR TITLE
Fix cptokenfieldtoken sizetofit

### DIFF
--- a/AppKit/CPTokenField.j
+++ b/AppKit/CPTokenField.j
@@ -974,9 +974,15 @@ var CPThemeStateAutoCompleting = @"CPThemeStateAutoCompleting",
     [super sizeToFit];
 
     var size = [self bounds].size,
-        minSize = [self currentValueForThemeAttribute:@"min-size"];
+        minSize = [self currentValueForThemeAttribute:@"min-size"],
+        contentInset = [self currentValueForThemeAttribute:@"content-inset"];
 
     size.height = minSize.height;
+
+    // this is necessary to recalculate the width of the token due to new CPTextField sizeToFit
+    // behaviour that doesn't resize width on bezeled textfield
+    size.width = [([self stringValue] || @" ") sizeWithFont:[self font]].width + contentInset.left + contentInset.right;
+
     [self setFrameSize:size];
 }
 


### PR DESCRIPTION
this patch fixes the problem of displaying token due to change in CPTextField's sizeToFit behaviour.
