### PR TITLE
CPKeyValueBinding reverse transformation fix

### DIFF
--- a/AppKit/CPKeyValueBinding.j
+++ b/AppKit/CPKeyValueBinding.j
@@ -247,7 +247,7 @@ var CPBindingOperationAnd = 0,
         valueTransformer = [options objectForKey:CPValueTransformerBindingOption];
 
     if (valueTransformer && [[valueTransformer class] allowsReverseTransformation])
-        aValue = [valueTransformer transformedValue:aValue];
+        aValue = [valueTransformer reverseTransformedValue:aValue];
 
     return aValue;
 }


### PR DESCRIPTION
Hey Folks,

here's a pull request for a small fix in CPKeyValueBinding.j

Description:
Instead of reverseTransformedValue:, transformedValue: is called in code.

Steps to reproduce:

Bind a CPTextField's value to any class' variable using a CPValueTransformer that can both transform and reverse transform values > Observe the issue.

It's an easy fix on line 252 of AppKit/CPKeyValueBinding.j

Cheers,
Josh Garth
