### PR TITLE
-[CPArrayController setContent:] fix for nil content

### DIFF
--- a/AppKit/CPArrayController.j
+++ b/AppKit/CPArrayController.j
@@ -150,6 +150,9 @@
 
 - (void)setContent:(id)value
 {
+    if (value == nil)
+        value = [];
+
     if (![value isKindOfClass:[CPArray class]])
         value = [value];
 

--- a/AppKit/CPObjectController.j
+++ b/AppKit/CPObjectController.j
@@ -1,5 +1,6 @@
 
 @import <Foundation/CPDictionary.j>
+@import <Foundation/CPCountedSet.j>
 
 @import "CPController.j"
 

--- a/Tests/AppKit/CPArrayControllerTest.j
+++ b/Tests/AppKit/CPArrayControllerTest.j
@@ -27,6 +27,12 @@
     [self assert:[_CPObservableArray class] equals:[[[self arrayController] arrangedObjects] class] message:"arranged objects should be observable"];
 }
 
+- (void)testInitWithoutContent
+{
+    _arrayController = [[CPArrayController alloc] init];
+    [self assert:[] equals:[[self arrayController] contentArray]];
+}
+
 - (void)testSetContent
 {
     otherContent = [@"5", @"6"];


### PR DESCRIPTION
When initializing a CPArrayController with a value that is not an array setContent: would make it an array by replacing value with [value]. This is consistent with how Cocoa does it, but it should first check to make sure that the content is not nil. If it is, the sensible thing to do (and what Cocoa does) is to replace it with an empty array.

This commit also includes a missing import to make CPArrayControllerTest run without error.
