### PR TITLE
CPPredicate parsing improvements

### DIFF
--- a/Foundation/CPPredicate/CPComparisonPredicate.j
+++ b/Foundation/CPPredicate/CPComparisonPredicate.j
@@ -1,3 +1,4 @@
+
 @import "CPArray.j"
 @import "CPNull.j"
 @import "CPString.j"

--- a/Foundation/CPPredicate/CPCompoundPredicate.j
+++ b/Foundation/CPPredicate/CPCompoundPredicate.j
@@ -1,6 +1,5 @@
+
 @import "CPPredicate.j"
-@import <Foundation/CPArray.j>
-@import <Foundation/CPString.j>
 
 /*!
     A predicate to compare directly the left and right hand sides.

--- a/Foundation/CPPredicate/CPExpression.j
+++ b/Foundation/CPPredicate/CPExpression.j
@@ -1,8 +1,8 @@
-@import <Foundation/CPString.j>
-@import <Foundation/CPArray.j>
-@import <Foundation/CPKeyValueCoding.j>
-@import <Foundation/CPDictionary.j>
-@import <Foundation/CPCoder.j>
+
+@import "CPString.j"
+@import "CPArray.j"
+@import "CPKeyValueCoding.j"
+@import "CPDictionary.j"
 
 /*!
     An expression that always returns the same value.
@@ -90,7 +90,7 @@ CPMinusSetExpressionType = 9;
 */
 + (CPExpression)expressionForEvaluatedObject
 {
-    return [[CPExpression_self alloc] init];
+    return [CPExpression_self evaluatedObject];
 }
 
 /*!

--- a/Foundation/CPPredicate/CPExpression_aggregate.j
+++ b/Foundation/CPPredicate/CPExpression_aggregate.j
@@ -1,7 +1,7 @@
 
 @import "CPExpression.j"
-@import <Foundation/CPArray.j>
-@import <Foundation/CPString.j>
+@import "CPArray.j"
+@import "CPString.j"
 
 @implementation CPExpression_aggregate : CPExpression
 {

--- a/Foundation/CPPredicate/CPExpression_constant.j
+++ b/Foundation/CPPredicate/CPExpression_constant.j
@@ -1,6 +1,6 @@
 
 @import "CPExpression.j"
-@import <Foundation/CPDictionary.j>
+@import "CPDictionary.j"
 
 @implementation CPExpression_constant : CPExpression
 {

--- a/Foundation/CPPredicate/CPExpression_keypath.j
+++ b/Foundation/CPPredicate/CPExpression_keypath.j
@@ -1,8 +1,8 @@
 
 @import "CPExpression.j"
-@import <Foundation/CPString.j>
-@import <Foundation/CPKeyValueCoding.j>
 @import "CPExpression_function.j"
+@import "CPString.j"
+@import "CPKeyValueCoding.j"
 
 @implementation CPExpression_keypath : CPExpression_function
 {
@@ -37,13 +37,26 @@
 
 - (CPString)keyPath
 {
-    return [[self pathExpression] constantValue];
+    return [[self pathExpression] keyPath];
 }
 
 - (CPString)description
 {
-    return [self keyPath];
+    var result = "";
+    if ([_operand expressionType] != CPEvaluatedObjectExpressionType)
+        result += [_operand description] + ".";
+    result += [self keyPath];
+
+    return result;
 }
 
 @end
 
+@implementation CPExpression_constant (KeyPath)
+
+- (CPString)keyPath
+{
+    return [self constantValue];
+}
+
+@end

--- a/Foundation/CPPredicate/CPExpression_self.j
+++ b/Foundation/CPPredicate/CPExpression_self.j
@@ -1,11 +1,19 @@
 
 @import "CPExpression.j"
-@import <Foundation/CPString.j>
-@import <Foundation/CPDictionary.j>
-@import <Foundation/CPCoder.j>
+@import "CPString.j"
+@import "CPDictionary.j"
 
+var evaluatedObject = nil;
 @implementation CPExpression_self : CPExpression
 {
+}
+
++ (id)evaluatedObject
+{
+    if (evaluatedObject == nil)
+        evaluatedObject = [CPExpression_self new];
+
+    return evaluatedObject;
 }
 
 - (id)init
@@ -17,7 +25,7 @@
 
 - (id)initWithCoder:(CPCoder)coder
 {
-    return [self init];
+    return [CPExpression_self evaluatedObject];
 }
 
 - (void)encodeWithCoder:(CPCoder)coder
@@ -26,7 +34,7 @@
 
 - (BOOL)isEqual:(id)object
 {
-    return (_type == CPEvaluatedObjectExpressionType);
+    return (object === self);
 }
 
 - (id)expressionValueWithObject:(id)object context:(CPDictionary)context

--- a/Foundation/CPPredicate/CPExpression_set.j
+++ b/Foundation/CPPredicate/CPExpression_set.j
@@ -30,7 +30,7 @@
 - (id)expressionValueWithObject:object context:(CPDictionary)context
 {
     var right = [_right expressionValueWithObject:object context:context];
-    if ([right isKindOfClass:[CPArray class]]) // Or we could do [[right objectEnumerator] allObjects]
+    if ([right isKindOfClass:[CPArray class]])
         right = [CPSet setWithArray:right];
     else if ([right isKindOfClass:[CPDictionary class]])
         right = [CPSet setWithArray:[right allValues]];
@@ -53,7 +53,7 @@
         default:
     }
 
-    return [CPExpression expressionForConstantValue:result];
+    return result;
 }
 
 - (CPExpression )_expressionWithSubstitutionVariables:(CPDictionary )variables

--- a/Foundation/CPPredicate/CPExpression_subquery.j
+++ b/Foundation/CPPredicate/CPExpression_subquery.j
@@ -1,3 +1,4 @@
+
 @import "CPExpression.j"
 
 @implementation CPExpression_subquery : CPExpression
@@ -9,12 +10,18 @@
 
 - (id)initWithExpression:(CPExpression)collection usingIteratorVariable:(CPString)variable predicate:(CPPredicate)subpredicate
 {
+    var variableExpression = [CPExpression expressionForVariable:variable];
+    return [self initWithExpression:collection usingIteratorExpression:variableExpression predicate:subpredicate];
+}
+
+- (id)initWithExpression:(CPExpression)collection usingIteratorExpression:(CPExpression)variableExpression predicate:(CPPredicate)subpredicate
+{
     [super initWithExpressionType:CPSubqueryExpressionType];
-    
+
     _subpredicate = subpredicate;
     _collection = collection;
-    _variableExpression = [CPExpression expressionForVariable:variable];
-    
+    _variableExpression = variableExpression;
+
     return self;
 }
 
@@ -23,16 +30,16 @@
     var collection = [_collection expressionValueWithObject:object context:context],
         count = [collection count],
         result = [CPArray array],
-        
+
         bindings = [CPDictionary dictionaryWithObject:[CPExpression expressionForEvaluatedObject] forKey:[self variable]];
-    
+
     for (var i = 0; i < count; i++)
     {
         var item = [collection objectAtIndex:i];
         if ([_subpredicate evaluateWithObject:item substitutionVariables:bindings])
             [result addObject:item];
     }
-    
+
     return result;
 }
 
@@ -40,14 +47,14 @@
 {
     if (self === object)
         return YES;
-    
+
     if (![_collection isEqual:[object collection]] || ![_subpredicate isEqual:[object predicate]])
         return NO;
-    
+
     return YES;
 }
 
-- (id)collection
+- (CPExpression)collection
 {
     return _collection;
 }
@@ -57,22 +64,27 @@
     return [[CPExpression_subquery alloc] initWithExpression:[_collection copy] usingIteratorExpression:[_variableExpression copy] predicate:[_subpredicate copy]];
 }
 
-- (id)predicate
+- (CPPredicate)predicate
 {
     return _subpredicate;
 }
 
-- (id)predicateFormat
+- (CPString)description
+{
+    return [self predicateFormat];
+}
+
+- (CPString)predicateFormat
 {
     return @"SUBQUERY(" + [_collection description] + ", " + [_variableExpression description] + ", " + [_subpredicate predicateFormat] + ")";
 }
 
-- (id)variable
+- (CPString)variable
 {
     return [_variableExpression variable];
 }
 
-- (id)variableExpression
+- (CPExpression)variableExpression
 {
     return _variableExpression;
 }
@@ -81,23 +93,23 @@
 var CPExpressionKey = @"CPExpression",
     CPSubpredicateKey = @"CPSubpredicate",
     CPVariableKey = @"CPVariable";
-    
+
 @implementation CPExpression_subquery (CPCoding)
 
 - (id)initWithCoder:(CPCoder)coder
 {
-    var collection = [coder decodeObjectForKey:CPExpressionKey],    
+    var collection = [coder decodeObjectForKey:CPExpressionKey],
         subpredicate = [coder decodeObjectForKey:CPSubpredicateKey],
-        variable = [coder decodeObjectForKey:CPVariableKey];
-    
-    return [self initWithExpression:collection usingIteratorVariable:variable predicate:subpredicate];
+        variableExpression = [coder decodeObjectForKey:CPVariableKey];
+
+    return [self initWithExpression:collection usingIteratorExpression:variableExpression predicate:subpredicate];
 }
 
 - (void)encodeWithCoder:(CPCoder)coder
 {
     [coder encodeObject:_collection forKey:CPExpressionKey];
     [coder encodeObject:_subpredicate forKey:CPSubpredicateKey];
-    [coder encodeObject:[variableExpression variable] forKey:CPVariableKey];
+    [coder encodeObject:_variableExpression forKey:CPVariableKey];
 }
 
 @end

--- a/Foundation/CPPredicate/CPExpression_variable.j
+++ b/Foundation/CPPredicate/CPExpression_variable.j
@@ -1,7 +1,7 @@
 
 @import "CPExpression.j"
-@import <Foundation/CPString.j>
-@import <Foundation/CPDictionary.j>
+@import "CPString.j"
+@import "CPDictionary.j"
 
 @implementation CPExpression_variable :  CPExpression
 {
@@ -35,8 +35,8 @@
 - (id)expressionValueWithObject:object context:(CPDictionary)context
 {
     var expression = [self _expressionWithSubstitutionVariables:context];
-        
-    return [expression expressionValueWithObject:object context:context];    
+
+    return [expression expressionValueWithObject:object context:context];
 }
 
 - (CPString)description
@@ -49,10 +49,10 @@
     var value = [variables objectForKey:_variable];
     if (value == nil)
         [CPException raise:CPInvalidArgumentException reason:@"Can't get value for '" + _variable + "' in bindings" + variables];
-        
+
     if ([value isKindOfClass:[CPExpression class]])
         return value;
-        
+
     return [CPExpression expressionForConstantValue:value];
 }
 


### PR DESCRIPTION
Support for:

 "($)path.($)variable"
 "SUBQUERY(collection, $x,$x = 2)"
 "sum:(arg1, ...)"
 "FUNCTION(target, selector, arg1, ...)
 "object[expression]"
 "set UNION|INTERSECT|MINUS otherset"
