### PR TITLE
2 copies of the same string should be equal.

### DIFF
--- a/Foundation/CPString.j
+++ b/Foundation/CPString.j
@@ -541,7 +541,7 @@ var CPStringRegexSpecialCharacters = [
 */
 - (BOOL)isEqualToString:(CPString)aString
 {
-    return self == aString;
+    return self == String(aString);
 }
 
 /*!

--- a/Tests/Foundation/CPStringTest.j
+++ b/Tests/Foundation/CPStringTest.j
@@ -351,4 +351,13 @@
         [self assert:[anException reason] equals:@"componentsSeparatedByCharactersInSet: the separator can't be 'nil'"];
 	}
 }
+
+- (void)testIsEqual
+{
+    var str = "s";
+    [self assert:str equals:[CPString stringWithString:str]];
+    [self assert:str equals:[str copy]];
+    [self assert:[str copy] equals:str];
+    [self assert:[str copy] equals:[str copy]];
+}
 @end


### PR DESCRIPTION
[[string copy] isEqual:[string copy]] currently returns NO (YES in cocoa).

This is because in javascript _new String("s") != new String("s")_.
But because _new String("s") == String("s")_, when comparing, we can do _self == String(aString)_.

There may be others places where strings are compared directly ...
