### PR TITLE
CPArrayController did not allow removing objects without a selection

### DIFF
--- a/AppKit/CPArrayController.j
+++ b/AppKit/CPArrayController.j
@@ -534,9 +534,6 @@
 
 - (void)removeObject:(id)object
 {
-    if (![self canRemove])
-        return;
-
    [self willChangeValueForKey:@"content"];
    [_contentObject removeObject:object];
 
@@ -598,9 +595,6 @@
 
 - (void)removeObjects:(CPArray)objects
 {
-    if (![self canRemove])
-        return;
-
     [self _removeObjects:objects];
 }
 

--- a/Tests/AppKit/CPArrayControllerTest.j
+++ b/Tests/AppKit/CPArrayControllerTest.j
@@ -122,6 +122,35 @@
     [self assert:[CPIndexSet indexSet] equals:[arrayController selectionIndexes] message:@"no objects left, selection should disappear"];
 }
 
+- (void)testRemoveObjectsWithoutSelection
+{
+    var arrayController = [self arrayController],
+        objectsToRemove = [[[self arrayController] arrangedObjects] objectsAtIndexes:[CPIndexSet indexSetWithIndexesInRange:CPMakeRange(1, 2)]];
+
+    // without any selection
+    [arrayController setSelectedObjects:[]];
+
+    // we should be able to remove arbitrary sets of objects
+    [arrayController removeObjects:objectsToRemove];
+
+    for (var i = 0; i < [objectsToRemove count]; i++)
+        [self assertFalse:[[arrayController arrangedObjects] containsObject:[objectsToRemove objectAtIndex:i]] message:@"remove objects should no longer appear in arrangedObjects"];
+}
+
+- (void)testRemoveObject
+{
+    var arrayController = [self arrayController],
+        objectToRemove = [[arrayController arrangedObjects] objectAtIndex:0];
+
+    // without any selection
+    [arrayController setSelectedObjects:[]];
+
+    // we should be able to remove arbitrary objects
+    [arrayController removeObject:objectToRemove];
+
+    [self assertFalse:[[arrayController arrangedObjects] containsObject:objectToRemove] message:@"removed objects should no longer appear in arrangedObjects"];
+}
+
 - (void)testSelectionWhenObjectsDisappear
 {
     // If the selected object disappeares during a rearrange, the selection


### PR DESCRIPTION
CPArrayController was erroneously using canRemove to determine whether explicit removal could take place, when in fact the documentation for [NSObjectController canRemove](NSArrayController does not override canRemove) states that it returns "YES if an object can be removed from the receiver using remove:, otherwise NO", implying that it should only be used to check whether there is a selected element that can be removed (for example, to bind the enabled state of a toolbar button to a CPArrayController's canRemove property). It should not be used to decide whether a specific object can be removed or not.
