### PR TITLE
-[CPCollectionView setContent:] did not always call reloadContent:

### DIFF
--- a/AppKit/CPCollectionView.j
+++ b/AppKit/CPCollectionView.j
@@ -203,9 +203,6 @@
 */
 - (void)setContent:(CPArray)anArray
 {
-    if (_content == anArray)
-        return;
-
     _content = anArray;
 
     [self reloadContent];

--- a/Tests/AppKit/CPCollectionViewTest.j
+++ b/Tests/AppKit/CPCollectionViewTest.j
@@ -15,19 +15,61 @@
 {
     var itemPrototype = [[CPCollectionViewItem alloc] init];
     [_collectionView setItemPrototype:itemPrototype];
-    
+
     [self assert:itemPrototype same:[_collectionView itemPrototype]];
 }
 
 - (void)testIsSelectableGetter
 {
     var collectionView = [[CPCollectionView alloc] initWithFrame:CGRectMakeZero()];
-    
+
     [collectionView setSelectable:YES];
     [self assertTrue:[collectionView isSelectable]];
-    
+
     [collectionView setSelectable:NO];
     [self assertFalse:[collectionView isSelectable]];
+}
+
+- (void)testSetContent
+{
+    var collectionView = [[_CPCollectionViewWithHooks alloc] initWithFrame:CGRectMakeZero()],
+        content = [1, 2, 3],
+        reloadContentCount;
+
+    reloadContentCount = [collectionView reloadContentCallCount];
+    [collectionView setContent:content];
+    [self assert:reloadContentCount+1 equals:[collectionView reloadContentCallCount] message:@"first call to setContent should have called reloadContent once"];
+
+    [content removeObjectAtIndex:0];
+    [self assertTrue:[collectionView content] === content message:@"collection view content should be as assigned"];
+
+    // make sure we call reloadContent even when the content hasn't changed for key-value binding compatibility
+    reloadContentCount = [collectionView reloadContentCallCount];
+    [collectionView setContent:content];
+    [self assert:[collectionView reloadContentCallCount] equals:reloadContentCount+1 message:@"subsequent calls to setContent should have called reloadContent once"];
+}
+
+@end
+
+@implementation _CPCollectionViewWithHooks : CPCollectionView
+{
+    CPInteger _reloadContentCallCount @accessors(property=reloadContentCallCount);
+}
+
+- (id)initWithFrame:(CGRect)aFrame
+{
+    if (self = [super initWithFrame:aFrame])
+    {
+        _reloadContentCallCount = 0;
+    }
+
+    return self;
+}
+
+- (void)reloadContent
+{
+  [super reloadContent];
+  _reloadContentCallCount++;
 }
 
 @end


### PR DESCRIPTION
This would break key-value binding setups where a CPCollectionView's content property was hooked up to a CPArrayController's content or arrangedObjects property since the CPArrayController maintains the same object and calls setValue:forKey: with the same object the CPCollectionView already has. Therefore we cannot skip calling reloadContent even when the incoming content array is the same one we got before, because most likely the contents have changed out from under us.
