### PR TITLE
CPTokenField sendAction:to: fix

### DIFF
--- a/AppKit/CPTokenField.j
+++ b/AppKit/CPTokenField.j
@@ -79,6 +79,7 @@ var CPThemeStateAutoCompleting          = @"CPThemeStateAutoCompleting",
     CPEvent             _mouseDownEvent;
 
     BOOL                _preventResign;
+    BOOL                _shouldNotifyTarget;
 }
 
 + (CPCharacterSet)defaultTokenizingCharacterSet
@@ -208,10 +209,7 @@ var CPThemeStateAutoCompleting          = @"CPThemeStateAutoCompleting",
     [self _inputElement].value = @"";
     [self setNeedsLayout];
 
-    var theBinding = [CPKeyValueBinding getBinding:CPValueBinding forObject:self];
-
-    if (theBinding)
-        [theBinding reverseSetValueFor:@"objectValue"];
+    [self _controlTextDidChange];
 }
 
 - (void)_autocomplete
@@ -271,6 +269,8 @@ var CPThemeStateAutoCompleting          = @"CPThemeStateAutoCompleting",
         [theBinding reverseSetValueFor:@"objectValue"];
 
     [self textDidChange:[CPNotification notificationWithName:CPControlTextDidChangeNotification object:self userInfo:nil]];
+
+    _shouldNotifyTarget = YES;
 }
 
 - (void)_removeSelectedTokens:(id)sender
@@ -401,7 +401,14 @@ var CPThemeStateAutoCompleting          = @"CPThemeStateAutoCompleting",
 
     [self setNeedsLayout];
 
-    [self textDidEndEditing:[CPNotification notificationWithName:CPControlTextDidBeginEditingNotification object:self userInfo:nil]];
+    if (_shouldNotifyTarget)
+    {
+        _shouldNotifyTarget = NO;
+        [self textDidEndEditing:[CPNotification notificationWithName:CPControlTextDidEndEditingNotification object:self userInfo:nil]];
+
+        if ([self sendsActionOnEndEditing])
+            [self sendAction:[self action] to:[self target]];
+    }
 
     return YES;
 }
@@ -552,6 +559,12 @@ var CPThemeStateAutoCompleting          = @"CPThemeStateAutoCompleting",
     _shouldScrollTo = CPScrollDestinationRight;
     [self setNeedsLayout];
     [self setNeedsDisplay:YES];
+}
+
+- (void)sendAction:(SEL)anAction to:(id)anObject
+{
+    _shouldNotifyTarget = NO;
+    [super sendAction:anAction to:anObject];
 }
 
 // Incredible hack to disable supers implementation


### PR DESCRIPTION
Fixes that `CPTokenField` did not always send its action when editing ended & sent the wrong notification. This may not be the best way to do this, so suggestions are appreciated.
