### PR TITLE
@accessors generating getter/setter with static type

### DIFF
--- a/Objective-J/Preprocessor.js
+++ b/Objective-J/Preprocessor.js
@@ -456,7 +456,10 @@ Preprocessor.prototype.implementation = function(tokens, /*StringBuffer*/ aStrin
                 {
                     token = tokens.next();
                     if (token === TOKEN_ACCESSORS)
+                    {
                         attributes = this.accessors(tokens);
+                        attributes["type"] = declaration[0];
+                    }
                     else if (token !== TOKEN_OUTLET)
                         throw new SyntaxError(this.error_message("*** Unexpected '@' token in ivar declaration ('@"+token+"')."));
                 }
@@ -502,11 +505,12 @@ Preprocessor.prototype.implementation = function(tokens, /*StringBuffer*/ aStrin
             for (ivar_name in accessors)
             {
                 var accessor = accessors[ivar_name],
+                    ivar_type = accessor["type"] || "id",
                     property = accessor["property"] || ivar_name;
 
                 // getter
                 var getterName = accessor["getter"] || property,
-                    getterCode = "(id)" + getterName + "\n{\nreturn " + ivar_name + ";\n}";
+                    getterCode = "(" + ivar_type + ")" + getterName + "\n{\nreturn " + ivar_name + ";\n}";
 
                 if (IS_NOT_EMPTY(instance_methods))
                     CONCAT(instance_methods, ",\n");
@@ -525,7 +529,7 @@ Preprocessor.prototype.implementation = function(tokens, /*StringBuffer*/ aStrin
                     setterName = (start ? "_" : "") + "set" + property.substr(start, 1).toUpperCase() + property.substring(start + 1) + ":";
                 }
 
-                var setterCode = "(void)" + setterName + "(id)newValue\n{\n";
+                var setterCode = "(void)" + setterName + "(" + ivar_type + ")newValue\n{\n";
 
                 if (accessor["copy"])
                     setterCode += "if (" + ivar_name + " !== newValue)\n" + ivar_name + " = [newValue copy];\n}";


### PR DESCRIPTION
When I work with CPActiveRecord. I found it set field value by setValue:forKey: directly. This will set all property to CPString value. I wanna find type of setter to make me set corrent value. But I got id type from class_copyMethodList().
I found Objective-j preprocessor lose @accessors variable type. The generating code like this:

CPDate birthday @accessors;
- (id)birthday
  {
  return birthday;
  }

So I think, preprocessor could pick up variable type after parse accessors attributes. Then generate getter/setter code with static type.

BTW. I'm new to cappuccino and cocoa. I don't know if it is the default behavior of Objective-C.
