### PR TITLE
CPMenu menuWillOpen: fix

### DIFF
--- a/AppKit/CPMenu/CPMenu.j
+++ b/AppKit/CPMenu/CPMenu.j
@@ -692,7 +692,7 @@ var _CPMenuBarVisible               = NO,
     var delegate = [self delegate];
 
     if ([delegate respondsToSelector:@selector(menuWillOpen:)])
-        [delegate menuWillOpen:aMenu];
+        [delegate menuWillOpen:self];
 
     // Convert location to global coordinates if not already in them.
     if (aView)


### PR DESCRIPTION
Fixes that a `CPMenu` delegate implementing `menuWillOpen:` would not cause an exception when the `CPMenu` tries to call the delegate method as a result of presenting the menu as a popup menu. This appears to have been a copy-paste error from `CPMenu.j:785`.
