### PR TITLE
Expand KeyEquivalent manual test

### DIFF
--- a/Tests/Manual/KeyEquivalents/AppController.j
+++ b/Tests/Manual/KeyEquivalents/AppController.j
@@ -8,7 +8,6 @@
 
 @import <Foundation/CPObject.j>
 
-
 @implementation AppController : CPObject
 {
 }
@@ -18,14 +17,16 @@
     var theWindow = [[CPWindow alloc] initWithContentRect:CGRectMakeZero() styleMask:CPBorderlessBridgeWindowMask],
         contentView = [theWindow contentView];
 
+    function plainFormatter(aString, aLevel, aTitle){
+        return aString;
+    }
+    CPLogRegisterRange(CPLogDefault, "debug", "debug", plainFormatter);
+    CPLogRegisterRange(CPLogDefault, "warn", "warn", plainFormatter);
+
     var label = [[CPTextField alloc] initWithFrame:CGRectMakeZero()];
-
-    [label setStringValue:@"Press Cmd-X on the keyboard for each button and verify that it reacts."];
-    [label setFont:[CPFont boldSystemFontOfSize:24.0]];
-
+    [label setStringValue:@"Press Cmd-X on Mac, or Ctrl-X on Windows, on the keyboard for each button and verify that it reacts."];
+    [label setFont:[CPFont boldSystemFontOfSize:14.0]];
     [label sizeToFit];
-
-    [label setAutoresizingMask:CPViewMinXMargin | CPViewMaxXMargin];
     [label setFrameOrigin:CGPointMake(10, 10)];
 
     [contentView addSubview:label];
@@ -43,36 +44,82 @@
         "[",
         "\\",
         "]"
-    ];
+        ];
 
-    for (var i=0; i<keysToTest.length; i++)
+    for (var i = 0; i < keysToTest.length; i++)
     {
-        var button = [[TestButton alloc] initWithFrame:CGRectMake(10 + i * 50, 100, 40, 24)];
+        var button = [[TestButton alloc] initWithFrame:CGRectMake(10 + i * 50, 50, 40, 24)];
         [button setTitle:keysToTest[i]];
         [button setKeyEquivalent:keysToTest[i]];
-        [button setKeyEquivalentModifierMask:CPCommandKeyMask];
+        [button setKeyEquivalentModifierMask:CPCommandKeyMask];     // Cmd on Mac === Ctrl on other O/Ss
+
+        [button setAction:@selector(reportButtonAction:)];
+
+        [contentView addSubview:button];
+    }
+
+
+    var label = [[CPTextField alloc] initWithFrame:CGRectMakeZero()];
+    [label setStringValue:@"Press the appropriate key on the keyboard for each button and verify that it reacts."];
+    [label setFont:[CPFont boldSystemFontOfSize:14.0]];
+    [label sizeToFit];
+    [label setFrameOrigin:CGPointMake(10, 110)];
+
+    [contentView addSubview:label];
+
+    var functionKeysToTest = [
+        ["backspace", CPBackspaceCharacter],
+        ["delete char", CPDeleteCharacter],
+        ["delete key", CPDeleteFunctionKey],
+        ["tab", CPTabCharacter],
+        ["carriage return", CPCarriageReturnCharacter],
+        ["newline", CPNewlineCharacter],
+        ["space", CPSpaceFunctionKey],
+        ["esc", CPEscapeFunctionKey],
+        ["pgup", CPPageUpFunctionKey],
+        ["pgdn", CPPageDownFunctionKey],
+        ["left arrow", CPLeftArrowFunctionKey],
+        ["up arrow", CPUpArrowFunctionKey],
+        ["right arrow", CPRightArrowFunctionKey],
+        ["down arrow", CPDownArrowFunctionKey]
+        ];
+
+    for (var i = 0, buttonsWide = 6, yOffset = 0; i < functionKeysToTest.length; i++)
+    {
+        if (i % buttonsWide  === 0)
+            yOffset += 30;
+
+        var button = [[TestButton alloc] initWithFrame:CGRectMake(10 + (i % buttonsWide) * 110,
+                                                                            120 + yOffset, 100, 24)];
+        [button setTitle:functionKeysToTest[i][0]];
+        [button setKeyEquivalent:functionKeysToTest[i][1]];
+        [button setAction:@selector(reportButtonAction:)];
 
         [contentView addSubview:button];
     }
 
     [theWindow orderFront:self];
+}
 
-    // Uncomment the following line to turn on the standard menu bar.
-    //[CPMenu setMenuBarVisible:YES];
+- (void)reportButtonAction:(id)sender
+{
+    CPLog.warn(" * Action selector called by button: " + [sender title] + " *");
 }
 
 @end
 
 @implementation TestButton :CPButton
 {
-
 }
 
-- (void)performKeyEquivalent:(CPEvent)anEvent
+- (BOOL)performKeyEquivalent:(CPEvent)anEvent
 {
-    console.log("anEvent: "+[anEvent charactersIgnoringModifiers]);
-    console.log(anEvent);
-    [super performKeyEquivalent:anEvent];
+    var eventKey = [anEvent charactersIgnoringModifiers],
+        keyMessage = (eventKey.charCodeAt(0) > 32 && eventKey.charCodeAt(0) < 127 ? "Key: " + eventKey + ", " : "");
+
+    CPLog.debug("TestButton \"" + [self title] + "\", " + keyMessage + "anEvent: " + anEvent);
+
+    return [super performKeyEquivalent:anEvent];
 }
 
 @end


### PR DESCRIPTION
I've added tests for the keys that are allowed as key equivalents without the Cmd/Ctrl modifier.

I've also added a callback for each button to confirm it is being called when the key equivalent is pressed.

Did a bit of cleanup on the code as well, fixed a few minor bugs and capp_linted it as well.
