### PR TITLE
CFURL parsing error with webkit nighty 73065+

### DIFF
--- a/Objective-J/CFURL.js
+++ b/Objective-J/CFURL.js
@@ -54,7 +54,7 @@ var URL_RE = new RegExp( /* url */
         "(" + /* authority */
             "(?:" +
                 "(" + /* userInfo */
-                    "([^:@]*)" + /* user */
+                    "([^:@]+)" + /* user */
                     ":?" +
                     "([^:@]*)" + /* password */
                 ")?" +


### PR DESCRIPTION
It seems the problem originates from this webkit patch:
http://trac.webkit.org/browser/trunk/JavaScriptCore/yarr

which introduced a bug in webkit regex matching ( i didn't finish to reduce it enough yet).

This capp patch will solve the problem but the consequence is that it won't match the _user_ and _password_ fields in http://user:password@domain.com if _user_ is empty. The RFC is not very clear about either or not _user_ can be empty. If the RFC does in fact allow empty user, then another solution should be found  in capp or, even better, we should fix the webkit bug.
