### PR TITLE
Google Chrome Frame support

### DIFF
--- a/Tools/capp/Resources/Templates/Application/index.html
+++ b/Tools/capp/Resources/Templates/Application/index.html
@@ -10,8 +10,7 @@
  Copyright __project.year__, __organization.name__ All rights reserved.
 -->
     <head>
-        <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7" />
-        <meta http-equiv="X-UA-Compatible" content="chrome=1" />
+        <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7,chrome=1" />
 
         <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
 


### PR DESCRIPTION
As per the GCF docs, the `IE=X` and `chrome=1` directives should be combined into one header, otherwise GCF doesn't work.

http://www.chromium.org/developers/how-tos/chrome-frame-getting-started
