### PR TITLE
Fixes for setParameters and flashvars in CPFlashView

### DIFF
--- a/AppKit/CPFlashView.j
+++ b/AppKit/CPFlashView.j
@@ -134,7 +134,10 @@ var IEFlashCLSID = "clsid:D27CDB6E-AE6D-11cf-96B8-444553540000";
             _DOMObjectElement.removeChild([elements objectAtIndex:i]);
     }
 #endif
-    _params = aDictionary;
+    if (!_params)
+        _params = aDictionary;
+    else
+        [_params addEntriesFromDictionary:aDictionary];
 #if PLATFORM(DOM)
     if (!CPBrowserIsEngine(CPInternetExplorerBrowserEngine))
     {
@@ -143,7 +146,7 @@ var IEFlashCLSID = "clsid:D27CDB6E-AE6D-11cf-96B8-444553540000";
         var enumerator = [_params keyEnumerator],
             key;
 
-        while (key = [enumerator nextObject] && _DOMObjectElement)
+        while (_DOMObjectElement && (key = [enumerator nextObject]))
         {
             var param = document.createElement(@"param");
             param.name = key;


### PR DESCRIPTION
The expression in the while loop in setParameters results in the wrong value being assigned to "key" which results in malformed param tags that look like the following:

```
<param name=​"[object HTMLObjectElement]" >
```

Also, _params is not checked before assignment in setParameters which will overwrite flashvars if setFlashVars was called before setParameters.

Addresses issues #1031 and #1032
