### PR TITLE
nib2cib tabview fix

### DIFF
--- a/Tools/nib2cib/NSTabView.j
+++ b/Tools/nib2cib/NSTabView.j
@@ -33,10 +33,10 @@
     {
         var flags = [aCoder decodeObjectForKey:@"NSTvFlags"];
 
-        type = flags & 0x7;
+        _type = flags & 0x7;
 
-        items           = [aCoder decodeObjectForKey:@"NSTabViewItems"];
-        selectedIndex   = [items indexOfObject:[aCoder decodeObjectForKey:@"NSSelectedTabViewItem"]];
+        _items           = [aCoder decodeObjectForKey:@"NSTabViewItems"];
+        _selectedIndex   = [_items indexOfObject:[aCoder decodeObjectForKey:@"NSSelectedTabViewItem"]];
 
         //_delegate               = [aCoder decodeObjectForKey:@""];
 


### PR DESCRIPTION
A recently commit (https://github.com/280north/cappuccino/commit/ab083a3baf4dfbc6b9c07bc3f40ec602800e524a) broken nib2cib tool. All variable of CPTabView has change to underscore style.
I simply change three variable name in NSTabView.
