### PR TITLE
CPTableColumn documentation typo

### DIFF
--- a/AppKit/CPTableColumn.j
+++ b/AppKit/CPTableColumn.j
@@ -225,7 +225,7 @@ CPTableColumnUserResizingMask   = 1 << 1;
 }
 
 /*!
-    This method set's the "prototype" view which will be used to create all table cells in this column.
+    This method sets the "prototype" view which will be used to create all table cells in this column.
 
     It creates a snapshot of aView, using keyed archiving, which is then copied over and over for each
     individual cell that is shown. As a result, changes made after calling this method won't be reflected.


### PR DESCRIPTION
Removes an errant apostrophe.
