### PR TITLE
Nib2cib binding transformer

### DIFF
--- a/Foundation/CPValueTransformer.j
+++ b/Foundation/CPValueTransformer.j
@@ -184,7 +184,8 @@ var transformerMap = [CPDictionary dictionary];
 
 @end
 
-CPNegateBooleanTransformerName  = @"CPNegateBooleanTransformerName";
-CPIsNilTransformerName          = @"CPIsNilTransformerName";
-CPIsNotNilTransformerName       = @"CPIsNotNilTransformerName";
-CPUnarchiveFromDataTransformerName = @"CPUnarchiveFromDataTransformerName";
+CPNegateBooleanTransformerName          = @"CPNegateBoolean";
+CPIsNilTransformerName                  = @"CPIsNil";
+CPIsNotNilTransformerName               = @"CPIsNotNil";
+CPUnarchiveFromDataTransformerName      = @"CPUnarchiveFromData";
+CPKeyedUnarchiveFromDataTransformerName = @"CPKeyedUnarchiveFromData";

--- a/Tools/nib2cib/NSNibConnector.j
+++ b/Tools/nib2cib/NSNibConnector.j
@@ -124,8 +124,14 @@ NIB_CONNECTION_EQUIVALENCY_TABLE = {};
             aKey;
         while (aKey = [keyEnum nextObject])
         {
-            var CPKey = "CP" + aKey.substring(2);
-            [_options setObject:[nsoptions objectForKey:aKey] forKey:CPKey];
+            var CPKey = [CPString stringWithFormat:@"CP%@", aKey.substring(2)],
+                nsvalue = [nsoptions objectForKey:aKey],
+                nstramsformers = [CPArray arrayWithObjects:@"NSNegateBoolean", @"NSIsNil", @"NSIsNotNil", @"NSUnarchiveFromData", @"NSKeyedUnarchiveFromData"];
+            
+            if (CPKey == CPValueTransformerNameBindingOption && [nstramsformers containsObject:nsvalue])
+                nsvalue = [CPString stringWithFormat:@"CP%@", nsvalue.substring(2)];
+                
+            [_options setObject:nsvalue forKey:CPKey];
         }
 
         CPLog.debug(@"Binding Connector: " + [_binding description] + " to: " + _destination + " " + [_keyPath description] + " " + [_options description]);


### PR DESCRIPTION
There are five buildin transformers in cocoa: NSNegateBoolean, NSIsNil, NSIsNotNil, NSUnarchiveFromData, NSKeyedUnarchiveFromData.
And we have buildin transformers in cappuccino except last one. So we need handle them by nib2cib.
The origin transformer name with suffix "TransformerName" is wrong. I have create a simple cocoa project and check these constant values.

```
- (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
    NSString *str = [NSString stringWithFormat:
                     @"%@\n%@\n%@\n%@\n%@\n",
                     NSNegateBooleanTransformerName,
                     NSIsNilTransformerName,
                     NSIsNotNilTransformerName,
                     NSUnarchiveFromDataTransformerName,
                     NSKeyedUnarchiveFromDataTransformerName];

    [textField setObjectValue:str];
}
```

![](http://cncolder.github.com/cappuccino/pages/images/cocoa-buildin-transformer-constant-names.png)
