### PR TITLE
CPTokenField missing import

### DIFF
--- a/AppKit/CPTokenField.j
+++ b/AppKit/CPTokenField.j
@@ -27,6 +27,7 @@
 @import "CPButton.j"
 @import "CPScrollView.j"
 @import "CPTextField.j"
+@import "CPTableView.j"
 @import "CPWindow.j"
 @import "_CPMenuWindow.j"
 


### PR DESCRIPTION
Includes `CPTableView` since `CPTokenField` uses it for the autocompleter.
