### PR TITLE
Null placeholder binding option fix

### DIFF
--- a/AppKit/CPKeyValueBinding.j
+++ b/AppKit/CPKeyValueBinding.j
@@ -231,7 +231,7 @@ var CPBindingOperationAnd = 0,
         aValue = [valueTransformer transformedValue:aValue];
 
 
-    if (aValue === undefined || aValue === nil)
+    if (aValue === undefined || aValue === nil || aValue === [CPNull null])
         aValue = [options objectForKey:CPNullPlaceholderBindingOption] || nil;
 
     return aValue;


### PR DESCRIPTION
Most time we got CPNull when binding to array controller's selection proxy. Other than undefined or nil.
I don't wanna something like `<CPNull 0x0000ab>` in my text field.
