### PR TITLE
Fix for Issue 216 and improvements to background color popup in theme showcase

### DIFF
--- a/AppKit/Themes/BlendKit/BKShowcaseController.j
+++ b/AppKit/Themes/BlendKit/BKShowcaseController.j
@@ -122,13 +122,28 @@ var BKLearnMoreToolbarItemIdentifier                = @"BKLearnMoreToolbarItemId
     [splitView addSubview:scrollView];
 
     [_themesCollectionView setSelectionIndexes:[CPIndexSet indexSetWithIndex:0]];
-    
+
     // Default control state enabled
     _controlState = YES;
     [self updateControlState];
 
+    [[CPColorPanel sharedColorPanel] setDelegate:self];
+
     [theWindow setFullPlatformWindow:YES];
     [theWindow makeKeyAndOrderFront:self];
+}
+
+- (void)windowWillClose:(id)sender
+{
+    if ([sender isKindOfClass:[CPColorPanel class]])
+    {
+        var color = [sender color],
+            colorPopUp = [[[[theWindow toolbar] items] objectAtIndex:2] view],
+            title = @"Other " + [color cssString];
+        [colorPopUp addItemWithTitle:title];
+        [[colorPopUp itemWithTitle:title] setRepresentedObject:color];
+        [colorPopUp selectItemWithTitle:title];
+    }
 }
 
 - (void)collectionViewDidChangeSelection:(CPCollectionView)aCollectionView
@@ -290,14 +305,7 @@ var BKLearnMoreToolbarItemIdentifier                = @"BKLearnMoreToolbarItemId
     var color = nil;
 
     if ([aSender isKindOfClass:[CPColorPanel class]])
-    {
         color = [aSender color];
-        var colorPopUp = [[[[theWindow toolbar] items] objectAtIndex:2] view],
-            title = @"Other " + [color cssString];
-        [colorPopUp addItemWithTitle:title];
-        [[colorPopUp itemWithTitle:title] setRepresentedObject:color];
-        [colorPopUp selectItemWithTitle:title];
-    }
     else
     {
         if ([aSender titleOfSelectedItem] === @"More Choices...")


### PR DESCRIPTION
The first commit fixes #216 and the second improves the background color popup in the toolbar so it changes to reflect the selected cell background color for the given theme.

However when a new color item is added to the popup button using the color picker, for some reason selecting it does not fire the changeColor: action. Can someone see why this is?
