### PR TITLE
Issue 99 and 362

### DIFF
--- a/Objective-J/Preprocessor.js
+++ b/Objective-J/Preprocessor.js
@@ -481,6 +481,9 @@ Preprocessor.prototype.implementation = function(tokens, /*StringBuffer*/ aStrin
                         name = declaration[0];
                     }
 
+                    if (ivar_names.hasOwnProperty(name))
+                        throw new SyntaxError(this.error_message("*** Ivar name '" + name + "' already declared."));
+
                     CONCAT(buffer, "new objj_ivar(\"" + name + "\")");
 
                     if (token == TOKEN_SEMICOLON)


### PR DESCRIPTION
Quick fix for issue 99 until the new parser comes along "Multiple non Javascript-native instance variable declarations per-line don't work"

Also fix for 362 to prevent ivars with same name in one decl block
