### PR TITLE
Fix the behavior of CPTableView when dataview commits changes

### DIFF
--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -3162,10 +3162,19 @@ CPTableViewFirstColumnOnlyAutoresizingStyle = 5;
 /*!
     @ignore
     The action for any dataview that supports editing. This will only be called when the value was changed.
+    The table view becomes the first responder after user is done editing a dataview.
 */
 - (void)_commitDataViewObjectValue:(id)sender
 {
     [_dataSource tableView:self setObjectValue:[sender objectValue] forTableColumn:sender.tableViewEditedColumnObj row:sender.tableViewEditedRowIndex];
+
+    if ([sender respondsToSelector:@selector(setEditable:)])
+        [sender setEditable:NO];
+
+    if ([sender respondsToSelector:@selector(setSelectable:)])
+        [sender setSelectable:NO];
+    
+    [[self window] makeFirstResponder:self];
 }
 
 /*!

--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -674,6 +674,10 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
 {
     if ([anEvent keyCode] === CPReturnKeyCode)
     {
+        // selectText: has a side effect - it can change first responder of the window
+        // we have to prevent such behaviour inside this method because target should be able to change first responder after receiving action.
+        [self selectText:nil];
+
         if (_isEditing)
         {
             _isEditing = NO;
@@ -681,7 +685,6 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
         }
 
         [self sendAction:[self action] to:[self target]];
-        [self selectText:nil];
 
         [[[self window] platformWindow] _propagateCurrentDOMEvent:NO];
     }


### PR DESCRIPTION
For now, CPTableView resigns the first responder status when a user starts editing a data view and doesn't obtain it again when user is done editing and new data is committed. This commit fixes that behavior.
