### PR TITLE
indexOfObject:inSortedRange:options:usingComparator: is incorrectly implemented

### DIFF
--- a/Foundation/CPArray/CPArray.j
+++ b/Foundation/CPArray/CPArray.j
@@ -440,13 +440,13 @@ CPBinarySearchingInsertionIndex = 1 << 10;
         else
         {
             if (options & CPBinarySearchingFirstEqual)
-                while (middle++ < count - 1 &&
-                    aComparator(anObject, [self objectAtIndex:middle]) === CPOrderedSame);
+                while (middle > first && aComparator(anObject, [self objectAtIndex:middle - 1]) === CPOrderedSame)
+                    --middle;
 
             else if (options & CPBinarySearchingLastEqual)
             {
-                while (middle-- > 0 &&
-                    aComparator(anObject, [self objectAtIndex:middle]) === CPOrderedSame);
+                while (middle < last && aComparator(anObject, [self objectAtIndex:middle + 1]) === CPOrderedSame)
+                    ++middle;
 
                 if (options & CPBinarySearchingInsertionIndex)
                     ++middle;

--- a/Tests/Foundation/CPArrayTest.j
+++ b/Tests/Foundation/CPArrayTest.j
@@ -142,10 +142,70 @@
 
 - (void)testIndexOfObject_inSortedRange_options_usingComparator_
 {
-    var array = [0, 1, 2, 3, 4, 7];
+    var array = [0, 1, 1, 1, 2, 2, 3, 3, 4, 4, 7];
+    var numComparator = function(a, b){ return a - b; };
 
-    [self assert:[array indexOfObject:3 inSortedRange:nil options:0 usingComparator:function(a, b){ return a - b; }] equals:3];
-    [self assert:[[array arrayByReversingArray] indexOfObject:3 inSortedRange:nil options:0 usingComparator:function(a, b){ return a - b; }] equals:2];
+    var index = [array indexOfObject:1
+                       inSortedRange:nil
+                             options:0
+                     usingComparator:numComparator];
+    [self assertTrue:[[1, 2, 3] containsObject:index]];
+    [self assert:[array indexOfObject:1
+                        inSortedRange:nil
+                              options:CPBinarySearchingFirstEqual
+                      usingComparator:numComparator]
+          equals:1];
+    [self assert:[array indexOfObject:1
+                        inSortedRange:nil
+                              options:CPBinarySearchingLastEqual
+                      usingComparator:numComparator]
+          equals:3];
+    index = [array indexOfObject:1
+                   inSortedRange:nil
+                         options:CPBinarySearchingInsertionIndex
+                 usingComparator:numComparator];
+    [self assertTrue:[[1, 2, 3, 4] containsObject:index]];
+    [self assert:[array indexOfObject:1
+                        inSortedRange:nil
+                              options:CPBinarySearchingFirstEqual | CPBinarySearchingInsertionIndex
+                      usingComparator:numComparator]
+          equals:1];
+    [self assert:[array indexOfObject:1
+                        inSortedRange:nil
+                              options:CPBinarySearchingLastEqual | CPBinarySearchingInsertionIndex
+                      usingComparator:numComparator]
+          equals:4];
+
+    index = [array indexOfObject:2
+                   inSortedRange:CPMakeRange(2, 5) // [ -, -, 1, 1, 2, 2, 3, -, -, -, -]
+                         options:0
+                 usingComparator:numComparator];
+    [self assertTrue:[[4, 5] containsObject:index]];
+    [self assert:[array indexOfObject:2
+                        inSortedRange:CPMakeRange(2, 5) // [ -, -, 1, 1, 2, 2, 3, -, -, -, -]
+                              options:CPBinarySearchingFirstEqual
+                      usingComparator:numComparator]
+          equals:4];
+    [self assert:[array indexOfObject:2
+                        inSortedRange:CPMakeRange(2, 5) // [ -, -, 1, 1, 2, 2, 3, -, -, -, -]
+                              options:CPBinarySearchingLastEqual
+                      usingComparator:numComparator]
+          equals:5];
+    index = [array indexOfObject:2
+                   inSortedRange:CPMakeRange(2, 5) // [ -, -, 1, 1, 2, 2, 3, -, -, -, -]
+                         options:CPBinarySearchingInsertionIndex
+                 usingComparator:numComparator];
+    [self assertTrue:[[4, 5, 6] containsObject:index]];
+    [self assert:[array indexOfObject:2
+                        inSortedRange:CPMakeRange(2, 5) // [ -, -, 1, 1, 2, 2, 3, -, -, -, -]
+                              options:CPBinarySearchingFirstEqual | CPBinarySearchingInsertionIndex
+                      usingComparator:numComparator]
+          equals:4];
+    [self assert:[array indexOfObject:2
+                        inSortedRange:CPMakeRange(2, 5) // [ -, -, 1, 1, 2, 2, 3, -, -, -, -]
+                              options:CPBinarySearchingLastEqual | CPBinarySearchingInsertionIndex
+                      usingComparator:numComparator]
+          equals:6];
 }
 
 - (void)testIndexOutOfBounds


### PR DESCRIPTION
1. middle must not be changed until while() returns YES (if CPBinarySearchingFirstEqual or CPBinarySearchingLastEqual is set)
2. if CPBinarySearchingFirstEqual is set, we need to _decrement_ middle
3. if CPBinarySearchingLastEqual is set, we need to _increment_ middle
4. We should use first/last instead of 0/[self count] - 1 during search if CPBinarySearchingFirstEqual or CPBinarySearchingLastEqual is set
