### PR TITLE
Reverse value transformation checkes wrong state

### DIFF
--- a/Foundation/CPValueTransformer.j
+++ b/Foundation/CPValueTransformer.j
@@ -76,7 +76,7 @@ var transformerMap = [CPDictionary dictionary];
 
 - (id)reverseTransformedValue:(id)aValue
 {
-    if ([[self class] allowsReverseTransformation])
+    if (![[self class] allowsReverseTransformation])
     {
         [CPException raise:CPInvalidArgumentException reason:(self + " is not reversible.")];
     }


### PR DESCRIPTION
The reverseValueTransformer method was checking allowsReverseTransformation wrong.
