### PR TITLE
Mistake in shouldCollapseSubview: delegate method docs

### DIFF
--- a/AppKit/CPSplitView.j
+++ b/AppKit/CPSplitView.j
@@ -730,8 +730,8 @@ var CPSplitViewHorizontalImage = nil,
             Notifies the delegate that the splitview is about to be collapsed. This usually happens when the user
             Double clicks on the divider. Return YES if the subview can be collapsed, otherwise NO.
 
-         - (BOOL)splitView:(CPSplitView)aSplitView shouldCollapseSubview:(CPView)aSubview;
-            Notifies the delegate that the splitview is about to be collapsed. This usually happens when the user
+         - (BOOL)splitView:(CPSplitView)aSplitView shouldCollapseSubview:(CPView)aSubview forDoubleClickOnDividerAtIndex:(int)indexOfDivider;
+            Notifies the delegate that the subview at indexOfDivider is about to be collapsed. This usually happens when the user
             Double clicks on the divider. Return YES if the subview should be collapsed, otherwise NO.
 
         - (float)splitView:(CPSplitView)aSpiltView constrainSplitPosition:(float)proposedPosition ofSubviewAt:(int)subviewIndex;


### PR DESCRIPTION
missing: forDoubleClickOnDividerAtIndex:(int)indexOfDivider;
