### PR TITLE
CPTextField maxLength

### DIFF
--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -181,7 +181,7 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
     if (!CPTextFieldDOMInputElement)
     {
         CPTextFieldDOMInputElement = document.createElement("input");
-        CPTextFieldDOMInputElement = _maxLength ? _maxLength : null;
+        CPTextFieldDOMInputElement.maxLength = _maxLength ? _maxLength : null;
         CPTextFieldDOMInputElement.style.position = "absolute";
         CPTextFieldDOMInputElement.style.border = "0px";
         CPTextFieldDOMInputElement.style.padding = "0px";


### PR DESCRIPTION
I added maxLength to CPTextField.

I know that in Cocoa it should be handled by a NSFormatter but I thought because maxLength is easy accessible in HTML why not go the obvious way?

What do you think?
