### PR TITLE
jake docs fix

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -116,6 +116,9 @@ task ("documentation", function()
 
         if (!OS.system([doxygen, FILE.join(documentationDir, "Cappuccino.doxygen")]))
         {
+            if (!FILE.isDirectory($BUILD_DIR))
+                FILE.mkdirs($BUILD_DIR);
+
             rm_rf($DOCUMENTATION_BUILD);
             mv("debug.txt", FILE.join("Documentation", "debug.txt"));
             mv("Documentation", $DOCUMENTATION_BUILD);


### PR DESCRIPTION
If 'jake docs' is done after 'jake clean' it fails because $CAPP_BUILD is gone. This commit fixes that.
