### PR TITLE
CPView -hasThemeAttribute

### DIFF
--- a/AppKit/CPView.j
+++ b/AppKit/CPView.j
@@ -2498,6 +2498,11 @@ setBoundsOrigin:
     return [_themeAttributes[aName] valueForState:_themeState];
 }
 
+- (BOOL)hasThemeAttribute:(CPString)aName
+{
+    return (_themeAttributes && _themeAttributes[aName] !== undefined);
+}
+
 - (CPView)createEphemeralSubviewNamed:(CPString)aViewName
 {
     return nil;

--- a/Tests/AppKit/CPButtonTest.j
+++ b/Tests/AppKit/CPButtonTest.j
@@ -132,4 +132,19 @@
     [self assert:CPMixedState equals:[button state] message:@"Mixed state is allowed, state should be CPMixedState"];
 }
 
+- (void)testThemeAttributes
+{
+    var attributes = [CPButton themeAttributes];
+
+    if (attributes)
+    {
+        var keys = [attributes allKeys],
+            firstKey = [keys objectAtIndex:0];
+
+        [self assertTrue:[button hasThemeAttribute:[firstKey]] message:[button className] + " should have the theme attribute \"" + firstKey + "\""];
+    }
+
+    [self assertFalse:[button hasThemeAttribute:@"foobar"] message:[button className] + " should not have theme attribute \"" + firstKey + "\""];
+}
+
 @end

--- a/Tests/AppKit/CPViewTest.j
+++ b/Tests/AppKit/CPViewTest.j
@@ -23,18 +23,18 @@
 /*
     During the layout process for the view, _CPImageAndTextView.j throws
     a ReferenceError with the following:
-    
+
         "hasDOMImageElement" is not defined
-    
-    The referenced variable is #if PLATFORM(DOM) excluded in all other 
-    instances. While not isolated to the behaviour of a CPView alone, the 
+
+    The referenced variable is #if PLATFORM(DOM) excluded in all other
+    instances. While not isolated to the behaviour of a CPView alone, the
     following test ensures that pending actions in the _CPDisplayServer can
     be flushed without touching unimplemented portions of the test platform
     (e.g. the DOM). There are times where we want to confirm that some setting
     requiring relayout (e.g. string truncation based on available space), the
     following test should help ensure those types of tests are safe to carry
     out with ojunit.
-    
+
     Demonstrates issue #562.
 */
 - (void)testCanFlushPendingLayoutWork
@@ -56,6 +56,21 @@
     [view setThemeState:CPThemeStateNormal | CPThemeStateHighlighted];
     [self assertFalse:[view hasThemeState:CPThemeStateNormal] message:@"CPThemeStateNormal cannot exist as part of a compound state"];
     [self assertTrue:[view hasThemeState:CPThemeStateHighlighted] message:@"The view should be CPThemeStateHighlighted"];
+}
+
+- (void)testThemeAttributes
+{
+    var attributes = [CPView themeAttributes];
+
+    if (attributes)
+    {
+        var keys = [attributes allKeys],
+            firstKey = [keys objectAtIndex:0];
+
+        [self assertTrue:[view hasThemeAttribute:[firstKey]] message:[view className] + " should have the theme attribute \"" + firstKey + "\""];
+    }
+
+    [self assertFalse:[view hasThemeAttribute:@"foobar"] message:[view className] + " should not have theme attribute \"" + firstKey + "\""];
 }
 
 @end


### PR DESCRIPTION
Since CPView -currentValueForThemeAttribute and -valueForThemeAttribute raise an exception of the named attribute does not exist, for completeness there should be a method to test the presence of an attribute so we do not have to rely on try/catch. This commit adds a -hasThemeAttribute method and relevant tests for CPButton and CPView.
