### PR TITLE
jake doc optimization

### DIFF
--- a/Tools/Documentation/Cappuccino.doxygen
+++ b/Tools/Documentation/Cappuccino.doxygen
@@ -651,7 +651,7 @@ RECURSIVE              = YES
 # excluded from the INPUT source files. This way you can easily exclude a 
 # subdirectory from a directory tree whose root is specified with the INPUT tag.
 
-EXCLUDE                = AppKit.doc/Themes
+EXCLUDE                =
 
 # The EXCLUDE_SYMLINKS tag can be used select whether or not files or 
 # directories that are symbolic links (a Unix filesystem feature) are excluded 

--- a/Tools/Documentation/make_headers.sh
+++ b/Tools/Documentation/make_headers.sh
@@ -10,11 +10,15 @@ if [ -d Foundation.doc ]; then
     rm -rf Foundation.doc
 fi
 
-echo "Copying source files..."
-cp -r AppKit AppKit.doc
-cp -r Foundation Foundation.doc
-
 echo "Processing source files..."
+tar cf AppKit.doc.tar --exclude='_*' -s /^AppKit/AppKit.doc/ AppKit/*.j AppKit/**/*.j
+tar xf AppKit.doc.tar
+rm AppKit.doc.tar
+
+tar cf Foundation.doc.tar --exclude='_*' -s /^Foundation/Foundation.doc/ Foundation/*.j Foundation/**/*.j
+tar xf Foundation.doc.tar
+rm Foundation.doc.tar
+
 find AppKit.doc -name *.j -exec sed -e '/@import.*/ d' -i '' {} \;
 find Foundation.doc -name *.j -exec sed -e '/@import.*/ d' -i '' {} \;
 


### PR DESCRIPTION
On closer inspection, I was blindly, recursively copying the AppKit and Foundation directories, which copied a lot of stuff that was unnecessary, like images, frameworks, etc.

This branch only copies the *.j files, shaving a few seconds off of the total processing time for docs.
