### PR TITLE
CPArrayController arrangedObjects always null fix

### DIFF
--- a/AppKit/CPArrayController.j
+++ b/AppKit/CPArrayController.j
@@ -136,7 +136,7 @@
     _sortDescriptors = [CPArray array];
     _filterPredicate = nil;
     _selectionIndexes = [CPIndexSet indexSet];
-    _arrangedObjects = nil;
+    _arrangedObjects = [CPArray array];
 }
 
 - (void)prepareContent

--- a/Tests/AppKit/CPArrayControllerTest.j
+++ b/Tests/AppKit/CPArrayControllerTest.j
@@ -56,6 +56,24 @@
     [self assert:object equals:[[arrayController arrangedObjects] objectAtIndex:1]];
 }
 
+- (void)testAddObjectUpdatesArrangedObjectsWithoutSortDescriptors
+{
+    var arrayController = [[CPArrayController alloc] init];
+
+    [arrayController addObject:@"content"];
+    [self assert:[@"content"] equals:[arrayController content]];
+    [self assert:[@"content"] equals:[arrayController arrangedObjects]];
+}
+
+- (void)testInsertObjectUpdatesArrangedObjectsWithoutSortDescriptors
+{
+    var arrayController = [[CPArrayController alloc] init];
+
+    [arrayController insertObject:@"content" atArrangedObjectIndex:0];
+    [self assert:[@"content"] equals:[arrayController content]];
+    [self assert:[@"content"] equals:[arrayController arrangedObjects]];
+}
+
 - (void)testSelectPrevious
 {
     var arrayController = [self arrayController];


### PR DESCRIPTION
In a recent commit (I believe it was 6a94263) `CPArrayController` was changed to initialize its `_arrangedObjects` ivar as `nil` instead of an array. I'm not sure why this was done, but this caused it to only ever be updated correctly if `sortDescriptors` is set. This patch includes tests to check for this case in the future. Here's how Cocoa handles this case:

```
>> controller = NSArrayController.new
=> #<NSArrayController:0x2004e4a20>
>> controller.addObject :a
=> #<NSArrayController:0x2004e4a20>
>> controller.content
=> [:a]
>> controller.arrangedObjects
=> [:a]
```
