### PR TITLE
CPScroller knob slot layout fix

### DIFF
--- a/AppKit/CPScroller.j
+++ b/AppKit/CPScroller.j
@@ -316,7 +316,7 @@ NAMES_FOR_PARTS[CPScrollerKnob]             = @"knob";
         {
             _partRects[CPScrollerIncrementLine] = _CGRectMakeZero();
             _partRects[CPScrollerDecrementLine] = _CGRectMakeZero();
-            _partRects[CPScrollerKnobSlot]      = _CGRectMake(0.0, 0.0,  width, slotHeight);
+            _partRects[CPScrollerKnobSlot]      = _CGRectMake(0.0, 0.0,  width, height - trackInset.top - trackInset.bottom);
         }
     }
 }


### PR DESCRIPTION
It appears that there was a copy-paste bug introduced quite a while ago in `CPScroller`. There's a variable called `slotHeight` referenced by `-[CPScroller checkSpaceForParts]` that is not defined within the scope in which it is referenced. The bug only manifests itself when the scroller is horizontal and `width < decrementLineSize.width + incrementLineSize.width - 2`, which I managed to trigger by creating a `CPScrollView` with negative width and height.

Interestingly, this was only a reproducible problem in Internet Explorer, presumably because other browsers consider setting a DOM element's height to `undefined` as the same as setting it to 0, whereas IE throws an exception.
