### PR TITLE
Fix to CPKeyedUnarchiver

### DIFF
--- a/Foundation/CPKeyedUnarchiver.j
+++ b/Foundation/CPKeyedUnarchiver.j
@@ -505,7 +505,7 @@ var _CPKeyedUnarchiverDecodeObjectAtIndex = function(self, anIndex)
             if (self._delegateSelectors & _CPKeyedUnarchiverDidDecodeObjectSelector)
                 processedObject = [self._delegate unarchiver:self didDecodeObject:object];
 
-            if (processedObject != object)
+            if (processedObject && processedObject != object)
             {
                 if (self._delegateSelectors & _CPKeyedUnarchiverWillReplaceObjectWithObjectSelector)
                     [self._delegate unarchiver:self willReplaceObject:object withObject:processedObject];


### PR DESCRIPTION
Cocoa docs state that if unarchiver:didDecodeObject: returns nil, the original object should be used, no replacement should be done.
