### PR TITLE
Button key equivalents stopped working

### DIFF
--- a/Tools/nib2cib/NSButton.j
+++ b/Tools/nib2cib/NSButton.j
@@ -133,6 +133,12 @@ var NSButtonIsBorderedMask = 0x00800000,
             _frame.origin.y += 4.0;
             _bounds.size.height = CPButtonDefaultHeight;
         }
+
+        _keyEquivalent = [cell keyEquivalent];
+        _keyEquivalentModifierMask = [cell keyEquivalentModifierMask];
+
+        _allowsMixedState = [cell allowsMixedState];
+        [self setImagePosition:[cell imagePosition]];
     }
 
     return self;


### PR DESCRIPTION
I left out 2 lines of code in commit f1f78d6c6a442a674cbea8217b6265776664839e, which broke key equivalents in buttons. This adds those lines back.
