### PR TITLE
fix wrong AGPL header in CPUserDefaultTest.j

### DIFF
--- a/Tests/Foundation/CPUserDefaultsTest.j
+++ b/Tests/Foundation/CPUserDefaultsTest.j
@@ -1,23 +1,4 @@
-/*
- * CPUserDefaultsTest.j
- *
- * Copyright (C) 2010 Antoine Mercadal <antoine.mercadal@inframonde.eu>
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
-
 @import <Foundation/Foundation.j>
-@import <AppKit/AppKit.j>
 
 
 CPUserDefaultsTestKey1 = @"KEY1";


### PR DESCRIPTION
As discussed here http://groups.google.com/group/objectivej-dev/browse_thread/thread/4407e15948427cbd?hl=en

I remove all headers like all other Foundation's test.
