### PR TITLE
Fixed timezone calculation in initWithString.

### DIFF
--- a/Foundation/CPDate.j
+++ b/Foundation/CPDate.j
@@ -110,10 +110,10 @@ var CPDateReferenceDate = new Date(Date.UTC(2001, 1, 1, 0, 0, 0, 0));
 
     if (!d || d.length != 10)
         [CPException raise:CPInvalidArgumentException
-                    reason:"initWithString: the string must be of YYYY-MM-DD HH:MM:SS ±HHMM format"];
+                    reason:"initWithString: the string must be in YYYY-MM-DD HH:MM:SS ±HHMM format"];
 
     var date = new Date(d[1], d[2] - 1, d[3]),
-        timeZoneOffset =  (Number(d[8]) * 60 + Number(d[9])) * (d[7] === '-' ? -1 : 1);
+        timeZoneOffset =  (Number(d[8]) * 60 + Number(d[9])) * (d[7] === '-' ? 1 : -1);
 
     date.setHours(d[4]);
     date.setMinutes(d[5]);


### PR DESCRIPTION
It is reversing the timezone offset currently, resulting in a wrong time.
