### PR TITLE
Fix feedback view when retargeting the drop row & operation.

### DIFF
--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -4327,6 +4327,9 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
 */
 - (CPDragOperation)draggingUpdated:(id)sender
 {
+    _retargetedDropRow = nil;
+    _retargetedDropOperation = nil;
+
     var location = [self convertPoint:[sender draggingLocation] fromView:nil],
         dropOperation = [self _proposedDropOperationAtPoint:location],
         numberOfRows = [self numberOfRows],
@@ -4335,6 +4338,8 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
 
     if (_retargetedDropRow !== nil)
         row = _retargetedDropRow;
+    if (_retargetedDropOperation !== nil)
+        dropOperation = _retargetedDropOperation;
 
 
     if (dropOperation === CPTableViewDropOn && row >= numberOfRows)


### PR DESCRIPTION
CPTableView was inappropriately preserving the retargeted drop row & operation as the drag operation continued, causing the data source call to - tableView:validateDrop:proposedRow:proposedDropOperation: to echo any row and operation set by the first call to -setDropRow:dropOperation:, making it impossible for the data source to determine new values for -setDropRow:dropOperation:, making the feedback view stay in the same place it was initially drawn.
