### PR TITLE
Make sure arrangedObjects is observable

### DIFF
--- a/AppKit/CPArrayController.j
+++ b/AppKit/CPArrayController.j
@@ -138,7 +138,7 @@
     _sortDescriptors = [CPArray array];
     _filterPredicate = nil;
     _selectionIndexes = [CPIndexSet indexSet];
-    _arrangedObjects = [CPArray array];
+    [self __setArrangedObjects:[CPArray array]];
 }
 
 - (void)prepareContent


### PR DESCRIPTION
This fixes both the case I reported earlier (#1174) and a new issue I found where attempting to bind to a `CPArrayController`'s `arrangedObjects` before calling `-setContent:` would throw this exception:

```
Uncaught CPInvalidArgumentException: Unsupported method on CPArray
```

The reason for this exception is that the old implementation set `_arrangedObjects` to an instance of `_CPJavaScriptArray`, whereas the new one will set it to a `_CPObservableArray`.
