### PR TITLE
Use non-default JVM

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -220,8 +220,6 @@ unset SEALVL
 
 PATH_SAVED="$PATH"
 
-check_build_environment
-
 if which "narwhal" > /dev/null; then
     narwhal_path="$(which narwhal)"
     # resolve symlinks


### PR DESCRIPTION
Allow the JVM to be specified when bootstrapping narwhal, using either a command line option or the
--java-home parameter to specify where the Java VM resides.

This patch executes check_build_environment later since its behavior is dependent upon using the correct
JVM. If the Java VM used to bootstrap narwhal is not in the PATH, append JAVA_HOME to narwhal.conf so that narwhal can use this value.

This patch depends on a patch for narwhal (280north/narwhal#23).
