### PR TITLE
Linear gradients only supports 2 colorstops

### DIFF
--- a/AppKit/CoreGraphics/CGGradient.j
+++ b/AppKit/CoreGraphics/CGGradient.j
@@ -29,10 +29,10 @@ kCGGradientDrawsAfterEndLocation    = 1 << 1;
 
 function CGGradientCreateWithColorComponents(aColorSpace, components, locations, count)
 {
-    if (arguments["locations"] == NULL)
+    if (arguments[2] == NULL) // locations argument
         var locations = [0.0, 1.0];
 
-    if (arguments["count"] == NULL)
+    if (arguments[3] == NULL) // count argument
         var count = locations.length;
 
     var colors = [];


### PR DESCRIPTION
Using 3 or more color stops did not work until i made this change. It seems that named arguments are not supported (at least in Safari 5.0.4 and Firefox 3.6.16) and that was preventing more than 2 color stops on a color gradient.

There seem to be other usages of named arguments, if this is really an issue, then they would also need to be removed.

Pull request https://github.com/280north/cappuccino/pull/1233 contains the test for this issue.
