### PR TITLE
add setPreventsNib2Cib to bundletask.js

### DIFF
--- a/Objective-J/CommonJS/lib/objective-j/jake/bundletask.js
+++ b/Objective-J/CommonJS/lib/objective-j/jake/bundletask.js
@@ -51,6 +51,7 @@ function BundleTask(aName, anApplication)
     this._compilerFlags = null;
     this._flattensSources = false;
     this._includesNibsAndXibs = false;
+    this._preventsNib2Cib = false;
 
     this._productName = this.name();
 
@@ -202,6 +203,16 @@ BundleTask.prototype.setIncludesNibsAndXibs = function(shouldIncludeNibsAndXibs)
 BundleTask.prototype.includesNibsAndXibs = function()
 {
     return this._includesNibsAndXibs;
+}
+
+BundleTask.prototype.setPreventsNib2Cib = function(shouldPreventNib2Cib)
+{
+    this._preventsNib2Cib = shouldPreventNib2Cib;
+}
+
+BundleTask.prototype.preventsNib2Cib = function()
+{
+    return this._preventsNib2Cib;
 }
 
 BundleTask.prototype.setProductName = function(aProductName)
@@ -486,9 +497,9 @@ BundleTask.prototype.defineResourceTask = function(aResourcePath, aDestinationPa
     var extension = FILE.extension(aResourcePath),
         extensionless = aResourcePath.substr(0, aResourcePath.length - extension.length);
     // NOT:
-    // (extname === ".cib" && (FILE.exists(extensionless + '.xib') || FILE.exists(extensionless + '.nib')) ||
+    // (extname === ".cib" && (FILE.exists(extensionless + '.xib') || FILE.exists(extensionless + '.nib') && !this._preventsNib2Cib) ||
     // (extname === ".xib" || extname === ".nib") && !this.shouldIncludeNibsAndXibs())
-    if ((extension !== ".cib" || !FILE.exists(extensionless + ".xib") && !FILE.exists(extensionless + ".nib")) &&
+    if ((extension !== ".cib" || !FILE.exists(extensionless + ".xib") && !FILE.exists(extensionless + ".nib") || this._preventsNib2Cib) &&
         ((extension !== ".xib" && extension !== ".nib") || this.includesNibsAndXibs()))
     {
         filedir (aDestinationPath, [aResourcePath], function()
@@ -505,7 +516,7 @@ BundleTask.prototype.defineResourceTask = function(aResourcePath, aDestinationPa
         this.enhance([aDestinationPath]);
     }
 
-    if (extension === ".xib" || extension === ".nib")
+    if ((extension === ".xib" || extension === ".nib") && !this._preventsNib2Cib)
     {
         var cibDestinationPath = FILE.join(FILE.dirname(aDestinationPath), FILE.basename(aDestinationPath, extension)) + ".cib";
 


### PR DESCRIPTION
This allows to be able to have the XIB/NIB and CIB version in the resource
directory and to prevent to run nib2cib by just copying the CIB version.
This is very usefull in the caseof using a Linux build machine for your application
