### PR TITLE
Ensure multiple _CPImageAndTextViews sharing the same image are notified

### DIFF
--- a/AppKit/_CPImageAndTextView.j
+++ b/AppKit/_CPImageAndTextView.j
@@ -294,13 +294,13 @@ var _CPimageAndTextViewFrameSizeChangedFlag         = 1 << 0,
         return;
 
     if ([_image delegate] === self)
-        [_image setDelegate:nil];
+        [[CPNotificationCenter defaultCenter] removeObserver:self name:CPImageDidLoadNotification object:_image];
 
     _image = anImage;
     _flags |= _CPImageAndTextViewImageChangedFlag;
 
     if ([_image loadStatus] !== CPImageLoadStatusCompleted)
-        [_image setDelegate:self];
+        [[CPNotificationCenter defaultCenter] addObserver:self selector:@selector(imageDidLoad:) name:CPImageDidLoadNotification object:_image];
 
     [self setNeedsLayout];
 }
@@ -319,13 +319,10 @@ var _CPimageAndTextViewFrameSizeChangedFlag         = 1 << 0,
     return _imageOffset;
 }
 
-- (void)imageDidLoad:(id)anImage
+- (void)imageDidLoad:(CPNotification)aNotification
 {
-    if (anImage === _image)
-    {
-        _flags |= _CPImageAndTextViewImageChangedFlag;
-        [self setNeedsLayout];
-    }
+    _flags |= _CPImageAndTextViewImageChangedFlag;
+    [self setNeedsLayout];
 }
 
 - (CPImage)image


### PR DESCRIPTION
Currently _CPImageAndTextView is using the CPImage delegate to get notified when the image is loaded. But if multiple _CPImageAndTextViews share the same image and are created when the image is still loading, only the last _CPImageAndTextView will be notified when the image loads, because only that one is the image's delegate.

This commit uses the image's notification mechanism instead of the delegate, which allows multiple _CPImageAndTextViews to observe the loading of a single image.

This problem showed up only in a new class I am creating that uses a CPButton with an image as an ephemeral subview. I am unable to make a test app at this time because it would require too much support code. I hope the logic of this change is self-evident and doesn't need a demonstration.
