### PR TITLE
Improvements to the ThemeDescriptor capp template

### DIFF
--- a/Tools/capp/Resources/Templates/ThemeDescriptor/Info.plist
+++ b/Tools/capp/Resources/Templates/ThemeDescriptor/Info.plist
@@ -2,11 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CPApplicationDelegateClass</key>
-	<string>BKShowcaseController</string>
-	<key>CPBundleName</key>
-	<string>__project.name__</string>
-	<key>CPPrincipalClass</key>
-	<string>CPApplication</string>
+    <key>CPApplicationDelegateClass</key>
+    <string>BKShowcaseController</string>
+    <key>CPBundleName</key>
+    <string>__project.name__</string>
+    <key>CPPrincipalClass</key>
+    <string>CPApplication</string>
 </dict>
 </plist>

--- a/Tools/capp/Resources/Templates/ThemeDescriptor/Jakefile
+++ b/Tools/capp/Resources/Templates/ThemeDescriptor/Jakefile
@@ -2,8 +2,7 @@
  * Jakefile
  * __project.name__
  *
- * Created by __user.name__ on __project.date__.
- *
+ * Created by __user.name__ on __project.date__
  * Copyright __project.year__, __organization.name__. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or

--- a/Tools/capp/Resources/Templates/ThemeDescriptor/ThemeDescriptors.j
+++ b/Tools/capp/Resources/Templates/ThemeDescriptor/ThemeDescriptors.j
@@ -2,7 +2,7 @@
  * ThemeDescriptors.j
  * __project.name__
  *
- * Created by __user.name__ on __project.date__.
+ * Created by __user.name__ on __project.date__
  * Copyright __project.year__, __organization.name__. All rights reserved.
  */
 

--- a/Tools/capp/Resources/Templates/ThemeDescriptor/index-debug.html
+++ b/Tools/capp/Resources/Templates/ThemeDescriptor/index-debug.html
@@ -6,7 +6,7 @@
  index-debug.html
  __project.name__
 
- Created by __user.name__ on __project.date__.
+ Created by __user.name__ on __project.date__
  Copyright __project.year__, __organization.name__. All rights reserved.
 -->
     <head>
@@ -26,7 +26,7 @@
             OBJJ_MAIN_FILE = "main.j";
             OBJJ_INCLUDE_PATHS = ["Frameworks/Debug", "Frameworks", "SomethingElse"];
         </script>
-        
+
         <script type="text/javascript" src="Frameworks/Debug/Objective-J/Objective-J.js" charset="UTF-8"></script>
 
         <script type="text/javascript">
@@ -36,7 +36,7 @@
 
             // Uncomment to enable printing of backtraces on exceptions:
             //objj_msgSend_decorate(objj_backtrace_decorator);
-            
+
             // Uncomment to supress exceptions that take place inside a message
             //objj_msgSend_decorate(objj_supress_exceptions_decorator)
 
@@ -52,8 +52,12 @@
             // Uncomment to enable a specific logger:
             //CPLogRegister(CPLogConsole);
             //CPLogRegister(CPLogPopup);
+
+            // Tag view DOM elements with a "data-cappuccino-view" attribute that contains
+            // the class name of the view that created them. Comment this or set to false to disable.
+            appkit_tag_dom_elements = true;
         </script>
-        
+
         <style type="text/css">
             body{margin:0; padding:0;}
             #container {position: absolute; top:50%; left:50%;}
@@ -79,7 +83,7 @@
                                    "<img id='loadgraphic' width='16' height='16' src='Resources/spinner.gif' /> " +
                                    "Loading __project.name__...</p></div>");
                 </script>
-        
+
                 <noscript>
                     <div id="container">
                         <div style="width: 440px; padding: 10px 25px 20px 25px; font-family: sans-serif; background-color: #ffffff; position: relative; left: -245px; top: -120px; text-align: center; -moz-border-radius: 20px; -webkit-border-radius: 20px; color: #555555">

--- a/Tools/capp/Resources/Templates/ThemeDescriptor/index.html
+++ b/Tools/capp/Resources/Templates/ThemeDescriptor/index.html
@@ -6,7 +6,7 @@
  index.html
  __project.name__
 
- Created by __user.name__ on __project.date__.
+ Created by __user.name__ on __project.date__
  Copyright __project.year__, __organization.name__. All rights reserved.
 -->
     <head>
@@ -25,7 +25,7 @@
         <script type="text/javascript">
             OBJJ_MAIN_FILE = "main.j";
         </script>
-        
+
         <script type="text/javascript" src="Frameworks/Objective-J/Objective-J.js" charset="UTF-8"></script>
 
         <style type="text/css">
@@ -53,7 +53,7 @@
                                    "<img id='loadgraphic' width='16' height='16' src='Resources/spinner.gif' /> " +
                                    "Loading __project.name__...</p></div>");
                 </script>
-        
+
                 <noscript>
                     <div id="container">
                         <div style="width: 440px; padding: 10px 25px 20px 25px; font-family: sans-serif; background-color: #ffffff; position: relative; left: -245px; top: -120px; text-align: center; -moz-border-radius: 20px; -webkit-border-radius: 20px; color: #555555">

--- a/Tools/capp/Resources/Templates/ThemeDescriptor/main.j
+++ b/Tools/capp/Resources/Templates/ThemeDescriptor/main.j
@@ -2,7 +2,7 @@
  * main.j
  * __project.name__
  *
- * Created by __user.name__ on __project.date__.
+ * Created by __user.name__ on __project.date__
  * Copyright __project.year__, __organization.name__. All rights reserved.
  */
 


### PR DESCRIPTION
## Motivation

The existing capp templates are kind of minimal and lack the rich functionality available in the main Cappuccino Jakefile. This improved template vastly improves the functionality of the theme descriptor template.

If you like this approach, I can do the same for the other templates as well.
## Enhancements
- New/improved jake tasks: debug, release, all, clean, clobber, test, test-release, help.
- **help** task shows comprehensive, formatted documentation for the available tasks.
- BlendKit is automatically symlinked into the Frameworks directory if necessary as part of the build process, so that the showcase will always work.
- User can easily change the build directory by changing one clearly marked line in the Jakefile.
- Fixed incorrect placeholders in main.j.
