### PR TITLE
[CPMutableSet addObject:nil] should raise

### DIFF
--- a/Foundation/CPSet/CPSet.j
+++ b/Foundation/CPSet/CPSet.j
@@ -424,9 +424,7 @@ var CPSetObjectsKey = @"CPSetObjectsKey";
     {
         var value = [object valueForKey:aKey];
 
-        // addObject: should be smart enough not to add these, but just in case...
-        if (value !== nil && value !== undefined)
-            [valueSet addObject:value];
+        [valueSet addObject:value];
     }
 
     return valueSet;

--- a/Foundation/CPSet/_CPConcreteMutableSet.j
+++ b/Foundation/CPSet/_CPConcreteMutableSet.j
@@ -85,7 +85,7 @@ var hasOwnProperty = Object.prototype.hasOwnProperty;
 - (void)addObject:(id)anObject
 {
     if (anObject === nil || anObject === undefined)
-        return;
+        [CPException raise:CPInvalidArgumentException reason:@"attempt to insert nil or undefined"];
 
     if ([self containsObject:anObject])
         return;


### PR DESCRIPTION
Although it is not documented in the Cocoa docs for NSMutableSet (which is an oversight), the following code raises "attempt to insert nil":

```
NSMutableSet* set = [NSMutableSet new];
[set addObject:nil];
```

The fact that this raises is indirectly documented here: http://is.gd/J6DIg7. Notice the warning for @distinctUnionOfObjects: "Important: This operator raises an exception if any of the leaf objects is nil." This is because internally the implementation is probably doing something like this:

```
NSArray* objects = [self valueForKeyPath:param];
// this raises if an element of objects is nil
return [[NSSet setWithArray:objects] allObjects];
```

Obviously nil/undefined should not be added to a set. Currently Cappuccino silently fails by doing nothing -- perhaps not the best approach. I trust Apple's judgement on this one -- I can see how it might lead to hard to track down bugs in user code, where the user expects a value to be in the set and it isn't there because it was nil/undefined, but they don't realize the value was nil. Raising would immediately alert them to something wrong somewhere else.

This obviously will cause some existing code to fail -- hopefully not Cappuccino code -- but some user code. But I think it's worth having safer behavior down the line.
