### PR TITLE
Add textFrame method to locate the text within the view

### DIFF
--- a/AppKit/_CPImageAndTextView.j
+++ b/AppKit/_CPImageAndTextView.j
@@ -288,6 +288,28 @@ var _CPimageAndTextViewFrameSizeChangedFlag         = 1 << 0,
     return _textShadowOffset;
 }
 
+- (CGRect)textFrame
+{
+    [self layoutIfNeeded];
+
+    var textFrame = CGRectMakeZero();
+
+    if (_DOMTextElement)
+    {
+        var textStyle = _DOMTextElement.style;
+
+        textFrame.origin.y = parseInt(textStyle.top.substr(0, textStyle.top.length - 2), 10),
+        textFrame.origin.x = parseInt(textStyle.left.substr(0, textStyle.left.length - 2), 10),
+        textFrame.size.width = parseInt(textStyle.width.substr(0, textStyle.width.length - 2), 10),
+        textFrame.size.height = parseInt(textStyle.height.substr(0, textStyle.height.length - 2), 10);
+
+        textFrame.size.width += _textShadowOffset.width;
+        textFrame.size.height += _textShadowOffset.height;
+    }
+
+    return textFrame;
+}
+
 - (void)setImage:(CPImage)anImage
 {
     if (_image == anImage)


### PR DESCRIPTION
## Motivation

Currently there is no public API to get the frame of the text within a _CPImageAndTextView, which is extremely useful when you are trying to do things like align with the text's baseline.
## Solution

This commit adds a single method, `textFrame`, which returns the frame of the text in _CPImageAndTextView coordinates.
