### PR TITLE
nib2cib now takes care of bold and italic

### DIFF
--- a/Tools/nib2cib/NSFont.j
+++ b/Tools/nib2cib/NSFont.j
@@ -63,9 +63,11 @@ var IBDefaultFontFace = @"Lucida Grande",
 
     if (name === IBDefaultFontFace)
     {
-        var size = [aFont size];
+        var size = [aFont size],
+            bold = [aFont isBold],
+            italic = [aFont isItalic];
 
-        if (size === IBDefaultFontSize)
+        if (size === IBDefaultFontSize && !bold && !italic)
             return nil;
         else
             return [[CPFont alloc] _initWithName:[CPFont systemFontFace] size:size bold:[aFont isBold] italic:[aFont isItalic]];


### PR DESCRIPTION
This allows to set bold and italic in IB even if the size of the font is the default one
