### PR TITLE
Do not truncate bold labels

### DIFF
--- a/Tools/nib2cib/NSTextField.j
+++ b/Tools/nib2cib/NSTextField.j
@@ -75,6 +75,7 @@
         {
             var frame = [self frame];
 
+            [self setFrameOrigin:CGPointMake(frame.origin.x, frame.origin.y - 1.0)];
             [self setFrameSize:CGSizeMake(frame.size.width, frame.size.height + 2.0)];
         }
 


### PR DESCRIPTION
When label with default size are bold, letter like p, g, q etc,
are truncated like in http://gyazo.com/d6c25af20574a96f9af0f288a7bd802a.png

This commit fix this.
