### PR TITLE
Right Command key on WebKit misinterpreted

### DIFF
--- a/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
@@ -183,11 +183,12 @@ KeyCodesToUnicodeMap[CPKeyCodes.BACKSLASH]              = "\\";
 KeyCodesToUnicodeMap[CPKeyCodes.CLOSE_SQUARE_BRACKET]   = "]";
 
 var ModifierKeyCodes = [
-    CPKeyCodes.META,
-    CPKeyCodes.MAC_FF_META,
-    CPKeyCodes.CTRL,
-    CPKeyCodes.ALT,
-    CPKeyCodes.SHIFT
+        CPKeyCodes.META,
+        CPKeyCodes.WEBKIT_RIGHT_META,
+        CPKeyCodes.MAC_FF_META,
+        CPKeyCodes.CTRL,
+        CPKeyCodes.ALT,
+        CPKeyCodes.SHIFT
     ],
     supportsNativeDragAndDrop = [CPPlatform supportsDragAndDrop];
 

--- a/AppKit/Platform/DOM/CPPlatformWindow+DOMKeys.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOMKeys.j
@@ -83,6 +83,7 @@ CPKeyCodes = {
   Y: 89,
   Z: 90,
   META: 91,
+  WEBKIT_RIGHT_META: 93,    // WebKit (on Mac at least) fires this for the right Command key
   CONTEXT_MENU: 93,
   NUM_ZERO: 96,
   NUM_ONE: 97,


### PR DESCRIPTION
On WebKit (at least on Mac), right Command key code is 93, not 91. This was not being trapped as a modifier key and was thus being interpreted as Command-].

To test, run the Test/Manual/KeyEquivalents test in Safari or Chrome on the current master. Press the right Command key. You will see the ] button activate, as if Command-] was pressed.

Then checkout this commit and try again. The right Command key alone no longer triggers the key equivalent.
