### PR TITLE
CPLevelIndicator fix last segment spacing + typos

### DIFF
--- a/AppKit/CPLevelIndicator.j
+++ b/AppKit/CPLevelIndicator.j
@@ -180,7 +180,7 @@ var _CPLevelIndicatorBezelColor = nil,
             segmentFrame = CGRectCreateCopy([self bounds]);
 
         segmentFrame.origin.x =  FLOOR(segment * basicSegmentWidth);
-        segmentFrame.size.width = FLOOR(((segment + 1) * basicSegmentWidth)) - FLOOR((segment * basicSegmentWidth)) - _CPLevelIndicatorSpacing;
+        segmentFrame.size.width = (segment == segmentCount - 1) ? bounds.size.width - segmentFrame.origin.x : FLOOR(((segment + 1) * basicSegmentWidth)) - FLOOR((segment * basicSegmentWidth)) - _CPLevelIndicatorSpacing;
         segmentFrame.size.height -= 1;
 
         return segmentFrame;


### PR DESCRIPTION
This patch avoids to have this kind of problem when too much segments are present:

http://gyazo.com/36da2019514c429dd6edc2318fc101fc

And do this:

http://gyazo.com/65e23eb978dc493be96633c612e538ca.png
- fix typo ("self" not "sef")
