### PR TITLE
Adding OJTest installation to the bootstrap.sh file.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -276,18 +276,22 @@ if ! prompt "yes"; then
     exit 1
 fi
 
-if [ ! "$install_capp" ] && prompt; then
+if [ ! "$install_capp" ]; then
     echo "================================================================================"
     echo "Would you like to install the pre-built Objective-J and Cappuccino packages?"
     echo "If you intend to build Cappuccino yourself this is not neccessary."
-    install_capp="yes"
+    if prompt; then
+      install_capp="yes"
+    fi
 fi
 
 
-if [ ! "$install_test" ] && prompt; then
+if [ ! "$install_test" ]; then
     echo "================================================================================"
     echo "Would you like to install test OJTest package?"
-    install_test="yes"
+    if prompt; then
+      install_test="yes"
+    fi
 fi
 
 # Make sure tusk can access GitHub's HTTPS URLs.


### PR DESCRIPTION
While I was poking around the bootstrap.sh file, I also put the cappuccino/objective-j package installation back in. It works for me so I'm not exactly sure why it was ever removed.

Related commits: 

https://github.com/280north/cappuccino/commit/4b770714bd968f656e7df24ba951f6256b40f0ac
https://github.com/280north/cappuccino/commit/289df53fb45f59f80b66ac2ed721081f8919ac79

It is worth noting that the starter bootstrap would not prompt for the prebuilt cappuccino packages but would prompt for the OJTest package. If you pass in the command-line flags, the prompt is skipped for the appropriate packages.
