### PR TITLE
Auxiliary theme support

### DIFF
--- a/AppKit/CPApplication.j
+++ b/AppKit/CPApplication.j
@@ -1292,8 +1292,12 @@ var _CPAppBootstrapperActions = nil,
 
 + (void)blendDidFinishLoading:(CPThemeBlend)aThemeBlend
 {
-    [[CPApplication sharedApplication] setThemeBlend:aThemeBlend];
-    [CPTheme setDefaultTheme:[CPTheme themeNamed:[CPApplication defaultThemeName]]];
+    var themeBlends = [CPApp themeBlends];
+
+    [themeBlends addObject:aThemeBlend];
+
+    if ([themeBlends count] === 1)
+        [CPTheme setDefaultTheme:[CPTheme themeNamed:[CPApplication defaultThemeName]]];
 
     if (_CPAppThemeURLsToLoad.length === 0)
         [self performActions];

--- a/AppKit/CPTheme.j
+++ b/AppKit/CPTheme.j
@@ -86,7 +86,8 @@ var CPThemesByName              = { },
 }
 
 /*!
-    Returns the closest matching theme for a given view. The matching proceeds as follows:
+    Returns the closest matching theme for a given view or view class.
+    The matching proceeds as follows:
 
     - The default theme class name for the class is retrieved.
     - Starting with the last loaded theme and proceeding towards the default theme,
@@ -94,16 +95,22 @@ var CPThemesByName              = { },
     - If the theme defines the class name, that theme is returned.
     - If no themes match, the default theme is returned.
 
-    @param aView The view to match with a theme
-    @return      The first matching theme
+    @param aViewOrClass The view or view class to match with a theme
+    @return             The first matching theme
 */
-+ (CPTheme)themeForView:(CPView)aView
++ (CPTheme)themeForView:(id)aViewOrClass
 {
-    var count = CPThemeNamesByInheritance.length,
-        themeClass = [aView themeClass];
+    var themeClass = nil;
+
+    if (class_isMetaClass(aViewOrClass.isa))
+        themeClass = [aViewOrClass defaultThemeClass];
+    else
+        themeClass = [aViewOrClass themeClass];
 
     if (themeClass)
     {
+        var count = CPThemeNamesByInheritance.length;
+
         while (count--)
         {
             var theme = CPThemesByName[CPThemeNamesByInheritance[count]];

--- a/AppKit/CPView.j
+++ b/AppKit/CPView.j
@@ -292,7 +292,7 @@ var CPViewFlags                     = { },
         _DOMImageSizes = [];
 #endif
 
-        _theme = [CPTheme defaultTheme];
+        _theme = [CPTheme themeForView:self];
         _themeState = CPThemeStateNormal;
 
         [self setupViewFlags];

--- a/AppKit/CPView.j
+++ b/AppKit/CPView.j
@@ -2670,7 +2670,7 @@ var CPViewAutoresizingMaskKey       = @"CPViewAutoresizingMask",
 
         [self setupViewFlags];
 
-        _theme = [CPTheme defaultTheme];
+        _theme = [CPTheme themeForView:self];
         _themeClass = [aCoder decodeObjectForKey:CPViewThemeClassKey];
         _themeState = CPThemeState([aCoder decodeIntForKey:CPViewThemeStateKey]);
         _themeAttributes = {};


### PR DESCRIPTION
## Motivation

The current theme engine provides little to no built in support for auxiliary themes that can augment or override the default theme. Although themes can be loaded dynamically, they don't really work well in that way, and nib2cib does not correctly support them. In the end most people end up merging everything into one master theme that they set as the default. This is obviously non-optimal.
### Solution

This release supports a `CPAuxiliaryThemes` item in an app or framework's Info.plist:

```
<key>CPAuxiliaryThemes</key>
<array>
    <string>MyTheme</string>
</array>
```

**Theme Loading**
At boot time, all of the auxiliary themes are loaded after the default theme. **CPTheme** keeps track of the order in which they were loaded, because themes loaded later augment or override themes loaded earlier.

**Theme Lookup**
Currently, if you use a class that uses a custom theme, you have to manually set its theme during init. In this release the correct theme for a given class is determined automatically by traversing the list of themes, most recently loaded first, matching a class' `+defaultTheme` with the names in the theme. The first matching theme is set as the view's theme.

**nib2cib Support**
This release solves the Cappuccino side of the problem and works quite well for views created in code. The nib2cib side will be fixed in a separate pull request.
