### PR TITLE
Fixup for CPDictionary's dictionaryWithJSObject:recursively: and null objects in arrays

### DIFF
--- a/Foundation/CPDictionary.j
+++ b/Foundation/CPDictionary.j
@@ -176,11 +176,18 @@
                 for (; i < count; i++)
                 {
                     var thisValue = value[i];
-
-                    if (thisValue.constructor === Object)
-                        newValue.push([CPDictionary dictionaryWithJSObject:thisValue recursively:YES]);
+                    
+                    if (thisValue === null)
+                    {
+                        newValue.push([CPNull null]);
+                    }
                     else
-                        newValue.push(thisValue);
+                    {
+                        if (thisValue.constructor === Object)
+                            newValue.push([CPDictionary dictionaryWithJSObject:thisValue recursively:YES]);
+                        else
+                            newValue.push(thisValue);
+                    }
                 }
 
                 value = newValue;


### PR DESCRIPTION
The fix adds special case for null values allowing to unpack JSON like ["abc",123,null]
