### PR TITLE
Do not return 0 if a XIB conversion fails

### DIFF
--- a/Tools/nib2cib/main.j
+++ b/Tools/nib2cib/main.j
@@ -51,18 +51,21 @@ function main(args)
 {
     try
     {
-        var options = parseOptions(args);
+        var options = parseOptions(args),
+            ret = 0;
 
         if (options.watch)
             watch(options);
         else
-            convert(options);
+            if (!convert(options))
+                ret = 2;
     }
     catch (anException)
     {
         CPLog.fatal(exceptionReason(anException));
         OS.exit(1);
     }
+    OS.exit(ret);
 }
 
 function convert(options, inputFile)


### PR DESCRIPTION
Do not return 0 if any XIB conversion fails (return 2 instead). This helps, in other things, xcodecapp-cocoa to know when something is wrong.
