### PR TITLE
CPViewAnimation: current frame based on -currentValue.

### DIFF
--- a/AppKit/CPAnimation.j
+++ b/AppKit/CPAnimation.j
@@ -306,6 +306,9 @@ ACTUAL_FRAME_RATE = 0;
 
     if ([_delegate respondsToSelector:@selector(animation:valueForProgress:)])
         return [_delegate animation:self valueForProgress:t];
+    
+    if (_animationCurve == CPAnimationLinear)
+        return t;
 
     var c1 = [],
         c2 = [];

--- a/AppKit/CPViewAnimation.j
+++ b/AppKit/CPViewAnimation.j
@@ -111,7 +111,8 @@ CPViewAnimationFadeOutEffect = @"CPViewAnimationFadeOutEffect";
             view = [self _targetView:dictionary],
             startFrame = [self _startFrame:dictionary],
             endFrame = [self _endFrame:dictionary],
-            differenceFrame = _CGRectMakeZero();
+            differenceFrame = _CGRectMakeZero(),
+            value = [super currentValue];
 
         differenceFrame.origin.x = endFrame.origin.x - startFrame.origin.x;
         differenceFrame.origin.y = endFrame.origin.y - startFrame.origin.y;
@@ -119,19 +120,19 @@ CPViewAnimationFadeOutEffect = @"CPViewAnimationFadeOutEffect";
         differenceFrame.size.height = endFrame.size.height - startFrame.size.height;
 
         var intermediateFrame = _CGRectMakeZero();
-        intermediateFrame.origin.x = startFrame.origin.x + differenceFrame.origin.x * progress;
-        intermediateFrame.origin.y = startFrame.origin.y + differenceFrame.origin.y * progress;
-        intermediateFrame.size.width = startFrame.size.width + differenceFrame.size.width * progress;
-        intermediateFrame.size.height = startFrame.size.height + differenceFrame.size.height * progress;
+        intermediateFrame.origin.x = startFrame.origin.x + differenceFrame.origin.x * value;
+        intermediateFrame.origin.y = startFrame.origin.y + differenceFrame.origin.y * value;
+        intermediateFrame.size.width = startFrame.size.width + differenceFrame.size.width * value;
+        intermediateFrame.size.height = startFrame.size.height + differenceFrame.size.height * value;
 
         [view setFrame:intermediateFrame];
 
         // Update the view's alpha value
         var effect = [self _effect:dictionary];
         if (effect === CPViewAnimationFadeInEffect)
-            [view setAlphaValue:1.0 * progress];
+            [view setAlphaValue:1.0 * value];
         else if (effect === CPViewAnimationFadeOutEffect)
-            [view setAlphaValue:1.0 + ( 0.0 - 1.0 ) * progress];
+            [view setAlphaValue:1.0 + ( 0.0 - 1.0 ) * value];
 
         if (progress === 1.0)
             [self _targetView:view setHidden:_CGRectIsNull(endFrame) || [view alphaValue] === 0.0];


### PR DESCRIPTION
In CPViewAnimation, the frame should be computed based on the currentValue, not the currentProgress (they are equal only for a linear curve).
