### PR TITLE
Have to set _themeClass when class changes

### DIFF
--- a/Tools/nib2cib/NSButton.j
+++ b/Tools/nib2cib/NSButton.j
@@ -99,6 +99,8 @@ var NSButtonIsBorderedMask = 0x00800000,
             self.isa = [CPRadio class];
             self._radioGroup = [CPRadioGroup new];
         }
+
+        _themeClass = [[self class] defaultThemeClass];
     }
 
     NIB_CONNECTION_EQUIVALENCY_TABLE[[cell UID]] = self;


### PR DESCRIPTION
If _themeClass is not set here, then [self themeClass] for CPCheckBox returns "button" instead of "check-box".
