### PR TITLE
Allow CPAlert subclasses to use +alertWithMessageText:... et al.

### DIFF
--- a/AppKit/CPAlert.j
+++ b/AppKit/CPAlert.j
@@ -117,7 +117,7 @@ CPCriticalAlertStyle        = 2;
 */
 + (CPAlert)alertWithMessageText:(CPString)aMessage defaultButton:(CPString)defaultButtonTitle alternateButton:(CPString)alternateButtonTitle otherButton:(CPString)otherButtonTitle informativeTextWithFormat:(CPString)informativeText
 {
-    var alert = [[CPAlert alloc] init];
+    var alert = [[self alloc] init];
 
     [alert setMessageText:aMessage];
     [alert addButtonWithTitle:defaultButtonTitle];
@@ -142,7 +142,7 @@ CPCriticalAlertStyle        = 2;
 */
 + (CPAlert)alertWithError:(CPString)anErrorMessage
 {
-    var alert = [[CPAlert alloc] init];
+    var alert = [[self alloc] init];
 
     [alert setMessageText:anErrorMessage];
     [alert setAlertStyle:CPCriticalAlertStyle];


### PR DESCRIPTION
Currently they force returning `CPAlert` instances instead of whatever the receiver class is, which might be a custom subclass. I've verified that this is how Cocoa does it via MacRuby:

```
donovan ~ $ macirb
>> framework 'AppKit'
=> true
>> class MMAlert < NSAlert; end
=> nil
>> a=MMAlert.alertWithMessageText("foo", defaultButton:'bar', alternateButton:nil, otherButton:nil, informativeTextWithFormat:'')
=> #<MMAlert:0x4011e5bc0>
>> a.class
=> MMAlert
```
