### PR TITLE
CPBox autoresize settings

### DIFF
--- a/AppKit/CPBox.j
+++ b/AppKit/CPBox.j
@@ -61,6 +61,7 @@ CPGrooveBorder  = 3;
     var box = [[self alloc] initWithFrame:CGRectMakeZero()],
         enclosingView = [aView superview];
 
+	[box setAutoresizingMask:[aView autoresizingMask]];
     [box setFrameFromContentFrame:[aView frame]];
 
     [enclosingView replaceSubview:aView with:box];


### PR DESCRIPTION
When using the +(id)boxEnclosingView:(CPView) method, Cappuccino should copy the original autoresizing settings from the view. This is already correctly done with CPShadowView and this pull request will add the same behavior.

PS: This is my first Pull Request and the first contribution to Cappuccino so let me know if something is wrong.
