### PR TITLE
CPSound supports play while loading

### DIFF
--- a/AppKit/CPSound.j
+++ b/AppKit/CPSound.j
@@ -45,6 +45,7 @@ CPSoundPlayBackStatePause   = 2;
     CPString            _name       @accessors(property=name);
     id                  _delegate   @accessors(property=delegate);
 
+    BOOL                _playRequestBeforeLoad;
     HTMLAudioElement    _audioTag;
     int                 _loadStatus;
     int                 _playBackStatus;
@@ -61,6 +62,7 @@ CPSoundPlayBackStatePause   = 2;
         _loops = NO;
         _audioTag = document.createElement("audio");
         _audioTag.preload = YES;
+        _playRequestBeforeLoad = NO;
 
         _audioTag.addEventListener("canplay", function()
         {
@@ -138,6 +140,12 @@ CPSoundPlayBackStatePause   = 2;
 - (void)_soundDidload
 {
     _loadStatus = CPSoundLoadStateCanBePlayed;
+
+    if (_playRequestBeforeLoad)
+    {
+        _playRequestBeforeLoad = NO;
+        [self play];
+    }
 }
 
 /*! @ignore
@@ -167,6 +175,12 @@ CPSoundPlayBackStatePause   = 2;
 */
 - (BOOL)play
 {
+    if (_loadStatus === CPSoundLoadStateLoading)
+    {
+        _playRequestBeforeLoad = YES;
+        return YES;
+    }
+
     if ((_loadStatus !== CPSoundLoadStateCanBePlayed)
         || (_playBackStatus === CPSoundPlayBackStatePlay))
         return NO;


### PR DESCRIPTION
This patch allow to send 'play' message before
the sound is actually loaded (by remembering the play request
and playing the sound when loaded if needed)

this allows to do:

``` objj
var sound = [[CPSound alloc] initWithContentsOfURL:aSoundURL byReference:NO];
[sound play];
```
