### PR TITLE
Move OJTest install to after the tusk install of other packages.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -288,7 +288,7 @@ fi
 
 if [ ! "$install_test" ]; then
     echo "================================================================================"
-    echo "Would you like to install test OJTest package?"
+    echo "Would you like to install test OJTest package (this will also install the pre-build packages)?"
     if prompt; then
       install_test="yes"
     fi
@@ -309,10 +309,6 @@ if [ "$install_capp" ]; then
     extra_packages="objective-j cappuccino"
 fi
 
-if [ "$install_test" ]; then
-    extra_packages="${extra_packages} https://github.com/280north/ojtest/zipball/latest"
-fi
-
 echo "Installing necessary packages..."
 
 if ! tusk update; then
@@ -321,6 +317,11 @@ if ! tusk update; then
 fi
 
 tusk $tusk_install_command browserjs jake shrinksafe $extra_packages
+
+if [ "$install_test" ]; then
+    echo "Installing OJTest from GitHub"
+    NARWHAL_ENGINE=rhino tusk install https://www.github.com/cappuccino/OJTest/zipball/latest
+fi
 
 if [ `uname` = "Darwin" ]; then
     echo "================================================================================"


### PR DESCRIPTION
Tusk seems to need OJTest to be alone in order to calculate and/or
download dependencies (which are the Objective-J and Cappuccino
pre-built packages).
