### PR TITLE
fix bug preventing the CPPlatformWindow's title to change once opened

### DIFF
--- a/AppKit/Platform/CPPlatformWindow.j
+++ b/AppKit/Platform/CPPlatformWindow.j
@@ -264,7 +264,8 @@ var PrimaryPlatformWindow   = NULL;
     _title = aTitle;
 
 #if PLATFORM(DOM)
-    if (_DOMWindow && _DOMWindow.document && (aWindow === [CPApp mainWindow]))
+    if (_DOMWindow && _DOMWindow.document
+        && (aWindow === [CPApp mainWindow] || [aWindow platformWindow] !== [CPPlatformWindow primaryPlatformWindow]))
         _DOMWindow.document.title = _title;
 #endif
 }


### PR DESCRIPTION
My previous patches was preventing to change the CPPlatformWindow't title once it was opened using window's setTitle:

This patch fix it.
