### PR TITLE
fix problem in CPTokenField with wrong theme state if containing tokens

### DIFF
--- a/AppKit/CPTokenField.j
+++ b/AppKit/CPTokenField.j
@@ -312,8 +312,7 @@ var CPThemeStateAutoCompleting          = @"CPThemeStateAutoCompleting",
 
 - (void)_updatePlaceholderState
 {
-    var objectValue = [self objectValue];
-    if ((!objectValue || [objectValue count] === 0) && ![self hasThemeState:CPThemeStateEditing])
+    if (([[self _tokens] count] === 0) && ![self hasThemeState:CPThemeStateEditing])
         [self setThemeState:CPTextFieldStatePlaceholder];
     else
         [self unsetThemeState:CPTextFieldStatePlaceholder];


### PR DESCRIPTION
CPTokenField has the theme state `CPTextFieldStatePlaceholder` even if tokens are present, resulting with a wrong positioning of tokens.
