### PR TITLE
If target view of a drag and drop is a CPTableView, set inset bounds based on the row height of the table

### DIFF
--- a/AppKit/CPDragServer.j
+++ b/AppKit/CPDragServer.j
@@ -261,10 +261,19 @@ var CPDraggingSource_draggedImage_movedTo_          = 1 << 0,
         {
             var contentView = [scrollView contentView],
                 bounds = [contentView bounds],
-                insetBounds = CGRectInset(bounds, 30, 30),
                 eventLocation = [contentView convertPoint:_draggingLocation fromView:nil],
                 deltaX = 0,
-                deltaY = 0;
+                deltaY = 0,
+                insetSize = 30;
+            
+            if ([contentView respondsToSelector:@selector(documentView)] &&
+                [[contentView documentView] respondsToSelector:@selector(rowHeight)])
+            {
+                // Adjust inset bounds based on CPTableView row height
+                insetSize = MAX(insetSize, [[contentView documentView] rowHeight]);
+            }
+            
+            var insetBounds = CGRectInset(bounds, insetSize, insetSize);
 
             if (!CGRectContainsPoint(insetBounds, eventLocation))
             {


### PR DESCRIPTION
My application utilizes a CPTableView with relatively large (height-wise) rows (holding image thumbnails), and dragging and dropping rows within a CPScrollView is quite painfully slow.

This change adjusts the inset bounds for the scroll area from a hard-coded value of 30 pixels to be dependent on the row height of the CPTableView, if the target of the drag-and-drop is a CPTableView.

This works quite well for my application and seems relatively close to the Cocoa behaviour (subjectively, as I haven't been able to track down any documentation describing how this is actually implemented in Cocoa), but I'm open to alternative suggestions if this doesn't seem like the right approach.

There was an earlier discussion on this some months back (see https://groups.google.com/group/objectivej/browse_thread/thread/ec4adf67a5fdadb3) that resulted in an increase of the inset bounds from 10 to 30 pixels, but I find that insufficient for my application's needs.
