### PR TITLE
Update internal string value of CPTextField when a newline is entered or the field loses focus

### DIFF
--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -574,11 +574,17 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
 #if PLATFORM(DOM)
 
     var element = [self _inputElement],
+        newValue = element.value,
         error = @"";
+
+    if (newValue !== _stringValue)
+    {
+        [self _setStringValue:newValue];
+    }
 
     // If there is a formatter, always give it a chance to reject the resignation,
     // even if the value has not changed.
-    if ([self _valueIsValid:element.value] === NO)
+    if ([self _valueIsValid:newValue] === NO)
     {
         [self setThemeState:CPThemeStateEditing];
         element.focus();
@@ -774,6 +780,13 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
 
 - (void)insertNewline:(id)sender
 {
+    var newValue = [self _inputElement].value;
+
+    if (newValue !== _stringValue)
+    {
+        [self _setStringValue:newValue];
+    }
+
     if ([self _valueIsValid:_stringValue])
     {
         // If _isEditing == YES then the target action can also be called via


### PR DESCRIPTION
Currently CPTextField only updates its internal string value from the actual HTML input element on a keyUp event. If the CPTextField loses focus before the keyUp event is received, the internal value does not get updated and any text entered since the last keyUp event is lost.

This is easily reproduced when editing a text field by quickly entering text and hitting the enter/return key to insert a new line (before the keyUp event has fired), or when holding down a key (to repeatedly enter the same character), and then tabbing out of the text field -- the value gets reset to whatever the value was before the key was held down.

This fix changes CPTextField#insertNewLine and CPTextField#resignFirstResponder to reload the string value from the input element if it has changed (in the same way as if a keyUp event had been triggered)
