### PR TITLE
bootstrap.sh libedit - No rule to make target `../src/libedit.la'

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -340,7 +340,7 @@ if [ `uname` = "Darwin" ]; then
     if prompt "yes"; then
         tusk $tusk_install_command narwhal-jsc
 
-        if ! (cd "$install_directory/packages/narwhal-jsc" && make webkit); then
+        if ! (cd "$install_directory/packages/narwhal-jsc/deps/libedit-20100424-3.0" && autoreconf -if && cd ../../ && make webkit); then
             rm -rf "$install_directory/packages/narwhal-jsc"
             echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
             echo "WARNING: building narwhal-jsc failed. Hit enter to continue."


### PR DESCRIPTION
adding autoreconf to fix issues reported at [1]

[1] http://groups.google.com/group/objectivej/browse_thread/thread/b0cddeb1046bfcf4/3f0b0cbbe57ed64b
