### PR TITLE
Reverse transform binding value after table view edit.

### DIFF
--- a/AppKit/CPTableColumn.j
+++ b/AppKit/CPTableColumn.j
@@ -680,6 +680,8 @@ CPTableColumnUserResizingMask   = 1 << 1;
             keyPath = [bindingInfo objectForKey:CPObservedKeyPathKey],
             dotIndex = keyPath.lastIndexOf(".");
 
+        newValue = [binding reverseTransformValue:newValue withOptions:[bindingInfo objectForKey:CPOptionsKey]];
+
         if (dotIndex === CPNotFound)
             [[destination valueForKeyPath:keyPath] replaceObjectAtIndex:aRow withObject:newValue];
         else


### PR DESCRIPTION
When table column bind to array controller with a value transformer. We transform the value in _prepareDataView:forRow:value = [binding transformValue:value withOptions:[bindingInfo objectForKey:CPOptionsKey]];[aDataView setValue:value forKey:@"objectValue"];But, look like we forget reverse it back.
