### PR TITLE
Compilation problems on ubuntu

### DIFF
--- a/Objective-J/Jakefile
+++ b/Objective-J/Jakefile
@@ -106,7 +106,7 @@ function environmentFlags()
 
     return environments.map(function(anEnvironment) {
         return "-D" + anEnvironment.toUpperCase();
-    }).concat("-DENVIRONMENTS=" + JSON.stringify(environments));
+    }).concat("-DENVIRONMENTS=" + OS.enquote(JSON.stringify(environments)));
 }
 
 var SHRINKSAFE = require("minify/shrinksafe");


### PR DESCRIPTION
This fixes two issues in compiling on linux (ubuntu):1. parameters to gcc should be joined with " "2. the -DENVIRONMENTS parameter needs OS.enquote otherwise the linux shell removes the quotes
