### PR TITLE
Issue #1297 - fixing CPBrowser selection when using up/down arrow keys

### DIFF
--- a/AppKit/CPBrowser.j
+++ b/AppKit/CPBrowser.j
@@ -901,6 +901,12 @@ var _CPBrowserResizeControlBackgroundImage = nil;
     [_browser _column:_index clickedRow:[selectedIndexes count] === 1 ? [selectedIndexes firstIndex] : -1];
 }
 
+- (void)tableViewSelectionDidChange:(CPNotification)aNotification
+{
+    var selectedIndexes = [[aNotification object] selectedRowIndexes];
+    [_browser selectRowIndexes:selectedIndexes inColumn:_index];
+}
+
 - (id)childAtIndex:(unsigned)index
 {
     return [_delegate browser:_browser child:index ofItem:_item];


### PR DESCRIPTION
## Problem

Keyboard navigation of a CPBrowser's table views does not notify the browser in such a way as to propagate the selection change back up to the CPBrowser.
## Solution

Added tableViewSelectionDidChange: to the table view delegates, allowing them to respond to table view selection changes and notify the browser when they occur.
