### PR TITLE
Edit in press utility

### DIFF
--- a/CommonJS/bin/press
+++ b/CommonJS/bin/press
@@ -371,8 +371,7 @@ function pngcrushDirectory(directory) {
     var pngs = directoryPath.glob("**/*.png");
 
     system.stderr.print("Running pngcrush on " + pngs.length + " pngs:");
-    pngs.forEach(function(dst) {
-        var dstPath = directoryPath.join(dst);
+    pngs.forEach(function(dstPath) {
         var tmpPath = FILE.path(dstPath+".tmp");
 
         var p = OS.popen(["pngcrush", "-rem", "alla", "-reduce", /*"-brute",*/ dstPath, tmpPath]);


### PR DESCRIPTION
I get partially duplicate paths to images when calling pngcrush in press.

This oneliner can reproduce the issue on my setup, bootstrap.sh from updated git on Lion:

```
capp gen FooApp; mkdir -p FooApp/Build/Deployment/FooApp; cd FooApp/ && jake release; press -f -p Build/Release/FooApp Build/Deployment/FooApp
```

directoryPath.glob("*_/_.png") at line 371 in press returns complete paths so there's no need to join each item with directoryPath.
