### PR TITLE
Correcting framework builds on jake release/deploy

### DIFF
--- a/Objective-J/CommonJS/lib/objective-j/jake/bundletask.js
+++ b/Objective-J/CommonJS/lib/objective-j/jake/bundletask.js
@@ -842,6 +842,24 @@ BundleTask.prototype.defineSourceTasks = function()
             var relativePath = aFilename.substring(basePathLength ? basePathLength + 1 : basePathLength),
                 compiledEnvironmentSource = FILE.join(sourcesPath, relativePath);
 
+            // if not top level, check for existence of jakefile
+            var pathdir = FILE.split(relativePath);
+            if (pathdir.length > 1) {
+                var jakefiles = ["jakefile", /*"Jakefile",*/ "jakefile.js", /*"Jakefile.js",*/ "jakefile.j", /*"Jakefile
+.j"*/];
+                var found = false;
+                for (var i=0; i < jakefiles.length; i++) {
+                    var templist = new Jake.FileList(pathdir[0]+"/"+pathdir[1]+"/**/"+jakefiles[i]);
+                    if (templist.length > 0) {
+                        TERM.stream.print("Ignoring [\0blue(" + anEnvironment + "\0)] \0purple(" + aFilename + "\0)");
+                        found = true;
+                    }
+                }
+                if (found) {
+                    return;
+                }
+            }
+
             filedir (compiledEnvironmentSource, [aFilename], function()
             {
                 var compile


### PR DESCRIPTION
If a framework contains a Jakefile, then it will run a jake <type> against it, and then copy the resultant compiled files into the compile of the main app.

-b

As per conversations on IRC. Existing build expects the Frameworks to live pre-built in their own folders, rather than uncompiled version. Uncompiled versions get compiled into the main .sj file, but their assets are unlocatable.

This change runs jake against uncompiled Frameworks, and then copies their compiled builds across properly, without adding to the .sj file and thus allowing cappuccino to load the compressed graphics from the correct location. 
