### PR TITLE
CPFont: fix typo in fontWithName:size: caching, rearrange constructor methods. With test.

### DIFF
--- a/AppKit/CPFont.j
+++ b/AppKit/CPFont.j
@@ -142,7 +142,7 @@ var _CPFonts                        = {},
 */
 + (CPFont)fontWithName:(CPString)aName size:(float)aSize
 {
-    return _CPCachedFont(aName, aSize, NO, NO) || [[CPFont alloc] _initWithName:aName size:aSize bold:NO italic:NO];
+    return [CPFont fontWithName:aName size:aSize bold:NO italic:NO];
 }
 
 /*!
@@ -154,7 +154,7 @@ var _CPFonts                        = {},
 */
 + (CPFont)fontWithName:(CPString)aName size:(float)aSize italic:(BOOL)italic
 {
-    return _CPCachedFont(aName, aSize, NO, NO) || [[CPFont alloc] _initWithName:aName size:aSize bold:NO italic:italic];
+    return [CPFont fontWithName:aName size:aSize bold:NO italic:italic];
 }
 
 /*!
@@ -165,7 +165,7 @@ var _CPFonts                        = {},
 */
 + (CPFont)boldFontWithName:(CPString)aName size:(float)aSize
 {
-    return _CPCachedFont(aName, aSize, YES, NO) || [[CPFont alloc] _initWithName:aName size:aSize bold:YES italic:NO];
+    return [CPFont fontWithName:aName size:aSize bold:YES italic:NO];
 }
 
 /*!
@@ -177,7 +177,7 @@ var _CPFonts                        = {},
 */
 + (CPFont)boldFontWithName:(CPString)aName size:(float)aSize italic:(BOOL)italic
 {
-    return _CPCachedFont(aName, aSize, YES, italic) || [[CPFont alloc] _initWithName:aName size:aSize bold:YES italic:italic];
+    return [CPFont fontWithName:aName size:aSize bold:YES italic:italic];
 }
 
 /*!
@@ -187,7 +187,7 @@ var _CPFonts                        = {},
 */
 + (CPFont)systemFontOfSize:(CPSize)aSize
 {
-    return _CPCachedFont(_CPFontSystemFontFace, aSize, NO, NO) || [[CPFont alloc] _initWithName:_CPFontSystemFontFace size:aSize bold:NO italic:NO];
+    return [CPFont fontWithName:_CPFontSystemFontFace size:aSize bold:NO italic:NO];
 }
 
 /*!
@@ -197,15 +197,15 @@ var _CPFonts                        = {},
 */
 + (CPFont)boldSystemFontOfSize:(CPSize)aSize
 {
-    return _CPCachedFont(_CPFontSystemFontFace, aSize, YES, NO) || [[CPFont alloc] _initWithName:_CPFontSystemFontFace size:aSize bold:YES italic:NO];
+    return [CPFont fontWithName:_CPFontSystemFontFace size:aSize bold:YES italic:NO];
 }
 
 /*  FIXME Font Descriptor
     @ignore
 */
-- (id)_initWithName:(CPString)aName size:(float)aSize bold:(BOOL)isBold
++ (CPFont)fontWithName:(CPString)aName size:(float)aSize bold:(BOOL)bold italic:(BOOL)italic
 {
-    return [self _initWithName:aName size:aSize bold:isBold italic:NO];
+    return _CPCachedFont(aName, aSize, bold, italic) || [[CPFont alloc] _initWithName:aName size:aSize bold:bold italic:italic];
 }
 
 - (id)_initWithName:(CPString)aName size:(float)aSize bold:(BOOL)isBold italic:(BOOL)isItalic

--- a/Tests/AppKit/CPFontTest.j
+++ b/Tests/AppKit/CPFontTest.j
@@ -51,6 +51,39 @@
     [self assert:_customFont notEqual:nil];
 }
 
+- (void)testConstructorsIsBoldIsItalic
+{
+    [self testConstructor:@selector(fontWithName:size:) args:["Arial", 12] isBold:NO isItalic:NO];
+    [self testConstructor:@selector(boldFontWithName:size:) args:["Arial", 13] isBold:YES isItalic:NO];
+    [self testConstructor:@selector(fontWithName:size:italic:) args:["Arial", 14, YES] isBold:NO isItalic:YES];
+    [self testConstructor:@selector(boldFontWithName:size:italic:) args:["Arial", 15, NO] isBold:YES isItalic:NO];
+}
+
+- (void)testConstructor:(SEL)aSelector args:(CPArray)args isBold:(BOOL)bold isItalic:(BOOL)italic
+{
+    var inv = [CPInvocation invocationWithMethodSignature:nil];
+    [inv setTarget:CPFont];
+    [inv setSelector:aSelector];
+    [args enumerateObjectsUsingBlock:function(arg, idx)
+    {
+        [inv setArgument:arg atIndex:idx + 2];
+    }];
+    
+    [inv invoke];
+    var font = [inv returnValue];
+    
+    [self assertTrue:([font isBold] == bold) message: [font description] + " should be bold: " + bold];
+    [self assertTrue:([font isItalic] == italic) message: [font description] + " should be italic: " + italic];
+    
+    // get from cache
+    [inv invoke];
+    var cachedFont = [inv returnValue];
+    [self assert:cachedFont equals:font];
+    
+    [self assertTrue:([cachedFont isBold] == bold) message:" cached " + [cachedFont description] + " should be bold: " + bold];
+    [self assertTrue:([cachedFont isItalic] == italic) message:" cached " + [cachedFont description] + " should be italic: " + italic];
+}
+
 @end
 
 var _CPFontStripRegExp = new RegExp("(^\\s*[\"']?|[\"']?\\s*$)", "g");


### PR DESCRIPTION
Have one main constructor and get cached font from there.
