### PR TITLE
Update DOM text field only if necessary to prevent problem with CPTextField binding

### DIFF
--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -960,7 +960,12 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
 #if PLATFORM(DOM)
 
     if (CPTextFieldInputOwner === self || [[self window] firstResponder] === self)
-        [self _inputElement].value = _stringValue;
+    {
+        var inputElement = [self _inputElement];
+
+        if (inputElement.value != _stringValue)
+            inputElement.value = _stringValue;
+    }
 
 #endif
 


### PR DESCRIPTION
Updating the value of a DOM text input field causes the cursor to jump at the end of the
text field. This behavior is usually what you want if you copy & paste new text into the text field but not if you are typing in new text in the middle of already existing text.

There is a problem if

a) the value of a CPTextField is bound to some other object and
b) the `CPContinuouslyUpdatesValueBindingOption` is enabled.

Once you type in new text the CPTextField value will be replaced with the already entered new content of the text field, causing the cursor to jump at the end of the text field.

This is a fix for issue #1435 that I posted a couple of weeks ago.
