### PR TITLE
Fix for issue 1425 CPOutlineView expand all items

### DIFF
--- a/AppKit/CPOutlineView.j
+++ b/AppKit/CPOutlineView.j
@@ -1365,7 +1365,7 @@ var CPOutlineViewCoalesceSelectionNotificationStateOff  = 0,
         [self collapseItem:item];
 
     else
-        [self expandItem:item];
+        [self expandItem:item expandChildren:([[CPApp currentEvent] modifierFlags] & CPAlternateKeyMask)];
 }
 
 /*!


### PR DESCRIPTION
 when option key is pressed while clicking the disclosure triangle
