### PR TITLE
Add support to proportionally scale to fit to CPImageView

### DIFF
--- a/AppKit/CPImageView.j
+++ b/AppKit/CPImageView.j
@@ -27,9 +27,10 @@
 @import "CPShadowView.j"
 
 
-CPScaleProportionally   = 0;
-CPScaleToFit            = 1;
-CPScaleNone             = 2;
+CPScaleProportionally       = 0;
+CPScaleToFit                = 1;
+CPScaleNone                 = 2;
+CPScaleToFitProportionally  = 4;
 
 CPImageAlignCenter      = 0;
 CPImageAlignTop         = 1;
@@ -310,11 +311,11 @@ var CPImageViewEmptyPlaceholderImage = nil;
         if (size.width == -1 && size.height == -1)
             return;
 
-        if (imageScaling === CPScaleProportionally)
+        if (imageScaling === CPScaleProportionally || imageScaling === CPScaleToFitProportionally)
         {
             // The max size it can be is size.width x size.height, so only
             // only proportion otherwise.
-            if (width >= size.width && height >= size.height)
+            if (width >= size.width && height >= size.height && imageScaling === CPScaleProportionally)
             {
                 width = size.width;
                 height = size.height;


### PR DESCRIPTION
Although not in cocoa, in cappuccino it is required to display an image larger than its original size.
