### PR TITLE
CFData: completed bytes(), base64() and adds CPData +dataWithBytes and +dataWithBase64:

### DIFF
--- a/Foundation/CPData.j
+++ b/Foundation/CPData.j
@@ -65,6 +65,22 @@
     return [[self alloc] initWithJSONObject:anObject];
 }
 
++ (CPData)dataWithBytes:(CPArray)bytesArray
+{
+    var data = [[self alloc] init];
+    data.setBytes(bytesArray);
+    
+    return data;
+}
+
++ (CPData)dataWithBase64:(CPString)aString
+{
+    var data = [[self alloc] init];
+    data.setBase64String(aString);
+    
+    return data;
+}
+
 - (id)initWithRawString:(CPString)aString
 {
     self = [super init];
@@ -118,6 +134,16 @@
 - (Object)JSONObject
 {
     return self.JSONObject();
+}
+
+- (CPArray)bytes
+{
+    return self.bytes();
+}
+
+- (CPString)base64
+{
+    return self.base64();
 }
 
 - (int)length

--- a/Objective-J/CFData.js
+++ b/Objective-J/CFData.js
@@ -67,9 +67,11 @@ CFData.prototype.rawString = function()
         else if (this._JSONObject)
             this._rawString = JSON.stringify(this._JSONObject);
 
-//        Ideally we would convert these bytes or base64 into a string.
-//        else if (this._bytes)
-//        else if (this._base64)
+        else if (this._bytes)
+            this._rawString = CFData.bytesToString(this._bytes);
+
+        else if (this._base64)
+            this._rawString = CFData.decodeBase64ToString(this._base64, true);
 
         else
             throw new Error("Can't convert data to string.");
@@ -80,11 +82,28 @@ CFData.prototype.rawString = function()
 
 CFData.prototype.bytes = function()
 {
+    if (this._bytes === NULL)
+    {
+        var bytes = CFData.stringToBytes(this.rawString());
+        this.setBytes(bytes);
+    }
+     
     return this._bytes;
 }
 
 CFData.prototype.base64 = function()
 {
+    if (this._base64 === NULL)
+    {
+        var base64;
+        if (this._bytes)
+            base64 = CFData.encodeBase64Array(this._bytes);
+        else
+            base64 = CFData.encodeBase64String(this.rawString());
+        
+        this.setBase64String(base64);
+    }
+    
     return this._base64;
 }
 
@@ -238,6 +257,14 @@ CFData.bytesToString = function(bytes)
     return String.fromCharCode.apply(NULL, bytes);
 }
 
+CFData.stringToBytes = function(input)
+{
+    var temp = [];
+    for (var i = 0; i < input.length; i++)
+        temp.push(input.charCodeAt(i));
+
+    return temp;
+}
 
 CFData.encodeBase64String = function(input)
 {

--- a/Tests/Foundation/CPDataTest.j
+++ b/Tests/Foundation/CPDataTest.j
@@ -66,4 +66,40 @@
     [self assertNull:[data plistObject]];
 }
 
+- (void)test_CPData_accessors
+{
+    var rawString = "cappuccino",
+        bytes = [99, 97, 112, 112, 117, 99, 99, 105, 110, 111],
+        base64 = "Y2FwcHVjY2lubw==";
+        
+    var data = [CPData dataWithBase64:base64];
+    [self assert:rawString equals:[data rawString]];
+    
+    data = [CPData dataWithBase64:base64];
+    [self assert:bytes equals:[data bytes]];
+
+    data = [CPData dataWithBase64:base64];
+    [self assert:base64 equals:[data base64]];
+
+
+    data = [CPData dataWithRawString:rawString];
+    [self assert:rawString equals:[data rawString]];
+    
+    data = [CPData dataWithRawString:rawString];
+    [self assert:bytes equals:[data bytes]];
+
+    data = [CPData dataWithRawString:rawString];
+    [self assert:base64 equals:[data base64]];
+
+
+    data = [CPData dataWithBytes:bytes];
+    [self assert:rawString equals:[data rawString]];
+    
+    data = [CPData dataWithBytes:bytes];
+    [self assert:bytes equals:[data bytes]];
+
+    data = [CPData dataWithBytes:bytes];
+    [self assert:base64 equals:[data base64]];
+}
+
 @end


### PR DESCRIPTION
Test inside.
Note that +dataWithBase64: does not exist in NSFoundation but base64 encoding is a common way to represent remote data.
