### PR TITLE
Baseline initalization for CPURLRequest in -(id) init; method

### DIFF
--- a/Foundation/CPURLRequest.j
+++ b/Foundation/CPURLRequest.j
@@ -54,18 +54,13 @@
 }
 
 /*!
-    Initializes the request with a URL.
-    @param aURL the url to set
-    @return the initialized CPURLRequest
+	Perform some baseline initialization
+	@return a baseline initialized CPURLRequest
 */
-- (id)initWithURL:(CPURL)aURL
+
+- (id) init
 {
-    self = [super init];
-
-    if (self)
-    {
-        [self setURL:aURL];
-
+	if(self = [super init]) {
         _HTTPBody = @"";
         _HTTPMethod = @"GET";
         _HTTPHeaderFields = [CPDictionary dictionary];
@@ -73,6 +68,23 @@
         [self setValue:"Thu, 01 Jan 1970 00:00:00 GMT" forHTTPHeaderField:"If-Modified-Since"];
         [self setValue:"no-cache" forHTTPHeaderField:"Cache-Control"];
         [self setValue:"XMLHttpRequest" forHTTPHeaderField:"X-Requested-With"];
+		}
+
+	return self;
+}
+
+/*!
+    Initializes the request with a URL.
+    @param aURL the url to set
+    @return the initialized CPURLRequest
+*/
+- (id)initWithURL:(CPURL)aURL
+{
+    self = [self init];
+
+    if (self)
+    {
+        [self setURL:aURL];
     }
 
     return self;


### PR DESCRIPTION
Hi,

I recently spent about an hour and a half trying to figure out why my CPURLRequest would not take headers when created like this:

var req = [[CPURLRequest alloc] init];

[req setURL: [CPURL URLWithString: @"http://google.com"]];

[req setValue: @"application/x-www-form-urlencoded" forHTTPHeaderField: @"Content-Type"];

It turns out that init does not properly create the datastructures in memory, even though I followed all the technical procedures. I realize init is not the designated initializer, but memory should be in a writable state at least when an object is created.

Thanks!

++ Briam R.
