### PR TITLE
Add missing help file in XcodeCapp to avoid startup crash

### DIFF
--- a/Tools/XcodeCapp/XcodeCapp.xcodeproj/project.pbxproj
+++ b/Tools/XcodeCapp/XcodeCapp.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		02998CEB1369BF7D006C73DB /* Growl Registration Ticket.growlRegDict in Resources */ = {isa = PBXBuildFile; fileRef = 02998CEA1369BF7D006C73DB /* Growl Registration Ticket.growlRegDict */; };
 		02998CF71369C339006C73DB /* Growl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02998CF61369C339006C73DB /* Growl.framework */; };
 		02998CF91369C38A006C73DB /* Growl.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 02998CF61369C339006C73DB /* Growl.framework */; };
+		4E2D0D01154840B400475C01 /* help.rtfd in Resources */ = {isa = PBXBuildFile; fileRef = 4E2D0D00154840B400475C01 /* help.rtfd */; };
+		4E2D0D03154840BC00475C01 /* help.rtfd in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4E2D0D00154840B400475C01 /* help.rtfd */; };
 		651DAE1F13B0CAB900ECA3F0 /* PRHEmptyGrowlDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 651DAE1D13B0CAB900ECA3F0 /* PRHEmptyGrowlDelegate.m */; };
 /* End PBXBuildFile section */
 
@@ -35,6 +37,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				02998CF91369C38A006C73DB /* Growl.framework in CopyFiles */,
+				4E2D0D03154840BC00475C01 /* help.rtfd in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -62,6 +65,7 @@
 		29B97319FDCFA39411CA2CEA /* English */ = {isa = PBXFileReference; lastKnownFileType = wrapper.nib; name = English; path = English.lproj/MainMenu.nib; sourceTree = "<group>"; };
 		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		29B97325FDCFA39411CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
+		4E2D0D00154840B400475C01 /* help.rtfd */ = {isa = PBXFileReference; lastKnownFileType = wrapper.rtfd; path = help.rtfd; sourceTree = "<group>"; };
 		651DAE1C13B0CAB900ECA3F0 /* PRHEmptyGrowlDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.objj.h; path = PRHEmptyGrowlDelegate.h; sourceTree = "<group>"; };
 		651DAE1D13B0CAB900ECA3F0 /* PRHEmptyGrowlDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PRHEmptyGrowlDelegate.m; sourceTree = "<group>"; };
 		8D1107310486CEB800E47090 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -152,6 +156,7 @@
 		29B97317FDCFA39411CA2CEA /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				4E2D0D00154840B400475C01 /* help.rtfd */,
 				022BCEA61468632000B72910 /* project.pbxproj.sample */,
 				027FE4B91462F64E00B1AB92 /* xcodecapp-icon-working.png */,
 				026F3B6413866E7D00EE5B83 /* xcodecapp-icon-active.png */,
@@ -236,6 +241,7 @@
 				027FE4BA1462F64E00B1AB92 /* xcodecapp-icon-working.png in Resources */,
 				0289AC9414668CAF003CD975 /* XcodeCapp.icns in Resources */,
 				022BCEA71468632000B72910 /* project.pbxproj.sample in Resources */,
+				4E2D0D01154840B400475C01 /* help.rtfd in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
The help.rtfd file to display the help of XcodeCapp is missing from the project and make the application crash when the help is displayed at the first app launch.

This pull request correct the Xcode project to add a copy of the help file in the application bundle.
