### PR TITLE
Fix incorrect _isLocalFileConnection if a locally called web application...

### DIFF
--- a/Foundation/CPURLConnection.j
+++ b/Foundation/CPURLConnection.j
@@ -151,12 +151,8 @@ var CPURLConnectionDelegate = nil;
         var URL = [_request URL],
             scheme = [URL scheme];
 
-        // Browsers use "file:", Titanium uses "app:"
-        _isLocalFileConnection =    scheme === "file" ||
-                                    ((scheme === "http" || scheme === "https:") &&
-                                    window.location &&
-                                    (window.location.protocol === "file:" || window.location.protocol === "app:"));
-
+        // Browsers use "file:"
+        _isLocalFileConnection =    scheme === "file";
         _HTTPRequest = new CFHTTPRequest();
 
         if (shouldStartImmediately)


### PR DESCRIPTION
... calls a remote server.

If a locally called web application (called with file://foo/index.html) is doing a http get request call using "http://whatever/", we receive a connection:didReceiveResponse: of response type CPURLResponse instead CPHTTPURLResponse as expected.

I've fixed it by removing the code that checks whether the application URL is using the scheme "file" or not.
This original code made no sense in my case.
