### PR TITLE
MainBundle path has no '/' at the end when running in CommonJS.

### DIFF
--- a/Objective-J/Bootstrap.js
+++ b/Objective-J/Bootstrap.js
@@ -22,7 +22,7 @@
 
 
 #ifdef COMMONJS
-var mainBundleURL = new CFURL("file:" + require("file").cwd());
+var mainBundleURL = new CFURL("file:" + require("file").cwd()).asDirectoryPathURL();
 #elif defined(BROWSER)
 // This is automatic when importing, but we'd like these important URLs to
 // be taken into consideration in the cache as well.


### PR DESCRIPTION
This will make relative paths fail. For example if OBJJ_INCLUDE_PATHS has the path "../../MyLibrary".
MyLibrary will not be found when the path is joined with mainBundlePath without an ending '/'.
This is working when running in Browser.
