### PR TITLE
Create support sources folder if necessary.

### DIFF
--- a/Tools/XcodeCapp/TNXCodeCapp.m
+++ b/Tools/XcodeCapp/TNXCodeCapp.m
@@ -469,10 +469,13 @@ NSString * const XCCListeningStartNotification = @"XCCListeningStartNotification
 }
 
 /*!
- Create the xCodeSupport/Sources folder if necessary.
+ Create the .xCodeSupport/Sources folder if necessary.
  */
-- (void)createXcodeSupportProjectSourcesDirIfNecessary {
-    if ([fm fileExistsAtPath:[XCodeSupportProjectSources path]]) return;
+- (void)createXcodeSupportProjectSourcesDirIfNecessary
+{
+    if ([fm fileExistsAtPath:[XCodeSupportProjectSources path]])
+        return;
+
     DLog(@"Creating source folder %@", [XCodeSupportProjectSources path]);
     [fm createDirectoryAtPath:[XCodeSupportProjectSources path] withIntermediateDirectories:YES attributes:nil error:nil];
 }


### PR DESCRIPTION
Make sure the the xCodeSupport/Sources folder is always
present. The objj tool will fail if it's missing.

The Sources folder could be missing if it's not checked
into a repos for example.
