### PR TITLE
fixed needsUntitled evaluation

### DIFF
--- a/AppKit/CPApplication.j
+++ b/AppKit/CPApplication.j
@@ -254,7 +254,7 @@ CPRunContinuesResponse  = -1002;
         count = [URLStrings count];
 
     for (; index < count; ++index)
-        needsUntitled = ![self _openURL:[CPURL URLWithString:URLStrings[index]]] || needsUntitled;
+        needsUntitled = ![self _openURL:[CPURL URLWithString:URLStrings[index]]] && needsUntitled;
 
     if (needsUntitled && [_delegate respondsToSelector:@selector(applicationShouldOpenUntitledFile:)])
         needsUntitled = [_delegate applicationShouldOpenUntitledFile:self];


### PR DESCRIPTION
This is the reduction version of [Pull Request #1555](https://github.com/cappuccino/cappuccino/pull/1555).

Just consider this portion of the existing code. No chance for _needsUntitled_ to become false. 

``` Objective-J
    var needsUntitled = !!_documentController,
        URLStrings = window.cpOpeningURLStrings && window.cpOpeningURLStrings(),
        index = 0,
        count = [URLStrings count];

    for (; index < count; ++index)
        needsUntitled = ![self _openURL:[CPURL URLWithString:URLStrings[index]]] || needsUntitled;
```

This fix is just to change the operator. 

``` Objective-J
needsUntitled = ![self _openURL:[CPURL URLWithString:URLStrings[index]]] && needsUntitled;
```
