### PR TITLE
nib2cib image fixes

### DIFF
--- a/Tools/imagesize/imagesize.xcodeproj/project.pbxproj
+++ b/Tools/imagesize/imagesize.xcodeproj/project.pbxproj
@@ -1,0 +1,223 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 45;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		E14061B7159D449000D99541 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E14061B6159D449000D99541 /* AppKit.framework */; };
+		E1D3CFAA12AFFB7F00CBB79E /* imagesize.m in Sources */ = {isa = PBXBuildFile; fileRef = 08FB7796FE84155DC02AAC07 /* imagesize.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		08FB7796FE84155DC02AAC07 /* imagesize.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = imagesize.m; sourceTree = "<group>"; };
+		08FB779EFE84155DC02AAC07 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
+		E14061B6159D449000D99541 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
+		E18587D81279B93100FB6A47 /* README */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README; sourceTree = "<group>"; };
+		E1E20D0B12B09283005A6A64 /* imagesize */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = imagesize; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		E1D3CF6912AFEE3800CBB79E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E14061B7159D449000D99541 /* AppKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		08FB7794FE84155DC02AAC07 /* font_info */ = {
+			isa = PBXGroup;
+			children = (
+				08FB7795FE84155DC02AAC07 /* Source */,
+				E18587DD1279B93600FB6A47 /* Documentation */,
+				08FB779DFE84155DC02AAC07 /* External Frameworks and Libraries */,
+				1AB674ADFE9D54B511CA2CBB /* Products */,
+			);
+			name = font_info;
+			sourceTree = "<group>";
+		};
+		08FB7795FE84155DC02AAC07 /* Source */ = {
+			isa = PBXGroup;
+			children = (
+				08FB7796FE84155DC02AAC07 /* imagesize.m */,
+			);
+			name = Source;
+			sourceTree = "<group>";
+		};
+		08FB779DFE84155DC02AAC07 /* External Frameworks and Libraries */ = {
+			isa = PBXGroup;
+			children = (
+				08FB779EFE84155DC02AAC07 /* Foundation.framework */,
+				E14061B6159D449000D99541 /* AppKit.framework */,
+			);
+			name = "External Frameworks and Libraries";
+			sourceTree = "<group>";
+		};
+		1AB674ADFE9D54B511CA2CBB /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				E1E20D0B12B09283005A6A64 /* imagesize */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		E18587DD1279B93600FB6A47 /* Documentation */ = {
+			isa = PBXGroup;
+			children = (
+				E18587D81279B93100FB6A47 /* README */,
+			);
+			name = Documentation;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		E1D3CF6A12AFEE3800CBB79E /* imagesize */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E1D3CF6F12AFEE3B00CBB79E /* Build configuration list for PBXNativeTarget "imagesize" */;
+			buildPhases = (
+				E1D3CF6812AFEE3800CBB79E /* Sources */,
+				E1D3CF6912AFEE3800CBB79E /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = imagesize;
+			productName = font_info;
+			productReference = E1E20D0B12B09283005A6A64 /* imagesize */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		08FB7793FE84155DC02AAC07 /* Project object */ = {
+			isa = PBXProject;
+			buildConfigurationList = 1DEB927808733DD40010E9CD /* Build configuration list for PBXProject "imagesize" */;
+			compatibilityVersion = "Xcode 3.1";
+			developmentRegion = English;
+			hasScannedForEncodings = 1;
+			knownRegions = (
+				English,
+				Japanese,
+				French,
+				German,
+			);
+			mainGroup = 08FB7794FE84155DC02AAC07 /* font_info */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				E1D3CF6A12AFEE3800CBB79E /* imagesize */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		E1D3CF6812AFEE3800CBB79E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E1D3CFAA12AFFB7F00CBB79E /* imagesize.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		1DEB927908733DD40010E9CD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)";
+				CONFIGURATION_TEMP_DIR = "$(CAPP_BUILD)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = NO;
+				GCC_PREFIX_HEADER = "";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = "$(CAPP_BUILD)";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-framework",
+					AppKit,
+				);
+				PREBINDING = NO;
+				PRODUCT_NAME = imagesize;
+				SDKROOT = macosx10.5;
+				SYMROOT = "$(CAPP_BUILD)/Debug/CommonJS/cappuccino/bin";
+			};
+			name = Debug;
+		};
+		1DEB927A08733DD40010E9CD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)";
+				CONFIGURATION_TEMP_DIR = "$(CAPP_BUILD)";
+				DEPLOYMENT_LOCATION = NO;
+				DEPLOYMENT_POSTPROCESSING = NO;
+				DSTROOT = "/tmp/$(PROJECT_NAME).dst";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PRECOMPILE_PREFIX_HEADER = NO;
+				GCC_PREFIX_HEADER = "";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INSTALL_PATH = "";
+				OBJROOT = "$(CAPP_BUILD)";
+				ONLY_ACTIVE_ARCH = NO;
+				PREBINDING = NO;
+				PRODUCT_NAME = imagesize;
+				SDKROOT = macosx10.5;
+				SYMROOT = "$(CAPP_BUILD)/Release/CommonJS/cappuccino/bin";
+			};
+			name = Release;
+		};
+		E1D3CF6D12AFEE3900CBB79E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = imagesize;
+			};
+			name = Debug;
+		};
+		E1D3CF6E12AFEE3900CBB79E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				MACOSX_DEPLOYMENT_TARGET = 10.5;
+				PRODUCT_NAME = imagesize;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		1DEB927808733DD40010E9CD /* Build configuration list for PBXProject "imagesize" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1DEB927908733DD40010E9CD /* Debug */,
+				1DEB927A08733DD40010E9CD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E1D3CF6F12AFEE3B00CBB79E /* Build configuration list for PBXNativeTarget "imagesize" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E1D3CF6D12AFEE3900CBB79E /* Debug */,
+				E1D3CF6E12AFEE3900CBB79E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 08FB7793FE84155DC02AAC07 /* Project object */;
+}

--- a/Tools/nib2cib/NSButton.j
+++ b/Tools/nib2cib/NSButton.j
@@ -112,6 +112,7 @@ var NSButtonIsBorderedMask = 0x00800000,
         }
 
         _themeClass = [[self class] defaultThemeClass];
+        alternateImage = nil;
     }
 
     NIB_CONNECTION_EQUIVALENCY_TABLE[[cell UID]] = self;
@@ -122,8 +123,7 @@ var NSButtonIsBorderedMask = 0x00800000,
     [self setBordered:[cell isBordered]];
     _bezelStyle = [cell bezelStyle];
 
-
-    // clean up:
+    // Map Cocoa bezel styles to Cappuccino bezel styles and adjust frame
     switch (_bezelStyle)
     {
         // implemented:
@@ -132,13 +132,16 @@ var NSButtonIsBorderedMask = 0x00800000,
             positionOffsetOriginX = 4;
             positionOffsetSizeWidth = -12;
             break;
+
         case CPTexturedRoundedBezelStyle:
             positionOffsetOriginY = 2;
             positionOffsetOriginX = -2;
             positionOffsetSizeWidth = 0;
             break;
+
         case CPHUDBezelStyle:
             break;
+
         // approximations:
         case CPRoundRectBezelStyle:
             positionOffsetOriginY = -3;
@@ -146,11 +149,13 @@ var NSButtonIsBorderedMask = 0x00800000,
             positionOffsetSizeWidth = 0;
             _bezelStyle = CPRoundedBezelStyle;
             break;
+
         case CPSmallSquareBezelStyle:
             positionOffsetOriginX = -2;
             positionOffsetSizeWidth = 0;
             _bezelStyle = CPTexturedRoundedBezelStyle;
             break;
+
         case CPThickSquareBezelStyle:
         case CPThickerSquareBezelStyle:
         case CPRegularSquareBezelStyle:
@@ -159,24 +164,28 @@ var NSButtonIsBorderedMask = 0x00800000,
             positionOffsetSizeWidth = -4;
             _bezelStyle = CPTexturedRoundedBezelStyle;
             break;
+
         case CPTexturedSquareBezelStyle:
             positionOffsetOriginY = 4;
             positionOffsetOriginX = -1;
             positionOffsetSizeWidth = -2;
             _bezelStyle = CPTexturedRoundedBezelStyle;
             break;
+
         case CPShadowlessSquareBezelStyle:
             positionOffsetOriginY = 5;
             positionOffsetOriginX = -2;
             positionOffsetSizeWidth = 0;
             _bezelStyle = CPTexturedRoundedBezelStyle;
             break;
+
         case CPRecessedBezelStyle:
             positionOffsetOriginY = -3;
             positionOffsetOriginX = -2;
             positionOffsetSizeWidth = 0;
             _bezelStyle = CPHUDBezelStyle;
             break;
+
         // unsupported
         case CPRoundedDisclosureBezelStyle:
         case CPHelpButtonBezelStyle:
@@ -185,6 +194,7 @@ var NSButtonIsBorderedMask = 0x00800000,
             CPLog.warn("NSButton [%s]: unsupported bezel style: %d", _title == null ? "<no title>" : '"' + _title + '"', _bezelStyle);
             _bezelStyle = CPHUDBezelStyle;
             break;
+
         // error:
         default:
             CPLog.warn("NSButton [%s]: unknown bezel style: %d", _title == null ? "<no title>" : '"' + _title + '"', _bezelStyle);
@@ -211,6 +221,7 @@ var NSButtonIsBorderedMask = 0x00800000,
 
     _allowsMixedState = [cell allowsMixedState];
     [self setImage:[cell normalImage]];
+    [self setAlternateImage:alternateImage];
     [self setImagePosition:[cell imagePosition]];
 
     [self setEnabled:[cell isEnabled]];
@@ -298,6 +309,7 @@ var NSButtonIsBorderedMask = 0x00800000,
             _imagePosition = CPNoImage;
 
         _highlightsBy = CPNoCellMask;
+
         if (buttonFlags & NSHighlightsByPushInCellMask)
             _highlightsBy |= CPPushInCellMask;
         if (buttonFlags & NSHighlightsByContentsCellMask)
@@ -308,6 +320,7 @@ var NSButtonIsBorderedMask = 0x00800000,
             _highlightsBy |= CPChangeBackgroundCellMask;
 
         _showsStateBy = CPNoCellMask;
+
         if (buttonFlags & NSShowsStateByContentsCellMask)
             _showsStateBy |= CPContentsCellMask;
         if (buttonFlags & NSShowsStateByChangeGrayCellMask)

--- a/Tools/nib2cib/NSCustomResource.j
+++ b/Tools/nib2cib/NSCustomResource.j
@@ -58,11 +58,13 @@ var FILE = require("file");
             if (!resourcePath)
                 CPLog.warn("Resource \"" + _resourceName + "\" not found in the resources path: " + [aCoder resourcesPath]);
             else
-                size = imageSize(FILE.canonical(resourcePath));
+                size = imageSize(FILE.canonical(resourcePath)) || CGSizeMakeZero();
 
             // Account for the fact that an extension may have been inferred.
             if (resourcePath && FILE.extension(resourcePath) !== FILE.extension(_resourceName))
                 _resourceName += FILE.extension(resourcePath);
+
+            CPLog.debug("Image path: %s\nImage size: %dx%d", FILE.canonical(resourcePath), size.width, size.height);
         }
 
         _properties = [CPDictionary dictionaryWithObject:size forKey:@"size"];


### PR DESCRIPTION
- nib2cib will now log the path and size of custom image resources in super verbose mode.
- Alternate images for buttons were not being set by nib2cib, that has been fixed.
- Fixed the name of the imagesize binary in the Xcode project.
