### PR TITLE
Splitview userinfo

### DIFF
--- a/AppKit/CPSplitView.j
+++ b/AppKit/CPSplitView.j
@@ -1028,13 +1028,28 @@ The sum of the views and the sum of the dividers should be equal to the size of 
 
 - (void)_postNotificationWillResize
 {
-    [[CPNotificationCenter defaultCenter] postNotificationName:CPSplitViewWillResizeSubviewsNotification object:self];
+    var userInfo = nil;
+
+    if (_currentDivider !== CPNotFound)
+        userInfo = [CPDictionary dictionaryWithObject:_currentDivider forKey:@"CPSplitViewDividerIndex"];
+
+    [[CPNotificationCenter defaultCenter] postNotificationName:CPSplitViewWillResizeSubviewsNotification
+                                                        object:self
+                                                      userInfo:userInfo];
 }
 
 - (void)_postNotificationDidResize
 {
     [self _autosave];
-    [[CPNotificationCenter defaultCenter] postNotificationName:CPSplitViewDidResizeSubviewsNotification object:self];
+
+    var userInfo = nil;
+
+    if (_currentDivider !== CPNotFound)
+        userInfo = [CPDictionary dictionaryWithObject:_currentDivider forKey:@"CPSplitViewDividerIndex"];
+
+    [[CPNotificationCenter defaultCenter] postNotificationName:CPSplitViewDidResizeSubviewsNotification
+                                                        object:self
+                                                      userInfo:userInfo];
 }
 
 /*!


### PR DESCRIPTION
Post OS X 10.5, Cocoa adds a userInfo with the divider index when the user drags the divider
