### PR TITLE
Make the default grid color in IB show correctly in CPTableView

### DIFF
--- a/AppKit/Themes/Aristo/ThemeDescriptors.j
+++ b/AppKit/Themes/Aristo/ThemeDescriptors.j
@@ -1556,7 +1556,7 @@ var themedButtonValues = nil,
         sortImage = PatternImage("tableview-headerview-ascending.png", 9.0, 8.0),
         sortImageReversed = PatternImage("tableview-headerview-descending.png", 9.0, 8.0),
         alternatingRowColors = [[CPColor whiteColor], [CPColor colorWithRed:245.0 / 255.0 green:249.0 / 255.0 blue:252.0 / 255.0 alpha:1.0]],
-        gridColor = [CPColor colorWithHexString:@"dce0e2"],
+        gridColor = [CPColor colorWithHexString:@"cccccc"],
         selectionColor = [CPColor colorWithHexString:@"5f83b9"],
         sourceListSelectionColor = [CPDictionary dictionaryWithObjects: [CGGradientCreateWithColorComponents(CGColorSpaceCreateDeviceRGB(), [98.0 / 255.0, 143.0 / 210.0, 209.0 / 255.0, 1.0, 46.0 / 255.0, 88.0 / 176.0, 208.0 / 255.0,1.0], [0,1], 2),
                                                                           [CPColor colorWithCalibratedRed:81.0 / 255.0 green:127.0 / 255.0 blue:200.0 / 255.0 alpha:1.0],
@@ -1749,17 +1749,17 @@ var themedButtonValues = nil,
         removeImage = PatternImage(@"rule-editor-remove.png", 8.0, 8.0);
 
     var ruleEditorThemedValues =
-    [
-        [@"alternating-row-colors",         backgroundColors],
-        [@"selected-color",                 selectedActiveRowColor, CPThemeStateNormal],
-        [@"selected-color",                 selectedInactiveRowColor, CPThemeStateDisabled],
-        [@"slice-top-border-color",         sliceTopBorderColor],
-        [@"slice-bottom-border-color",      sliceBottomBorderColor],
-        [@"slice-last-bottom-border-color", sliceLastBottomBorderColor],
-        [@"font",                           [CPFont systemFontOfSize:10.0]],
-        [@"add-image",                      addImage],
-        [@"remove-image",                   removeImage]
-    ];
+        [
+            [@"alternating-row-colors",         backgroundColors],
+            [@"selected-color",                 selectedActiveRowColor, CPThemeStateNormal],
+            [@"selected-color",                 selectedInactiveRowColor, CPThemeStateDisabled],
+            [@"slice-top-border-color",         sliceTopBorderColor],
+            [@"slice-bottom-border-color",      sliceBottomBorderColor],
+            [@"slice-last-bottom-border-color", sliceLastBottomBorderColor],
+            [@"font",                           [CPFont systemFontOfSize:10.0]],
+            [@"add-image",                      addImage],
+            [@"remove-image",                   removeImage]
+        ];
 
     [self registerThemeValues:ruleEditorThemedValues forView:ruleEditor];
 

--- a/Tools/nib2cib/NSColor.j
+++ b/Tools/nib2cib/NSColor.j
@@ -74,6 +74,7 @@ var NSUnknownColorSpaceModel    = -1,
 
             result = [CPColor colorWithCalibratedWhite:values[0] alpha:values[1]];
             break;
+
 /*
         case 5:
             var cmyk        = [aCoder decodeBytesForKey:@"NSCMYK"],
@@ -87,37 +88,37 @@ var NSUnknownColorSpaceModel    = -1,
             result = [CPColor colorWithDeviceCyan:values[0] magenta:values[1] yellow:values[2] black:values[3] alpha:values[4]];
             break;
 */
-        case 6:
+
+        case 6: // named color
             var catalogName = [aCoder decodeObjectForKey:@"NSCatalogName"],
                 colorName   = [aCoder decodeObjectForKey:@"NSColorName"],
-                color       = [aCoder decodeObjectForKey:@"NSColor"];
-
-            // We don't having color mappings implemented, so just use the cached NSColor
+                color       = [aCoder decodeObjectForKey:@"NSColor"],
+                result      = nil;
 
             if (catalogName === @"System")
             {
-                var //display = [NSDisplay currentDisplay],
-                    result = null;//[display colorWithName: colorName];
-
-                if (colorName === @"controlColor")
-                    result = nil;
-
-                else if (colorName === @"controlBackgroundColor")
-                    result = [CPColor whiteColor];
-
-                else if (!result)
+                switch (colorName)
                 {
-                    result = color;
-                    //[display _addSystemColor: result forName: colorName];
+                    case "controlColor":
+                        result = [CPColor colorWithCalibratedWhite:175.0 / 255.0 alpha:1.0];
+                        break;
+
+                    case "controlBackgroundColor":
+                        result = [CPColor whiteColor];
+                        break;
+
+                    case "gridColor":
+                        result = [CPColor colorWithCalibratedWhite:204.0 / 255.0 alpha:1.0];
+                        break;
+
+                    default:
+                        result = color;
                 }
             }
             else
-            {
-                result = null;//[CPColor colorWithCatalogName: catalogName colorName: colorName];
-                if (!result)
-                    result = color;
-            }
+                result = color;
             break;
+
         default:
             CPLog.warn(@"-[%@ %s] unknown color space %d", isa, _cmd, colorSpace);
             result  = [CPColor blackColor];

--- a/Tools/nib2cib/NSTableView.j
+++ b/Tools/nib2cib/NSTableView.j
@@ -59,11 +59,7 @@
         _intercellSpacing = CGSizeMake([aCoder decodeFloatForKey:@"NSIntercellSpacingWidth"],
                                        [aCoder decodeFloatForKey:@"NSIntercellSpacingHeight"]);
 
-        var gridColor = [aCoder decodeObjectForKey:@"NSGridColor"];
-
-        if (![gridColor isEqual:[CPColor colorWithRed:127.0 / 255.0 green:127.0 / 255.0 blue:127.0 / 255.0 alpha:1.0]])
-            [self setValue:gridColor forThemeAttribute:@"grid-color"];
-
+        [self setValue:[aCoder decodeObjectForKey:@"NSGridColor"] forThemeAttribute:@"grid-color"];
         _gridStyleMask = [aCoder decodeIntForKey:@"NSGridStyleMask"];
 
         _usesAlternatingRowBackgroundColors = (flags & 0x00800000) ? YES : NO;


### PR DESCRIPTION
Currently #888888 is being used as the default, mainly because NSColor.j doesn't recognize the "gridColor" named color, and the cached color in the .xib is #888888 for some reason. Actually the default grid color is #CCCCCC.
