### PR TITLE
Text clip fix

### DIFF
--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -1042,7 +1042,15 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
         textSize = [text sizeWithFont:font inWidth:textSize.width];
     }
     else
+    {
         textSize = [text sizeWithFont:font];
+
+        // Account for possible fractional pixels at right edge
+        textSize.width += 1;
+    }
+
+    // Account for possible fractional pixels at bottom edge
+    textSize.height += 1;
 
     frameSize.height = textSize.height + contentInset.top + contentInset.bottom;
 

--- a/AppKit/_CPImageAndTextView.j
+++ b/AppKit/_CPImageAndTextView.j
@@ -680,9 +680,19 @@ var _CPimageAndTextViewFrameSizeChangedFlag         = 1 << 0,
             {
                 if (_lineBreakMode === CPLineBreakByCharWrapping ||
                     _lineBreakMode === CPLineBreakByWordWrapping)
+                {
                     _textSize = [_text sizeWithFont:_font inWidth:textRectWidth];
+                }
                 else
+                {
                     _textSize = [_text sizeWithFont:_font];
+
+                    // Account for possible fractional pixels at right edge
+                    _textSize.width += 1;
+                }
+
+                // Account for possible fractional pixels at bottom edge
+                _textSize.height += 1;
             }
 
             if (_verticalAlignment === CPCenterVerticalTextAlignment)


### PR DESCRIPTION
Currently when controls and text fields size to fit text, they use a <span> to determine the correct height/width. Some browsers do not account for fractional pixels that arise from antialiasing. Cappuccino views must clip their contents, so the fractional pixels get clipped, and depending on the font this can be quite noticeable.

This patch adds 1 pixel when necessary to ensure no clipping occurs.
