### PR TITLE
CPDictionary -initWithObjectsAndKeys: do not treat a nil value as a final value

### DIFF
--- a/Foundation/CPDictionary.j
+++ b/Foundation/CPDictionary.j
@@ -299,7 +299,7 @@
             var value = arguments[index];
 
             if (value === nil)
-                break;
+                continue;
 
             [self setObject:value forKey:arguments[index + 1]];
         }

--- a/Tests/Foundation/CPDictionaryTest.j
+++ b/Tests/Foundation/CPDictionaryTest.j
@@ -250,4 +250,13 @@
     [self assertTrue:d.indexOf("y: 6") !== -1 message:"Can't find 'y: 6' in description of dictionary " + d];
 }
 
+- (void)testInitWithObjectsAndKeys
+{
+    var dict = [[CPDictionary alloc] initWithObjectsAndKeys:@"Value1", @"Key1", nil, @"Key2", @"Value3", @"Key3"];
+
+    [self assert:2 equals:[dict count]];    
+    [self assert:@"Value1" equals:[dict objectForKey:@"Key1"]];
+    [self assert:nil equals:[dict objectForKey:@"Key2"]]; // No key/value pair
+    [self assert:@"Value3" equals:[dict objectForKey:@"Key3"]];
+}
 @end


### PR DESCRIPTION
**Current implementation:**

``` objective-j
- (id)initWithObjectsAndKeys:(id)firstObject, ...
{
    var argCount = arguments.length;

    if (argCount % 2 !== 0)
        [CPException raise:CPInvalidArgumentException reason:"Key-value count is mismatched. (" + argCount + " arguments passed)"];

    self = [super init];

    if (self)
    {
        // The arguments array contains self and _cmd, so the first object is at position 2.
        var index = 2;

        for (; index < argCount; index += 2)
        {
            var value = arguments[index];

            if (value === nil)
                break;

            [self setObject:value forKey:arguments[index + 1]];
        }
    }

    return self;
}
```

The documentation states that _there's no final nil like in Objective-C/Cocoa._
So why do we break the loop on a nil value ?

Setting a nil value in a dictionary will remove the key/value pair, so i think we should do the same for the initializer and just skip the key/value pair if a value is nil.

... or is it because we unofficially support the old behavior ?
