### PR TITLE
Removed tailing comma from CPColorWithImages call.

### DIFF
--- a/AppKit/CPWindow/_CPBorderlessBridgeWindowView.j
+++ b/AppKit/CPWindow/_CPBorderlessBridgeWindowView.j
@@ -38,7 +38,7 @@ var _CPToolbarViewBackgroundColor = nil;
         _CPToolbarViewBackgroundColor = CPColorWithImages([
                 ["_CPToolbarView/toolbar-background-top.png", 1, 1, bundle],
                 ["_CPToolbarView/toolbar-background-center.png", 1, 57.0, bundle],
-                ["_CPToolbarView/toolbar-background-bottom.png", 1, 1, bundle],
+                ["_CPToolbarView/toolbar-background-bottom.png", 1, 1, bundle]
             ], CPColorPatternIsVertical);
     }
 


### PR DESCRIPTION
The extra comma causes IE to think it was passed an array with 4
values and causes CPColorWithImages to return a NinePartImage even
though it only has three parts.
