### PR TITLE
CPCib -initWithContentsOfURL: return nil if the requested data is nil.

### DIFF
--- a/AppKit/Cib/CPCib.j
+++ b/AppKit/Cib/CPCib.j
@@ -61,6 +61,10 @@ var CPCibObjectDataKey  = @"CPCibObjectDataKey";
     if (self)
     {
         _data = [CPURLConnection sendSynchronousRequest:[CPURLRequest requestWithURL:aURL] returningResponse:nil];
+
+        if (!_data)
+            return nil;
+
         _awakenCustomResources = YES;
     }
 


### PR DESCRIPTION
CPCib -initWithNibNamed:@"NotFound" will also return nil.

Depends on #1636
