### PR TITLE
Added CPViewController -isViewLoaded, fixed CPWindowController -setViewController to use that

### DIFF
--- a/AppKit/CPViewController.j
+++ b/AppKit/CPViewController.j
@@ -67,6 +67,7 @@ var CPViewControllerCachedCibs;
     CPView          _view @accessors(property=view);
     BOOL            _isLoading;
     BOOL            _isLazy;
+    BOOL            _isViewLoaded @accessors(getter=isViewLoaded);
 
     id              _representedObject @accessors(property=representedObject);
     CPString        _title @accessors(property=title);
@@ -206,17 +207,24 @@ var CPViewControllerCachedCibs;
             [cibOwner viewControllerDidLoadCib:self];
 
         _isLoading = NO;
-        [self viewDidLoad];
+        [self _viewDidLoad];
     }
     else if (_isLazy)
     {
         _isLazy = NO;
-        [self viewDidLoad];
+        [self _viewDidLoad];
     }
 
     return _view;
 }
 
+- (void)_viewDidLoad
+{
+    [self willChangeValueForKey:"isViewLoaded"];
+    [self viewDidLoad];
+    isViewLoaded = YES;
+    [self didChangeValueForKey:"isViewLoaded"];
+}
 
 /*!
     This method is called after the view controller has loaded its associated views into memory.
@@ -242,7 +250,21 @@ var CPViewControllerCachedCibs;
 */
 - (void)setView:(CPView)aView
 {
+    var willChangeIsViewLoaded = (_isViewLoaded == NO && aView != nil) || (_isViewLoaded == YES && aView == nil);
+
+    if (willChangeIsViewLoaded)
+        [self willChangeValueForKey:"isViewLoaded"];
+
     _view = aView;
+    _isViewLoaded = aView !== nil;
+
+    if (willChangeIsViewLoaded)
+        [self didChangeValueForKey:"isViewLoaded"];
+}
+
+- (BOOL)automaticallyNotifiesObserversOfIsViewLoaded
+{
+    return NO;
 }
 
 @end

--- a/AppKit/CPWindowController.j
+++ b/AppKit/CPWindowController.j
@@ -181,8 +181,7 @@
 
         if (!_window)
         {
-            var reason = [CPString stringWithFormat:@"Window for %@ could not be loaded from Cib or no window specified. \
-                                                        Override loadWindow to load the window manually.", self];
+            var reason = [CPString stringWithFormat:@"Window for %@ could not be loaded from Cib or no window specified. Override loadWindow to load the window manually.", self];
 
             [CPException raise:CPInternalInconsistencyException reason:reason];
         }
@@ -336,18 +335,21 @@
     if (!_viewControllerContainerView && !aView)
         return;
 
-    var viewControllerView = [[self viewController] view],
+    var viewController = [self viewController],
+        viewControllerView = [viewController isViewLoaded] ? [viewController view] : nil,
         contentView = [[self window] contentView];
 
     if (aView)
     {
         [aView setFrame:[contentView frame]];
         [aView setAutoresizingMask:[contentView autoresizingMask]];
+
         if (viewControllerView)
         {
             [viewControllerView removeFromSuperview];
             [aView addSubview:viewControllerView];
         }
+
         [[self window] setContentView:aView];
     }
     else if (viewControllerView)
@@ -379,11 +381,12 @@
         return;
 
     var containerView = [self viewControllerContainerView],
-        newView = [aViewController view];
+        newView = [aViewController isViewLoaded] ? [aViewController view] : nil;
 
     if (containerView)
     {
-        var oldView = [_viewController view];
+        var oldView = [_viewController isViewLoaded] ? [_viewController view] : nil;
+
         if (oldView)
         {
             [newView setFrame:[oldView frame]];
@@ -408,6 +411,7 @@
     {
         var view = [[CPView alloc] init],
             contentView = [[self window] contentView];
+
         [view setFrame:[contentView frame]];
         [view setAutoresizingMask:[contentView autoresizingMask]];
         [[self window] setContentView:view]


### PR DESCRIPTION
Before this fix, CPWindowController -setViewController was unconditionally loading the view, which should not happen.
