### PR TITLE
Fix for CPButton not hightlighting with AlternateImage

### DIFF
--- a/AppKit/CPButton.j
+++ b/AppKit/CPButton.j
@@ -697,8 +697,8 @@ CPButtonImageOffset   = 3.0;
             }
             else
             {
-                title = _title;
-                image = [self image];
+                title = ([self hasThemeState:CPThemeStateHighlighted] && _alternateTitle) ? _alternateTitle : _title;
+                image = [self currentValueForThemeAttribute:@"image"];
             }
         }
         else
@@ -711,7 +711,7 @@ CPButtonImageOffset   = 3.0;
             else
             {
                 title = _title;
-                image = [self image];
+                image = [self currentValueForThemeAttribute:@"image"];
             }
         }
 


### PR DESCRIPTION
CPButton with an alternate image, the alternate image is no longer used for highlighting when clicked.

This commit that broke it.
https://github.com/cappuccino/cappuccino/commit/7cf3ac3b40114a826e993278575ab76ce8677a86

To test:

```

@import <Foundation/CPObject.j>
@implementation AppController : CPObject
{

}

- (void)applicationDidFinishLaunching:(CPNotification)aNotification
{
    var window = [[CPWindow alloc] initWithContentRect:CPRectMake(30, 30, 200, 200) styleMask:CPTitledWindowMask | CPClosableWindowMask];

    var button = [[CPButton alloc] initWithFrame:CGRectMake(30,50, 120, 32)],
        bundle = [CPBundle bundleForClass:[CPApplication class]],
        image = [[CPImage alloc] initWithContentsOfFile:[bundle pathForResource:@"CPApplication/Open.png"] size:CGSizeMake(16.0, 16.0)],
            alternateImage = [[CPImage alloc] initWithContentsOfFile:[bundle pathForResource:@"CPApplication/OpenHighlighted.png"] size:CGSizeMake(16.0, 16.0)];
        [button setBordered:NO];
        [button setImagePosition:CPImageAbove];
        [button setImage:image];
        [button setAlternateImage:alternateImage];
        [button setTitle:@"Title"];
        [button setAlternateTitle:@"Alternate Title"];
        [[window contentView] addSubview:button];
    [window makeKeyAndOrderFront:self];
}    


@end
```
