### PR TITLE
Fixed error in CPDescriptionOfObject when JSON property has null value

### DIFF
--- a/Foundation/CPObject.j
+++ b/Foundation/CPObject.j
@@ -532,6 +532,9 @@ CPLog(@"Got some class: %@", inst);
 
 function CPDescriptionOfObject(anObject)
 {
+    if (!anObject)
+        return String(anObject);
+
     if (anObject.isa)
     {
         if ([anObject isKindOfClass:CPString])

--- a/Tests/Foundation/CPObjectTest.j
+++ b/Tests/Foundation/CPObjectTest.j
@@ -50,6 +50,15 @@
     [self assertTrue:expectedReturnValue === returnValue];
 }
 
+- (void)testCPDescriptionOfObject
+{
+    var jSON = {"name": "Martin", "access":null},
+        d = CPDescriptionOfObject(jSON);
+
+    [self assertTrue:d.indexOf("name:") !== -1 message:"Can't find 'name:' in description of json " + d];
+    [self assertTrue:d.indexOf("access:") !== -1 message:"Can't find 'access:' in description of json " + d];
+}
+
 @end
 
 @implementation SuperReceiver : CPObject


### PR DESCRIPTION
The function can't handle the following JSON object: {name: null}.
Also added a test case for this.
