### PR TITLE
Fixed: incorrect `- CPWindow contentRectForFrameRect:` and  `frameRectForContentRect:` for borderless windows with toolbars.

### DIFF
--- a/AppKit/CPWindow/_CPStandardWindowView.j
+++ b/AppKit/CPWindow/_CPStandardWindowView.j
@@ -152,38 +152,6 @@ var STANDARD_GRADIENT_HEIGHT                    = 41.0;
     return _CPStandardWindowViewDividerBackgroundColor;
 }
 
-- (CGRect)contentRectForFrameRect:(CGRect)aFrameRect
-{
-    var contentRect = [[self class] contentRectForFrameRect:aFrameRect],
-        theToolbar = [[self window] toolbar];
-
-    if ([theToolbar isVisible])
-    {
-        var toolbarHeight = CGRectGetHeight([[theToolbar _toolbarView] frame]);
-
-        contentRect.origin.y += toolbarHeight;
-        contentRect.size.height -= toolbarHeight;
-    }
-
-    return contentRect;
-}
-
-- (CGRect)frameRectForContentRect:(CGRect)aContentRect
-{
-    var frameRect = [[self class] frameRectForContentRect:aContentRect],
-        theToolbar = [[self window] toolbar];
-
-    if ([theToolbar isVisible])
-    {
-        var toolbarHeight = CGRectGetHeight([[theToolbar _toolbarView] frame]);
-
-        frameRect.origin.y -= toolbarHeight;
-        frameRect.size.height += toolbarHeight;
-    }
-
-    return frameRect;
-}
-
 - (id)initWithFrame:(CPRect)aFrame styleMask:(unsigned)aStyleMask
 {
     self = [super initWithFrame:aFrame styleMask:aStyleMask];

--- a/AppKit/CPWindow/_CPWindowView.j
+++ b/AppKit/CPWindow/_CPWindowView.j
@@ -76,12 +76,34 @@ var _CPWindowViewResizeIndicatorImage = nil;
 
 - (CGRect)contentRectForFrameRect:(CGRect)aFrameRect
 {
-    return [[self class] contentRectForFrameRect:aFrameRect];
+    var contentRect = [[self class] contentRectForFrameRect:aFrameRect],
+        theToolbar = [[self window] toolbar];
+
+    if ([theToolbar isVisible])
+    {
+        var toolbarHeight = CGRectGetHeight([[theToolbar _toolbarView] frame]);
+
+        contentRect.origin.y += toolbarHeight;
+        contentRect.size.height -= toolbarHeight;
+    }
+
+    return contentRect;
 }
 
 - (CGRect)frameRectForContentRect:(CGRect)aContentRect
 {
-    return [[self class] frameRectForContentRect:aContentRect];
+    var frameRect = [[self class] frameRectForContentRect:aContentRect],
+        theToolbar = [[self window] toolbar];
+
+    if ([theToolbar isVisible])
+    {
+        var toolbarHeight = CGRectGetHeight([[theToolbar _toolbarView] frame]);
+
+        frameRect.origin.y -= toolbarHeight;
+        frameRect.size.height += toolbarHeight;
+    }
+
+    return frameRect;
 }
 
 - (id)initWithFrame:(CPRect)aFrame styleMask:(unsigned)aStyleMask


### PR DESCRIPTION
The window views driving non standard windows (such as borderless or bridge
windows) did not take the toolbar into account when calculating the content
rect.

Apart from being wrong, this could lead to the content view overlapping the
toolbar if the content view was set after the toolbar was prepared.

Perhaps the thought was that the base _CPWindowView shouldn't make
assumptions about the placement and sizing of a toolbar and leave that up to
subclasses, but the _CPWindowView tile method already did.
