### PR TITLE
CPBinder -_updatePlaceholdersWithOptions:  add a reference to the binding.

### DIFF
--- a/AppKit/CPKeyValueBinding.j
+++ b/AppKit/CPKeyValueBinding.j
@@ -307,7 +307,7 @@ var CPBindingOperationAnd = 0,
     delete objectSuppressions[aKeyPath];
 }
 
-- (void)_updatePlaceholdersWithOptions:(CPDictionary)options forBinding:(CPString)aBinding
+- (void)_updatePlaceholdersWithOptions:(CPDictionary)options
 {
     var count = [CPBinderPlaceholderMarkers count];
 
@@ -321,9 +321,9 @@ var CPBindingOperationAnd = 0,
     }
 }
 
-- (void)_updatePlaceholdersWithOptions:(CPDictionary)options
+- (void)_updatePlaceholdersWithOptions:(CPDictionary)options forBinding:(CPString)aBinding
 {
-    [self _updatePlaceholdersWithOptions:options forBinding:nil];
+    [self _updatePlaceholdersWithOptions:options];
 }
 
 - (void)_placeholderForMarker:aMarker


### PR DESCRIPTION
If a binder instance can manage several bindings, you may want to set placeholders depending on the binding name.

Currently you need to create a different binder subclass for each binding if their placeholders are different.

Example here: 78791dd
