### PR TITLE
nib2cib will now adjust to the correct themed height for subclasses of CPButton

### DIFF
--- a/Tools/nib2cib/NSButton.j
+++ b/Tools/nib2cib/NSButton.j
@@ -220,8 +220,8 @@ var NSButtonIsBorderedMask = 0x00800000,
             - If there is no max height either, don't do any height adjustments.
         */
         var theme = [[Converter sharedConverter] themes][0],
-            minSize = [theme valueForAttributeWithName:@"min-size" forClass:[CPButton class]],
-            maxSize = [theme valueForAttributeWithName:@"max-size" forClass:[CPButton class]],
+            minSize = [theme valueForAttributeWithName:@"min-size" forClass:[self class]],
+            maxSize = [theme valueForAttributeWithName:@"max-size" forClass:[self class]],
             adjustHeight = NO;
 
         if (minSize.height > 0 && maxSize.height > 0 && minSize.height === maxSize.height)


### PR DESCRIPTION
For examples CPPopUpButton can get another height then CPButton.
