### PR TITLE
Travis CI Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ before_install:
     - jdk_switcher use openjdk6
 install: ./bootstrap.sh --noprompt --directory ./narwhal
 script: jake test
-env: PATH=/home/travis/builds/ahankinson/cappuccino/narwhal/bin:$PATH CAPP_BUILD=/home/travis/builds/ahankinson/cappuccino/Build NARWHAL_ENGINE=rhino
+env: PATH=/home/travis/builds/cappuccino/cappuccino/narwhal/bin:$PATH CAPP_BUILD=/home/travis/builds/cappuccino/cappuccino/Build NARWHAL_ENGINE=rhino


### PR DESCRIPTION
To deploy:
- Go to http://travis-ci.org and sign in with an account that has access to Github.com/cappuccino
- Go to "Accounts" and enable building for the cappuccino repository
- Merge .travis.yml into the root of the Cappuccino repository
- This should kick off a build. If it does not, edit, commit, and push any file. It should then start a build automatically.
