### PR TITLE
Allow setTimeout(f) to support some JS libraries such as PDF.js.

### DIFF
--- a/Foundation/CPTimer.j
+++ b/Foundation/CPTimer.j
@@ -254,6 +254,9 @@ var _CPTimerBridgeTimer = function(codeOrFunction, aDelay, shouldRepeat, functio
         theFunction = function() { codeOrFunction.apply(window, functionArgs); if (!shouldRepeat) CPTimersForTimeoutIDs[timeoutID] = nil; }
     }
 
+    // A call such as setTimeout(f) is technically invalid but browsers seem to treat it as setTimeout(f, 0), so so will we.
+    aDelay = aDelay | 0.0;
+
     CPTimersForTimeoutIDs[timeoutID] = [CPTimer scheduledTimerWithTimeInterval:aDelay / 1000 callback:theFunction repeats:shouldRepeat];
 
     return timeoutID;


### PR DESCRIPTION
Without this change some 3rd party JS libraries such as PDF.js, which rely on
the nonstandard setTimeout(f), will not operate correctly.

According to MDN the delay argument is required. However browsers seem to
treat setTimeout without delay argument the same as a delay of 0. This fix
makes it so that Cappuccino apps do the same.
