### PR TITLE
Fixed: CPPopovers could not become key windows in recent versions.

### DIFF
--- a/AppKit/_CPAttachedWindow.j
+++ b/AppKit/_CPAttachedWindow.j
@@ -389,6 +389,14 @@ var _CPAttachedWindow_attachedWindowShouldClose_    = 1 << 0,
 #pragma mark Overrides
 
 /*!
+    Attached windows, such as pop overs, can usually become the key window.
+*/
+- (BOOL)canBecomeKeyWindow
+{
+    return YES;
+}
+
+/*!
     Called when the window is losing focus.
 */
 - (void)resignMainWindow


### PR DESCRIPTION
This prevented text fields and token fields from accepting input when placed
in a pop over.

This fix allows the underlying popover window to become the key window.
