### PR TITLE
Fixed: popoverDidShow in Firefox. New: popover animation support in Firefox, Opera and IE10.

### DIFF
--- a/AppKit/_CPAttachedWindow.j
+++ b/AppKit/_CPAttachedWindow.j
@@ -134,7 +134,7 @@ var _CPAttachedWindow_attachedWindowShouldClose_    = 1 << 0,
         [self setMovableByWindowBackground:YES];
         [self setHasShadow:NO];
 
-        [self setCSS3Property:@"TransitionProperty" value:@"-webkit-transform, opacity"];
+        [self setCSS3Property:@"TransitionProperty" value:CPBrowserCSSProperty('transform') + @", opacity"];
 
         [_windowView setNeedsDisplay:YES];
     }
@@ -350,25 +350,18 @@ var _CPAttachedWindow_attachedWindowShouldClose_    = 1 << 0,
 }
 
 /*! @ignore */
-- (void)setCSS3Property:(CPString)property value:(CPString)value
+- (void)setCSS3Property:(CPString)aProperty value:(CPString)value
 {
-    _DOMElement.style['webkit' + property] = value;
+    var browserProperty = CPBrowserStyleProperty(aProperty);
 
-    // Support other browsers here eventually
+    if (browserProperty)
+        _DOMElement.style[browserProperty] = value;
 }
 
 /*! @ignore */
 - (BOOL)browserSupportsAnimation
 {
-    return typeof(_DOMElement.style.webkitTransition) !== "undefined";
-
-    /*
-        No others browsers supported yet.
-
-           typeof(_DOMElement.style.MozTransition) !== "undefined" ||
-           typeof(_DOMElement.style.MsTransition) !== "undefined" ||
-           typeof(_DOMElement.style.OTransition) !== "undefined";
-    */
+    return CPBrowserStyleProperty('transition') && CPBrowserStyleProperty('transitionend');
 }
 
 #pragma mark -
@@ -452,28 +445,28 @@ var _CPAttachedWindow_attachedWindowShouldClose_    = 1 << 0,
 
                 // Set up the pop-out transition
                 [self setCSS3Property:@"Transform" value:@"scale(1.1)"];
-                [self setCSS3Property:@"Transition" value:@"-webkit-transform 200ms ease-in"];
+                [self setCSS3Property:@"Transition" value:CPBrowserCSSProperty('transform') + @" 200ms ease-in"];
 
                 var transitionEndFunction = function()
                 {
-                    _DOMElement.removeEventListener("webkitTransitionEnd", transitionEndFunction, YES);
+                    _DOMElement.removeEventListener(CPBrowserStyleProperty('transitionend'), transitionEndFunction, YES);
 
                     // Now set up the pop-in to normal size transition.
                     // Because we are watching the -webkit-transform, it will occur now.
                     [self setCSS3Property:@"Transform" value:@"scale(1)"];
-                    [self setCSS3Property:@"Transition" value:@"-webkit-transform 50ms linear"];
+                    [self setCSS3Property:@"Transition" value:CPBrowserCSSProperty('transform') + @" 50ms linear"];
 
                     var transitionCompleteFunction = function()
                     {
-                        _DOMElement.removeEventListener("webkitTransitionEnd", transitionCompleteFunction, YES);
+                        _DOMElement.removeEventListener(CPBrowserStyleProperty('transitionend'), transitionCompleteFunction, YES);
                         if (_implementedDelegateMethods & _CPAttachedWindow_attachedWindowDidShow_)
                              [_delegate attachedWindowDidShow:self];
                     }
 
-                    _DOMElement.addEventListener("webkitTransitionEnd", transitionCompleteFunction, YES);
+                    _DOMElement.addEventListener(CPBrowserStyleProperty('transitionend'), transitionCompleteFunction, YES);
                 };
 
-                _DOMElement.addEventListener("webkitTransitionEnd", transitionEndFunction, YES);
+                _DOMElement.addEventListener(CPBrowserStyleProperty('transitionend'), transitionEndFunction, YES);
             }, 0);
         }
         else
@@ -506,11 +499,11 @@ var _CPAttachedWindow_attachedWindowShouldClose_    = 1 << 0,
 
         var transitionEndFunction = function()
         {
-            _DOMElement.removeEventListener("webkitTransitionEnd", transitionEndFunction, YES);
+            _DOMElement.removeEventListener(CPBrowserStyleProperty("transitionend"), transitionEndFunction, YES);
             [self _close];
         };
 
-        _DOMElement.addEventListener("webkitTransitionEnd", transitionEndFunction, YES);
+        _DOMElement.addEventListener(CPBrowserStyleProperty("transitionend"), transitionEndFunction, YES);
     }
     else
     {


### PR DESCRIPTION
Before this fix, popoverDidShow: would not be sent to popover delegates when
the app ran in Firefox due to Firefox now recognising the -webkit-transition
property, but not the webkitTransitionEnd event.

Also, before this fix popover animation was only implemented for Webkit based
browsers.

This fix resolves that issue and in addition adds full support for animated
popovers in all browsers that support CSS transitions. The fix also improves
Cappuccino's general support for CSS3 animations.
