### PR TITLE
Improved support for converting CSS properties to their JS equivalent in CPBrowserStyleProperty

### DIFF
--- a/AppKit/CPCompatibility.j
+++ b/AppKit/CPCompatibility.j
@@ -348,26 +348,32 @@ function CPBrowserCSSProperty(aProperty)
     if (!browserProperty)
         return nil;
 
-    var parts = browserProperty.match(/[A-Z][a-z]+/g),
-        formattedBrowserProperty = browserProperty,
-        prefixes = {
-            'Webkit': '-webkit',
-            'Moz': '-moz',
-            'O': '-o',
-            'ms': '-ms'
+    var prefixes = {
+            'Webkit': '-webkit-',
+            'Moz': '-moz-',
+            'O': '-o-',
+            'ms': '-ms-'
         };
-
-    // If there were any capitalized words in the browserProperty, insert a "-" between each one
-    if (parts && parts.length > 0)
-        formattedBrowserProperty = parts.join("-");
 
     for (var prefix in prefixes)
     {
-        if (formattedBrowserProperty.substring(0, prefix.length) == prefix)
+        if (browserProperty.substring(0, prefix.length) == prefix)
         {
-            return prefixes[prefix] + formattedBrowserProperty.substring(prefix.length).toLowerCase();
+            var browserPropertyWithoutPrefix = browserProperty.substring(prefix.length),
+                parts = browserPropertyWithoutPrefix.match(/[A-Z][a-z]+/g);
+
+            // If there were any capitalized words in the browserProperty, insert a "-" between each one
+            if (parts && parts.length > 0)
+                browserPropertyWithoutPrefix = parts.join("-");
+
+            return prefixes[prefix] + browserPropertyWithoutPrefix.toLowerCase();
         }
     }
 
-    return formattedBrowserProperty.toLowerCase();
+    var parts = browserProperty.match(/[A-Z][a-z]+/g);
+
+    if (parts && parts.length > 0)
+        browserProperty = parts.join("-");
+
+    return browserProperty.toLowerCase();
 }


### PR DESCRIPTION
Currently **CPBrowserStyleProperty** does not support hyphenated or camel cased property names. For example:
- CPBrowserStyleProperty('TransformOrigin') -> 'WebkitTransformorigin' // Incorrect
- CPBrowserStyleProperty('transform-origin') -> 'WebkitTransform-origin' // Incorrect

Both of these are invalid CSS properties.

Therefore, I've fixed this by:
- Firstly, checking if the unformatted property name is in fact already valid. E.g. 'WebKit' + 'TransformOrigin' is valid with no further formatting.
- Secondly, checking if the formatted property name is valid by first stripping any "-" and ensuring the string is properly camel cased. E.g 'transform-origin' -> 'TransformOrigin'.

With this fix the following examples now work correctly:
- CPBrowserStyleProperty('TransformOrigin') -> 'WebkitTransformOrigin' // Correct
- CPBrowserStyleProperty('transform-origin') -> 'WebkitTransformOrigin' // Correct

**Note:**
I first noticed this bug in **_CPAttachedWindow** in which line 444 is:

`[self setCSS3Property:@"TransformOrigin" value:transformOrigin];`

As per the example above this would result in a CSS property of 'WebkitTransformorigin' being used, which is invalid.

This would ultimately result in the attached window (in this case a popover) scaling from the center, rather than an offset origin as expected if `setAnimates:YES`. With this fix, the popover scales from the transform origin correctly and I've tested this in all the main browsers.
