### PR TITLE
Fixed: 2 integration problems with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ before_install:
     - jdk_switcher use openjdk6
 install: ./bootstrap.sh --quiet --noprompt --directory ./narwhal
 script: jake test
-env: PATH=/home/travis/builds/cappuccino/cappuccino/narwhal/bin:$PATH CAPP_BUILD=/home/travis/builds/cappuccino/cappuccino/Build NARWHAL_ENGINE=rhino
+env: PATH=$HOME/build/$TRAVIS_REPO_SLUG/narwhal/bin:$PATH CAPP_BUILD=$HOME/build/$TRAVIS_REPO_SLUG/Build NARWHAL_ENGINE=rhino


### PR DESCRIPTION
Before this fix:
- Build PATH has recently changed on Travis CI and hard-coded values in `.travis.yml` were no more valid (the `builds` folder has been renamed as `build`, e.g. `/home/travis/build/cappuccino/cappuccino`). See latest build marked as "Errored", https://travis-ci.org/cappuccino/cappuccino/builds/4467958
- Any contributor that forked the main project repository had to modify the definition of environment variables in order to integrate with http://travis-ci.org

With this fix cappuccino is correctly configured to be built on Travis CI and makes `.travis.yml` more generic (forkable).

**Notes:**
- I hope my commit message wording complies with contributing guidelines. Don't hesitate to ask me for any rewording.
- I'll ask Travis team about this renaming from 'builds' to 'build', because I'm not sure that it was expected or not. This is supposed to be internal stuff, but with custom build as here, this could break things. I'll also plan to open soon a pull request to provide a TRAVIS_BUILD_WD variable in the build environment, and thus make `.travis.yml` definition even safer than with `$HOME/build/$TRAVIS_REPO_SLUG`.
- Good news BTW: There is no more out of memory error (https://github.com/travis-ci/travis-ci/issues/848). This is certainly due to a change on the bluebox worker server. I'll update this issue asap too...
