### PR TITLE
Add basic compatibility for CPBrowser

### DIFF
--- a/Tools/nib2cib/NSBrowser.j
+++ b/Tools/nib2cib/NSBrowser.j
@@ -1,0 +1,56 @@
+/*
+ * NSBrowser.j
+ * nib2cib
+ *
+ * Created by Andrew Hankinson.
+ * Copyright 2013.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+@import <AppKit/CPBrowser.j>
+
+@implementation CPBrowser (NSCoding)
+
+- (id)NS_initWithCoder:(CPCoder)aCoder
+{
+    _allowsEmptySelection = YES;
+
+    if (self = [super NS_initWithCoder:aCoder])
+    {
+        _isSelectable             = [aCoder decodeBoolForKey:@"NSSelectable"];
+        _allowsMultipleSelection  = [aCoder decodeBoolForKey:@"NSAllowsMultipleSelection"];
+    }
+
+    return self;
+}
+
+@end
+
+@implementation NSBrowser : CPBrowser
+{
+}
+
+- (id)initWithCoder:(CPCoder)aCoder
+{
+    return [self NS_initWithCoder:aCoder];
+}
+
+- (Class)classForKeyedArchiver
+{
+    return [CPBrowser class];
+}
+
+@end


### PR DESCRIPTION
Without this fix, nib2cib fails to convert CPBrowser widgets from Interface Builder. This fix adds a basic class stub to prevent it from failing.

This should probably be made more robust in the future.
