### PR TITLE
Fix for NSSlider circular widget

### DIFF
--- a/Tools/nib2cib/NSSlider.j
+++ b/Tools/nib2cib/NSSlider.j
@@ -47,7 +47,7 @@
         {
             var frame = [self frame];
 
-            [self setFrameSize:CGSizeMake(frame.size.width + 4.0, frame.size.height + 2.0)];
+            [self setFrameSize:CGSizeMake(frame.size.width + 2.0, frame.size.height + 2.0)];
         }
     }
 


### PR DESCRIPTION
Without this fix the frame size of the circular slider is off by 2px. This fix corrects this and makes the circular slider display correctly.
