### PR TITLE
Fix for #1633: setRepresentedFilename

### DIFF
--- a/AppKit/CPWindow/CPWindow.j
+++ b/AppKit/CPWindow/CPWindow.j
@@ -1467,7 +1467,7 @@ CPTexturedBackgroundWindowMask
 - (void)setRepresentedFilename:(CPString)aFilePath
 {
     // FIXME: urls vs filepaths and all.
-    [self setRepresentedURL:aFilePath];
+    [self setRepresentedURL:[CPURL URLWithString:aFilePath]];
 }
 
 /*!
@@ -1475,7 +1475,7 @@ CPTexturedBackgroundWindowMask
 */
 - (CPString)representedFilename
 {
-    return _representedURL;
+    return [_representedURL absoluteString];
 }
 
 /*!

--- a/Tests/AppKit/CPWindowTest.j
+++ b/Tests/AppKit/CPWindowTest.j
@@ -1,6 +1,7 @@
 
 @import <AppKit/CPWindow.j>
 @import <AppKit/_CPBorderlessWindowView.j>
+@import <Foundation/CPURL.j>
 
 [CPApplication sharedApplication];
 
@@ -107,6 +108,24 @@
     [self assert:nextTextField
           equals:[contentView previousValidKeyView]
          message:@"nextTextField should be the previous valid key view of contentView"];
+}
+
+- (void)testRepresentedFilename
+{
+    /*
+        representedURL and representedFilename
+        are drawn from the _representedURL variable.
+    */
+    var aURL = @"http://www.cappuccino-project.org";
+
+    [[self window] setRepresentedURL:[CPURL URLWithString:aURL]];
+    [self assertTrue:[[[self window] representedURL] class] === [CPURL class]];
+    /*
+        Test for Issue 1633
+        Make sure that changing it via setRepresentedFilename doesn't change the type
+    */
+    [[self window] setRepresentedFilename:aURL];
+    [self assertTrue:[[[self window] representedURL] class] === [CPURL class]];
 }
 
 @end


### PR DESCRIPTION
Without this fix, CPWindow setRepresentedFilename is set as a string, not a CPURL (as specified by the variable type). (With tests)
