### PR TITLE
Fix for #1723: CPArrayController insert

### DIFF
--- a/AppKit/CPArrayController.j
+++ b/AppKit/CPArrayController.j
@@ -915,7 +915,7 @@
         lastSelectedIndex = [_selectionIndexes lastIndex];
 
     if (lastSelectedIndex)
-        [self insertObject:newObject atArrangedObjectIndex:lastSelectedIndex + 1];
+        [self insertObject:newObject atArrangedObjectIndex:lastSelectedIndex];
     else
         [self addObject:newObject];
 

--- a/Tests/AppKit/CPArrayControllerTest.j
+++ b/Tests/AppKit/CPArrayControllerTest.j
@@ -222,7 +222,7 @@
     [_arrayController setObjectClass:[Department class]];
     [_arrayController setSelectionIndex:1];
     [_arrayController insert:nil];
-    [self assert:[[[_arrayController arrangedObjects] objectAtIndex:2] class] equals:[Department class]];
+    [self assert:[[[_arrayController arrangedObjects] objectAtIndex:1] class] equals:[Department class]];
 }
 
 - (void)_initTestRemoveObjects_SimpleArray


### PR DESCRIPTION
This fix addresses the following problems:
- fixes a bug with `add:` where it would try to add the sender object, not the represented object
- changes `insert:` to insert a new represented object after the currently selected object. If no object is currently selected it behaves like add: and adds a new object to the end.

This patch includes tests.
