### PR TITLE
Fix for issue #1720

### DIFF
--- a/Foundation/CPDecimal.j
+++ b/Foundation/CPDecimal.j
@@ -386,16 +386,19 @@ function CPDecimalCompare(leftOperand, rightOperand)
         s1 = leftOperand._exponent + leftOperand._mantissa.length,
         s2 = rightOperand._exponent + rightOperand._mantissa.length;
 
-    if (leftIsZero || s1 < s2)
+    if (leftIsZero && rightIsZero)
+        return CPOrderedSame;
+
+    if (leftIsZero || (s1 < s2 && !rightIsZero))
     {
         if (rightOperand._isNegative)
             return CPOrderedDescending;
         else
             return CPOrderedAscending;
     }
-    if (rightIsZero || s1 > s2)
+    if (rightIsZero || (s1 > s2 && !leftIsZero))
     {
-        if (rightOperand._isNegative)
+        if (leftOperand._isNegative)
             return CPOrderedAscending;
         else
             return CPOrderedDescending;

--- a/Tests/Foundation/CPDecimalTest.j
+++ b/Tests/Foundation/CPDecimalTest.j
@@ -339,12 +339,37 @@
     dcm1 = CPDecimalMakeWithString(@"0.0");
     dcm = CPDecimalMakeWithString(@"0.5");
     c = CPDecimalCompare(dcm1,dcm);
-    [self assert:CPOrderedAscending equals:c message:"CPDecimalCompare() Tc4: should be descending"];
+    [self assert:CPOrderedAscending equals:c message:"CPDecimalCompare() (0.0, 0.5) should be ascending"];
 
     dcm1 = CPDecimalMakeWithString(@"0.0");
     dcm = CPDecimalMakeWithString(@"-0.5");
     c = CPDecimalCompare(dcm1,dcm);
-    [self assert:CPOrderedDescending equals:c message:"CPDecimalCompare() Tc4: should be descending"];
+    [self assert:CPOrderedDescending equals:c message:"CPDecimalCompare() (0, -0.5) should be descending"];
+
+    dcm1 = CPDecimalMakeZero();
+    dcm = CPDecimalMakeZero();
+    c = CPDecimalCompare(dcm1,dcm);
+    [self assert:CPOrderedSame equals:c message:"CPDecimalCompare(): zeros should be same"];
+
+    dcm1 = CPDecimalMakeWithString(@"0.0001");
+    dcm = CPDecimalMakeZero();
+    c = CPDecimalCompare(dcm1,dcm);
+    [self assert:CPOrderedDescending equals:c message:"CPDecimalCompare(): (0.0001, 0) should be descending"];
+
+    dcm1 = CPDecimalMakeZero();
+    dcm = CPDecimalMakeWithString(@"0.0001");
+    c = CPDecimalCompare(dcm1,dcm);
+    [self assert:CPOrderedAscending equals:c message:"CPDecimalCompare(): (0, 0.0001) should be ascending"];
+
+    dcm1 = CPDecimalMakeWithString(@"-0.0001");
+    dcm = CPDecimalMakeZero();
+    c = CPDecimalCompare(dcm1,dcm);
+    [self assert:CPOrderedAscending equals:c message:"CPDecimalCompare(): (-0.0001, 0) should be ascending"];
+
+    dcm1 = CPDecimalMakeZero();
+    dcm = CPDecimalMakeWithString(@"-0.0001");
+    c = CPDecimalCompare(dcm1,dcm);
+    [self assert:CPOrderedDescending equals:c message:"CPDecimalCompare(): (0, -0.0001) should be descending"];
 }
 
 - (void)testCompact


### PR DESCRIPTION
Fix for CPDecimalCompare fails when comparing positive numbers <1 to zero

See
https://github.com/cappuccino/cappuccino/issues/1720
