### PR TITLE
Fix Issue 1755: CPCollectionView drag update method

### DIFF
--- a/AppKit/CPCollectionView.j
+++ b/AppKit/CPCollectionView.j
@@ -1108,15 +1108,20 @@ Not supported. Use -collectionView:dataForItemsAtIndexes:fortype:
     _currentDropIndex = dropIndex;
     _currentDragOperation = dragOperation;
 
+    if (!_dropView)
+        _dropView = [[_CPCollectionViewDropIndicator alloc] initWithFrame:_CGRectMake(-8, -8, 0, 0)];
+
+    [_dropView setFrameSize:_CGSizeMake(10, _itemSize.height + _verticalMargin)];
+    [self addSubview:_dropView];
+
     var frameOrigin,
         dropviewFrameWidth = _CGRectGetWidth([_dropView frame]);
 
-    if (_currentDropIndex == -1 || _currentDragOperation == CPDragOperationNone)
+    if (_currentDropIndex == -1 || _currentDragOperation == CPDragOperationNone || [_items count] == 0)
         frameOrigin = _CGPointMake(-dropviewFrameWidth, 0);
     else
     {
         var offset;
-
         if ((_currentDropIndex % _numberOfColumns) !== 0 || _currentDropIndex == [_items count])
         {
             dropIndex = _currentDropIndex - 1;


### PR DESCRIPTION
Without this fix, attempting to drag and drop an item into an empty CPCollectionView will fire `[_updateDragAndDropStateWithDraggingInfo:newDragOperation:newDropIndex:newDropOperation]`, which will first complain about a nil _dropView, and then will attempt to get the size of the previous item in the collection, which will be nil.

This commit fixes both errors by initializing the _dropView if it is not already initialized, and checking to see the length of the item count before attempting to determine the size of the previous item.
