### PR TITLE
Addresses #449: Change CPControl's Defaults

### DIFF
--- a/AppKit/CPControl.j
+++ b/AppKit/CPControl.j
@@ -113,7 +113,7 @@ var CPControlBlackColor = [CPColor blackColor];
 + (CPDictionary)themeAttributes
 {
     return [CPDictionary dictionaryWithObjects:[CPLeftTextAlignment,
-                                                CPTopVerticalTextAlignment,
+                                                CPCenterVerticalTextAlignment,
                                                 CPLineBreakByClipping,
                                                 [CPColor blackColor],
                                                 [CPFont systemFontOfSize:CPFontCurrentSystemSize],


### PR DESCRIPTION
This fix changes the default vertical text alignment from CPTopVerticalTextAlignment to CPCenterVerticalTextAlignment
