### PR TITLE
main menubar looping cursor navigation

### DIFF
--- a/AppKit/CPMenu/_CPMenuManager.j
+++ b/AppKit/CPMenu/_CPMenuManager.j
@@ -701,6 +701,8 @@ var STICKY_TIME_INTERVAL            = 0.4,
         if ([item isSeparatorItem] || [item isHidden] || ![item isEnabled])
             [self moveDown:menu];
     }
+    else if (menu == [CPApp mainMenu])
+         [menu _highlightItemAtIndex:0];
 }
 
 - (void)moveUp:(CPMenu)menu
@@ -709,7 +711,7 @@ var STICKY_TIME_INTERVAL            = 0.4,
 
     if (index < 0)
     {
-        if (index != CPNotFound)
+        if (index != CPNotFound || menu == [CPApp mainMenu])
             [menu _highlightItemAtIndex:[menu numberOfItems] - 1];
         return;
     }


### PR DESCRIPTION
In cocoa, cursor movement on the main menu bar loops. Meaning if the first menu item is active and you cursor left, the last item is activated and vice-versa.

Can be tested in any app with a main menubar.
