### PR TITLE
Fixes #1685: CPToolbar calls incorrect notification method

### DIFF
--- a/AppKit/CPToolbar.j
+++ b/AppKit/CPToolbar.j
@@ -230,7 +230,7 @@ var CPToolbarsByIdentifier              = nil,
 - (void)_setWindow:(CPWindow)aWindow
 {
     if (_window)
-        [[CPNotificationCenter defaultCenter] removeObserver:self name:nil object:_window];
+        [[CPNotificationCenter defaultCenter] removeObserver:self name:_CPWindowDidChangeFirstResponderNotification object:_window];
 
     _window = aWindow;
 


### PR DESCRIPTION
This fix corrects the call in CPToolbar _setWindow to `removeObserver:name:object`. Before, this was calling the non-existent `removeObserver:object`, which would raise an exception.

This was fixed by @schipmolder.
