### PR TITLE
Fix #1539: Figure out the best shell config file

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -48,19 +48,47 @@ function ask_append_shell_config () {
     config_string="$1"
 
     shell_config_file=""
-    # use order outlined by http://hayne.net/MacDev/Notes/unixFAQ.html#shellStartup
-    if [ -f "$HOME/.bash_profile" ]; then
-        shell_config_file="$HOME/.bash_profile"
-    elif [ -f "$HOME/.bash_login" ]; then
-        shell_config_file="$HOME/.bash_login"
-    elif [ -f "$HOME/.profile" ]; then
-        shell_config_file="$HOME/.profile"
-    elif [ -f "$HOME/.bashrc" ]; then
-        shell_config_file="$HOME/.bashrc"
-    elif [ -f "$HOME/.zshrc" ]; then
-        shell_config_file="$HOME/.zshrc"
-    fi
 
+    if [[ "$SHELL" == *zsh* ]]; then
+        if [ -f "$HOME/.zshrc" ]; then
+            shell_config_file="$HOME/.zshrc"
+        elif [ -f "$HOME/.profile" ]; then
+            shell_config_file="$HOME/.profile"
+        else
+            touch "$HOME/.profile"
+            shell_config_file="$HOME/.zshrc"
+        fi
+    elif [[ "$SHELL" == *bash* ]]; then
+        if [ -f "$HOME/.bash_profile" ]; then
+            shell_config_file="$HOME/.bash_profile"
+        elif [ -f "$HOME/.bash_login" ]; then
+            shell_config_file="$HOME/.bash_login"
+        elif [ -f "$HOME/.bashrc" ]; then
+            shell_config_file="$HOME/.bashrc"
+        elif [ -f "$HOME/.profile" ]; then
+            shell_config_file="$HOME/.profile"
+        else
+            touch "$HOME/.profile"
+            shell_config_file="$HOME/.profile"
+        fi
+    else
+        echo "    Could not automatically determine your shell. Looking for other configuration possibilities."
+        # use order outlined by http://hayne.net/MacDev/Notes/unixFAQ.html#shellStartup
+        if [ -f "$HOME/.bash_profile" ]; then
+            shell_config_file="$HOME/.bash_profile"
+        elif [ -f "$HOME/.bash_login" ]; then
+            shell_config_file="$HOME/.bash_login"
+        elif [ -f "$HOME/.bashrc" ]; then
+            shell_config_file="$HOME/.bashrc"
+        elif [ -f "$HOME/.zshrc" ]; then
+            shell_config_file="$HOME/.zshrc"
+        elif [ -f "$HOME/.profile" ]; then
+            shell_config_file="$HOME/.profile"
+        else
+            touch "$HOME/.profile"
+            shell_config_file="$HOME/.profile"
+        fi
+    fi
 
     echo "    \"$config_string\" will be appended to \"$shell_config_file\"."
     if prompt "no"; then


### PR DESCRIPTION
This fix adds a little more intelligence to the bootstrap.sh script.

If a user is using ZSH or BASH it will recognize those and append to the appropriate config file, creating .profile if necessary.

If the user's shell cannot be read from the $SHELL variable, it will attempt to find the first suitable configuration file in the user's home directory. If none can be found, it will create .profile.

This was based off the Wikipedia article on Unix shells and the configuration files they will read. The only shells that are not supported by this patch should be csh and tcsh.
