### PR TITLE
Fix #1184: Add missing argument to .apply()

### DIFF
--- a/AppKit/CPWebView.j
+++ b/AppKit/CPWebView.j
@@ -962,7 +962,7 @@ CPWebViewAppKitScrollMaxPollCount                  = 3;
     {
         try
         {
-            return _window[methodName].apply(this, args);
+            return _window[methodName].apply(_window, args);
         }
         catch (e)
         {


### PR DESCRIPTION
The Javascript .apply() method takes two arguments: A context argument and an array of values. In CPWebScriptObject callWebScriptMethod:withArguments, only an array of arguments was passed to the .apply() method.

This fix inserts `this` as the first argument, and the array of arguments as the second. This has been converted to a pull request from the original issue (#1184)

The original issue also suggested a fix for handling namespaces, which are not incorporated in this patch.
