### PR TITLE
Fixed: mouseEntered and mouseExited mixed up for custom views in menu

### DIFF
--- a/AppKit/CPMenu/_CPMenuManager.j
+++ b/AppKit/CPMenu/_CPMenuManager.j
@@ -221,9 +221,9 @@ var STICKY_TIME_INTERVAL            = 0.4,
 
         if (_lastMouseOverMenuView != mouseOverMenuView)
         {
-            [mouseOverMenuView mouseExited:anEvent];
+            [_lastMouseOverMenuView mouseExited:anEvent];
             // FIXME: Possibly multiple of these?
-            [_lastMouseOverMenuView mouseEntered:anEvent];
+            [mouseOverMenuView mouseEntered:anEvent];
 
             _lastMouseOverMenuView = mouseOverMenuView;
         }


### PR DESCRIPTION
Fixed: when clicking and dragging inside a menu, mouseEntered and mouseExited was mixed up for custom views.

Test case in https://groups.google.com/forum/?fromgroups=#!topic/objectivej/VFo8rw75Zec
