### PR TITLE
Travis CI: Use new $TRAVIS_BUILD_DIR environment variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ node_js:
     - 0.8
 install: ./bootstrap.sh --quiet --noprompt --directory ./narwhal
 script: jake test
-env: PATH=$HOME/build/$TRAVIS_REPO_SLUG/narwhal/bin:$PATH CAPP_BUILD=$HOME/build/$TRAVIS_REPO_SLUG/Build NARWHAL_ENGINE=rhino
+env: PATH="$TRAVIS_BUILD_DIR/narwhal/bin:$PATH" CAPP_BUILD="$TRAVIS_BUILD_DIR/Build" NARWHAL_ENGINE=rhino


### PR DESCRIPTION
Before this fix, environment variables defined `.travis.yml` were still
dependant of internal configuration of the travis worker virtual
machine. See also previous pull request #1728.

With this fix, generic and long term integration with travis-ci is better guaranteed.

See also http://about.travis-ci.org/docs/user/ci-environment/#Environment-variables
