### PR TITLE
Use dedicated class instead of CPString for selection markers

### DIFF
--- a/AppKit/CPKeyValueBinding.j
+++ b/AppKit/CPKeyValueBinding.j
@@ -345,7 +345,7 @@ var CPBindingOperationAnd = 0,
     [self _updatePlaceholdersWithOptions:options];
 }
 
-- (JSObject)_placeholderForMarker:aMarker
+- (JSObject)_placeholderForMarker:(id)aMarker
 {
     var placeholder = _placeholderForMarker[[aMarker UID]];
 


### PR DESCRIPTION
This is the part from #1524 that replaces the magical strings used for selection state markers with the _CPStateMarker class.

Note: In Cocoa there's no NSNullMarker, nil is used instead.
