### PR TITLE
Fixed: Wrong placeholder string in CPTextField when using bindings

### DIFF
--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -1660,7 +1660,8 @@ var CPTextFieldIsEditableKey            = "CPTextFieldIsEditableKey",
 
 - (void)setValue:(id)aValue forBinding:(CPString)aBinding
 {
-    [_source setPlaceholderString:[self _placeholderForMarker:CPNullMarker]];
+    if (!aValue || (aValue.isa && [aValue isMemberOfClass:CPNull]))
+        [_source setPlaceholderString:[self _placeholderForMarker:CPNullMarker]];
     [_source setObjectValue:aValue];
 }
 
@@ -1676,7 +1677,8 @@ var CPTextFieldIsEditableKey            = "CPTextFieldIsEditableKey",
 
 - (void)setValue:(id)aValue forBinding:(CPString)aBinding
 {
-    [_source setPlaceholderString:[self _placeholderForMarker:CPNullMarker]];
+    if (!aValue || (aValue.isa && [aValue isMemberOfClass:CPNull]))
+        [_source setPlaceholderString:[self _placeholderForMarker:CPNullMarker]];
     [_source setObjectValue:aValue];
 }
 


### PR DESCRIPTION
Fix for issue #1499
