### PR TITLE
fix for undoManager isUndoRegistrationEnabled

### DIFF
--- a/Foundation/CPUndoManager.j
+++ b/Foundation/CPUndoManager.j
@@ -218,6 +218,7 @@ var _CPUndoGroupingParentKey        = @"_CPUndoGroupingParentKey",
         _redoStack = [];
         _undoStack = [];
 
+        _disableCount = 0;
         _state = CPUndoManagerNormal;
 
         [self setRunLoopModes:[CPDefaultRunLoopMode]];
@@ -576,7 +577,7 @@ if (_currentGroup == nil)
 */
 - (BOOL)isUndoRegistrationEnabled
 {
-    return !_disableCount;
+    return _disableCount == 0;
 }
 
 // Checking Whether Undo or Redo Is Being Performed


### PR DESCRIPTION
UndoRegistration should be enabled by default.
https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSUndoManager_Class/Reference/Reference.html#//apple_ref/occ/instm/NSUndoManager/isUndoRegistrationEnabled

Currently it is not because the method only test for "_disabledCount == 0" which does not account for _disableCount being null which it is at start.

Here is a simple test:

```
console.log("UndoRegistration should be enabled by default, this should return true: " + [[theWindow undoManager]  isUndoRegistrationEnabled]);
[[theWindow undoManager]  disableUndoRegistration];
console.log("UndoRegistration is disabled, this should return false: " + [[theWindow undoManager]  isUndoRegistrationEnabled]);
[[theWindow undoManager]  enableUndoRegistration];
console.log("UndoRegistration is enabled, this should return true: " + [[theWindow undoManager]  isUndoRegistrationEnabled]);
```
