### PR TITLE
don't allow views from another window to be next/previouskeyViews

### DIFF
--- a/AppKit/CPView.j
+++ b/AppKit/CPView.j
@@ -2557,7 +2557,7 @@ setBoundsOrigin:
 
 - (void)_setPreviousKeyView:(CPView)previous
 {
-    if ([previous isEqual:self])
+    if ([previous isEqual:self] || ![[previous window] isEqual:[self window]])
         _previousKeyView = nil;
     else
         _previousKeyView = previous;
@@ -2565,7 +2565,7 @@ setBoundsOrigin:
 
 - (void)setNextKeyView:(CPView)next
 {
-    if ([next isEqual:self])
+    if ([next isEqual:self] || ![[next window] isEqual:[self window]])
         _nextKeyView = nil;
     else
     {


### PR DESCRIPTION
IB allows the user to select a view from another window as the nextKeyView.
But, when run in cocoa it does nothing. In Cappuccino we get an infinite loop.
This fix disables views from another window to be set as the next or previousKeyView.
