### PR TITLE
Fixed: using keyboard navigation in empty CPCollectionView threw exception

### DIFF
--- a/AppKit/CPCollectionView.j
+++ b/AppKit/CPCollectionView.j
@@ -1218,8 +1218,10 @@ Not supported. Use -collectionView:dataForItemsAtIndexes:fortype:
 - (void)_modifySelectionWithNewIndex:(int)anIndex direction:(int)aDirection expand:(BOOL)shouldExpand
 {
     var count = [[self items] count];
+
     if (count === 0)
         return;
+
     anIndex = MIN(MAX(anIndex, 0), count - 1);
 
     if (_allowsMultipleSelection && shouldExpand)


### PR DESCRIPTION
Previously, if an empty CPCollectionView was first responder and keyboard navigation was used, a CPInvalidArgumentException (Range {-1, 1} is out of bounds) was thrown.

This commit checks for an empty collection, eliminating the exception.
