### PR TITLE
Fixed: main menus were too far apart

### DIFF
--- a/AppKit/Themes/Aristo2/ThemeDescriptors.j
+++ b/AppKit/Themes/Aristo2/ThemeDescriptors.j
@@ -2028,7 +2028,7 @@ var themedButtonValues = nil,
         [
             [@"menu-item-selection-color",                              [CPColor colorWithHexString:@"5C85D8"]],
             [@"menu-item-text-shadow-color",                            [CPColor colorWithCalibratedRed:26.0 / 255.0 green: 73.0 / 255.0 blue:109.0 / 255.0 alpha:1.0]],
-            [@"horizontal-margin",                                      12.0],
+            [@"horizontal-margin",                                      9.0],
             [@"submenu-indicator-margin",                               3.0],
             [@"vertical-margin",                                        4.0]
         ];


### PR DESCRIPTION
Previously the main menus were farther apart than the Aristo 2 PSD indicated, and too far apart visually.

This commit reduces the horizontal margin between menu items that have originated from Interface Builder. A value of 9.0 for horizontal margin (down from 12.0) reduces the margin on both sides of the menu by 3px, reducing the inter-menu spacing by a total of 6px.

Fixes #1809
