### PR TITLE
Fixed: next/previous key view could be from another window

### DIFF
--- a/AppKit/CPView.j
+++ b/AppKit/CPView.j
@@ -2513,8 +2513,9 @@ setBoundsOrigin:
 
 - (CPView)nextKeyView
 {
-    if (_nextKeyView && [[_nextKeyView window] isEqual:[self window]])
+    if ([[_nextKeyView window] isEqual:[self window]])
         return _nextKeyView;
+
     return nil;
 }
 
@@ -2537,8 +2538,9 @@ setBoundsOrigin:
 
 - (CPView)previousKeyView
 {
-    if (_previousKeyView && [[_previousKeyView window] isEqual:[self window]])
+    if ([[_previousKeyView window] isEqual:[self window]])
         return _previousKeyView;
+
     return nil;
 }
 


### PR DESCRIPTION
Previously, Cappuccino would allow a next/previous key view to belong to a different window, which could result in an infinite loop.

Attempting to prevent this when setting the next/previous key view broke the responder chain, because sometimes the responder chain is being constructed before the view has a window.

This commit defers the check for next/previous views belonging to the same window to when they are requested.
