### PR TITLE
CPTableView: fix for wrong highlighting after column sort

### DIFF
--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -2824,6 +2824,8 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
 {
     [self _sendDelegateDidClickColumn:clickedColumn];
 
+    [self _changeSortDescriptorsForClickOnColumn:clickedColumn];
+
     if (_allowsColumnSelection)
     {
         [self _noteSelectionIsChanging];
@@ -2850,8 +2852,6 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
         else
             [self selectColumnIndexes:[CPIndexSet indexSetWithIndex:clickedColumn] byExtendingSelection:NO];
     }
-
-    [self _changeSortDescriptorsForClickOnColumn:clickedColumn];
 }
 
 // From GNUSTEP
@@ -3189,12 +3189,10 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
 - (void)setSortDescriptors:(CPArray)sortDescriptors
 {
     var oldSortDescriptors = [[self sortDescriptors] copy],
-        newSortDescriptors = nil;
-
-    if (sortDescriptors == nil)
         newSortDescriptors = [CPArray array];
-    else
-        newSortDescriptors = [CPArray arrayWithArray:sortDescriptors];
+
+    if (sortDescriptors !== nil)
+        [newSortDescriptors addObjectsFromArray:sortDescriptors];
 
     if ([newSortDescriptors isEqual:oldSortDescriptors])
         return;


### PR DESCRIPTION
Some info if you started looking into that.

When the user clicked a sortable column, we were selecting/deselecting twice: A/ selecting the column directly in CPTableView and B/ selecting a row via the sortDescriptors binding -> CPArrayController setSortDescriptors -> CPArrayController setSelectionIndexes -> CPTableView _setSelectedRows:

This commit just reverses A/ and B/ but there are 2 underlying bugs:
1/ We should select the column only once and skip B/. We may need a CPTableSortDescriptors binder subclass that would rearrange the content but not update selection.
2/ When the CPArrayController selectionIndexes updates the selected rows in the CPTableView via _setSelectedRows:, a selected column is not deselected. (1 would hide 2).

These 2 bugs can be fixed later independently and won't conflict with this fix.
