### PR TITLE
FIXED When editing a table dataview, the row highlight lost focus

### DIFF
--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -3889,7 +3889,9 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
 */
 - (BOOL)_isFocused
 {
-    return [[self window] isKeyWindow] && [[self window] firstResponder] === self;
+    var isEditing = _editingRow !== CPNotFound || _editingCellIndex;
+
+    return [[self window] isKeyWindow] && ([[self window] firstResponder] === self || isEditing);
 }
 
 /*!


### PR DESCRIPTION
This fix updates the _isFocused test to include test for editing in both
old style tableviews and new veiwbased.
