### PR TITLE
Fixed: stringByTrimmingCharactersInSet not removing characters at end

### DIFF
--- a/Foundation/CPCharacterSet.j
+++ b/Foundation/CPCharacterSet.j
@@ -490,10 +490,10 @@ _CPCharacterSetTrimAtEnd        = 1 << 2;
     {
         var cutEdgeEnd = str.length;
 
-        while (cutEdgeEnd > 0 && [set characterIsMember:self.charAt(cutEdgeEnd)])
+        while (cutEdgeEnd > 0 && [set characterIsMember:str.charAt(cutEdgeEnd - 1)])
             cutEdgeEnd--;
 
-        str = str.substr(0, cutEdgeEnd + 1);
+        str = str.substr(0, cutEdgeEnd);
     }
 
     return str;

--- a/Tests/Foundation/CPStringTest.j
+++ b/Tests/Foundation/CPStringTest.j
@@ -526,4 +526,44 @@
     [self assertTrue:sawException message:"expected CPRangeException"];
 }
 
+- (void)testStringByTrimmingCharactersInSet
+{
+    var startOneString = @".This is a test startOne",
+        startManyString = @".,.This is a test startMany",
+        endOneString = @"This is a test endOne.",
+        endManyString = @"This is a test endMany.,.",
+        bothOneString = @".This is a test bothOne,",
+        bothManyString = @".,,This is a test bothMany..,",
+        noneString = @"This is a test none",
+        set = [CPCharacterSet characterSetWithCharactersInString:@".,"];
+
+    [self assert:"This is a test startOne" equals:[startOneString stringByTrimmingCharactersInSet:set]];
+    [self assert:"This is a test startMany" equals:[startManyString stringByTrimmingCharactersInSet:set]];
+    [self assert:"This is a test endOne" equals:[endOneString stringByTrimmingCharactersInSet:set]];
+    [self assert:"This is a test endMany" equals:[endManyString stringByTrimmingCharactersInSet:set]];
+    [self assert:"This is a test bothOne" equals:[bothOneString stringByTrimmingCharactersInSet:set]];
+    [self assert:"This is a test bothMany" equals:[bothManyString stringByTrimmingCharactersInSet:set]];
+    [self assert:"This is a test none" equals:[noneString stringByTrimmingCharactersInSet:set]];
+}
+
+- (void)testStringByTrimmingWhitespace
+{
+    var startOneString = @" This is a test startOne",
+        startManyString = @"   This is a test startMany",
+        endOneString = @"This is a test endOne ",
+        endManyString = @"This is a test endMany   ",
+        bothOneString = @" This is a test bothOne ",
+        bothManyString = @"   This is a test bothMany   ",
+        noneString = @"This is a test none",
+        set = [CPCharacterSet characterSetWithCharactersInString:@" "];
+
+    [self assert:"This is a test startOne" equals:[startOneString stringByTrimmingCharactersInSet:set]];
+    [self assert:"This is a test startMany" equals:[startManyString stringByTrimmingCharactersInSet:set]];
+    [self assert:"This is a test endOne" equals:[endOneString stringByTrimmingCharactersInSet:set]];
+    [self assert:"This is a test endMany" equals:[endManyString stringByTrimmingCharactersInSet:set]];
+    [self assert:"This is a test bothOne" equals:[bothOneString stringByTrimmingCharactersInSet:set]];
+    [self assert:"This is a test bothMany" equals:[bothManyString stringByTrimmingCharactersInSet:set]];
+    [self assert:"This is a test none" equals:[noneString stringByTrimmingCharactersInSet:set]];
+}
+
 @end


### PR DESCRIPTION
If a string had characters from the set at both the start and end,
the end trim was one character less than required.
