### PR TITLE
Fixed: XCodeCapp adding duplicate files to Xcode project

### DIFF
--- a/Tools/XcodeCapp/pbxprojModifier.py
+++ b/Tools/XcodeCapp/pbxprojModifier.py
@@ -22,6 +22,9 @@ def update_general_include(project, projectBaseURL):
 def add_file(project, shadowGroup, sourceGroup, shadowHeaderPath, shadowImplementationFilePath, sourcePath, projectBaseURL):
     project.add_file(shadowHeaderPath, parent=shadowGroup)
     project.add_file(shadowImplementationFilePath, parent=shadowGroup)
+
+    if sourcePath in project.get_files_by_os_path(os.path.relpath(sourcePath, projectBaseURL)):
+        return
     project.add_file(sourcePath, parent=sourceGroup)
 
 def remove_file(project, shadowGroup, sourceGroup, shadowHeaderPath, shadowImplementationFilePath, sourcePath, projectBaseURL):


### PR DESCRIPTION
Previously, XCC would indiscriminately add files to the Xcode project via the pbxprojModifier.py script. This resulted in duplicate references to a file.

This fix adds a check to see if the file is already included in the project's sourceGroup folder, and will return None if it is.

Fixes #1866
