### PR TITLE
Fixed: Typo in CPImageView Category

### DIFF
--- a/AppKit/CPImageView.j
+++ b/AppKit/CPImageView.j
@@ -585,7 +585,7 @@ var CPImageViewImageKey          = @"CPImageViewImageKey",
 
 @end
 
-@implementation CPImage (CahedImage)
+@implementation CPImage (CachedImage)
 
 + (CPImage)cachedImageWithContentsOfFile:(CPString)aFile
 {


### PR DESCRIPTION
The category name for CPImage (CachedImage) was spelled wrong. This commit fixes the typo.
