### PR TITLE
Fixed: 'RowCountChanged' notification generates nil warning when dragging a row

### DIFF
--- a/AppKit/CPRuleEditor/CPRuleEditor.j
+++ b/AppKit/CPRuleEditor/CPRuleEditor.j
@@ -2279,7 +2279,7 @@ TODO: implement
 
 - (void)_postRowCountChangedNotificationOfType:(CPString)notificationName indexes:indexes
 {
-    var userInfo = @{ "indexes": indexes };
+    var userInfo = indexes === nil ? @{} : @{ "indexes": indexes };
     [[CPNotificationCenter defaultCenter] postNotificationName:notificationName object:self userInfo:userInfo];
 }
 


### PR DESCRIPTION
Previously, when
- Dragging a row in the rule editor

would eventually try to generate a dictionary with key 'indexes' and a
nil value in the method _postRowCountChangedNotificationOfType:indexes:.
Generating an empty dictionary instead when there is no indexes solves
this issue.
