### PR TITLE
Fixed: Allow Interface Builder to set CPTextField enabled state

### DIFF
--- a/Tools/nib2cib/NSTextField.j
+++ b/Tools/nib2cib/NSTextField.j
@@ -38,6 +38,7 @@
     [super NS_initWithCell:cell];
 
     [self setEditable:[cell isEditable]];
+    [self setEnabled:[cell isEnabled]];
     [self setSelectable:[cell isSelectable]];
     [self setSendsActionOnEndEditing:[cell sendsActionOnEndEditing]];
 


### PR DESCRIPTION
Previously, the enabled/disabled control for NSTextField in Interface Builder was ignored by nib2cib.

This change allows the enabled/disabled state on CPTextField to be set in interface builder.
