### PR TITLE
Fixed: Additional keys in default Info.plist templates

### DIFF
--- a/Tools/capp/Resources/Templates/NibApplication/Info.plist
+++ b/Tools/capp/Resources/Templates/NibApplication/Info.plist
@@ -6,5 +6,9 @@
 	<string>MainMenu.cib</string>
 	<key>CPBundleName</key>
 	<string>__project.name__</string>
+    <key>CPBundleVersion</key>
+    <string>1.0</string>
+    <key>CPHumanReadableCopyright</key>
+    <string>Copyright © __project.year__, __organization.name__ All rights reserved.</string>
 </dict>
 </plist>


### PR DESCRIPTION
This fix adds two keys to the default Info.plist in the capp gen template for NibApplication, "CPBundleVersion" and "CPHumanReadableCopyright". These are introduced primarily to fill out the fields in the default "About" panel. (see #1896)
