### PR TITLE
Docs: Fix small but potentially confusing typo in CPTableView

### DIFF
--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -2645,7 +2645,7 @@ Return YES if the table column given should be selected, otherwise NO to deny th
 - (BOOL)tableView:(CPTableView)aTableView shouldSelectTableColumn:(CPTableColumn)aTableColumn;
 @endcode
 
-Informs the delegate that the tableview is in the process of chaining the selection.
+Informs the delegate that the tableview is in the process of changing the selection.
 This usually happens when the user is dragging their mouse across rows.
 @code
 - (void)tableViewSelectionIsChanging:(CPNotification)aNotification


### PR DESCRIPTION
This commit fixes the delegate documentation for `- (void)tableViewSelectionIsChanging:(CPNotification)aNotification`, removing reference to "selection chaining." (should be "selection changing")
