### PR TITLE
Don't miss scrollwheel events

### DIFF
--- a/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
@@ -1091,7 +1091,7 @@ var resizeTimer = nil;
                                   timestamp:timestamp windowNumber:windowNumber context:nil eventNumber:-1 clickCount:1 pressure:0];
     event._DOMEvent = aDOMEvent;
 
-    // We lag many events behind without this closure depending on browser.
+    // We lag many events behind without this closure, depending on browser.
     var eventCaller = (function(scrollLeft,scrollTop,DOMEventDeltaY)
     {
         return function() {


### PR DESCRIPTION
A solution to issue https://github.com/cappuccino/cappuccino/issues/1118
Also commented on https://groups.google.com/forum/?fromgroups=#!topic/objectivej/Y29eKFTAsWs

Positive tests:

-WindowsXP+Chrome
-WindowsXP+Opera
-WindowsXP+Firefox
-ArchLinux+Chromium
-ArchLinux+Opera
-ArchLinux+Firefox

Needs to be tested on:

-WindowsXP+IE8 (I can't due to issue https://github.com/cappuccino/cappuccino/issues/1901)
-Windows[...]+IE[...]
-iOS+[...]
-MacOSX+[...]

Please, test other scrolling devices as Apple point/ball and scrolling pads, specially horizontal scrolling as I can't do it.
