### PR TITLE
Fixed: CornerView in TableViews from cibs are not sized well

### DIFF
--- a/Tools/nib2cib/_NSCornerView.j
+++ b/Tools/nib2cib/_NSCornerView.j
@@ -22,6 +22,13 @@
 
 @import <AppKit/CPTableHeaderView.j>
 @import <AppKit/_CPCornerView.j>
+@import <AppKit/CPScroller.j>
+@import <AppKit/CPTableView.j>
+
+@class Nib2Cib
+
+@global CPThemeStateVertical
+@global CPThemeStateScrollViewLegacy
 
 @implementation _CPCornerView (NSCoding)
 
@@ -39,10 +46,17 @@
 - (id)initWithCoder:(CPCoder)aCoder
 {
     self =  [super NS_initWithCoder:aCoder];
+
     if (self)
     {
-        _frame.size.height = 23.0;
-        _bounds.size.height = 23.0;
+        var theme = [Nib2Cib defaultTheme],
+            height = [theme valueForAttributeWithName:@"default-row-height" forClass:[CPTableView class]],
+            width = [theme valueForAttributeWithName:@"scroller-width" inState:CPThemeStateVertical | CPThemeStateScrollViewLegacy forClass:[CPScroller class]];
+
+        _frame.size.height = height;
+        _bounds.size.height = height;
+        _frame.size.width = width;
+        _bounds.size.width = width;
     }
 
     return self;


### PR DESCRIPTION
Previously the size of the cornerView was wrong in a TableView from cib.

Now the nib2cib of _CPCornerView set the good values.

Fixes #1865
