### PR TITLE
Fixed: OutlineView disclosure button selected themestate when selected

### DIFF
--- a/AppKit/CPOutlineView.j
+++ b/AppKit/CPOutlineView.j
@@ -725,11 +725,13 @@ var CPOutlineViewCoalesceSelectionNotificationStateOff  = 0,
 */
 - (void)_setSelectedRowIndexes:(CPIndexSet)rows
 {
-    [[_disclosureControlsForRows objectsAtIndexes:_selectedRowIndexes] makeObjectsPerformSelector:@selector(unsetThemeState:) withObject:CPThemeStateSelected];
+    if (_disclosureControlsForRows.length)
+        [[_disclosureControlsForRows objectsAtIndexes:_selectedRowIndexes] makeObjectsPerformSelector:@selector(unsetThemeState:) withObject:CPThemeStateSelected];
 
     [super _setSelectedRowIndexes:rows];
 
-    [[_disclosureControlsForRows objectsAtIndexes:_selectedRowIndexes] makeObjectsPerformSelector:@selector(setThemeState:) withObject:CPThemeStateSelected];
+    if (_disclosureControlsForRows.length)
+        [[_disclosureControlsForRows objectsAtIndexes:_selectedRowIndexes] makeObjectsPerformSelector:@selector(setThemeState:) withObject:CPThemeStateSelected];
 }
 
 /*!


### PR DESCRIPTION
Previously, when a row with a disclosure control (triangle) was selected, the row was selected
but the control remained in the unselected themestate. Disclosure control themestate was only being
changed when the control itself was clicked on. This fix changes the controls themestate whenever
the row selection changes.

Bug that this fixes can be seen in any of the CPOutlineView tests by simply selecting a row without clicking on the disclosure triangle.
