### PR TITLE
Fixed: CPLocal can't handle unknown language codes

### DIFF
--- a/Foundation/CPLocale.j
+++ b/Foundation/CPLocale.j
@@ -101,7 +101,7 @@ var sharedSystemLocale = nil,
 
             language = [CPString stringWithFormat:@"%s_%s", [language lowercaseString], [language uppercaseString]];
 
-            if ([availableLocaleIdentifiers indexOfObject:language])
+            if ([availableLocaleIdentifiers indexOfObject:language] !== CPNotFound)
                 localeIdentifier = language;
         }
 


### PR DESCRIPTION
When the language code is not known it still sets the current language code
to the unknown code instead of the defualt 'en_US' code.
This makes the test cases for CPDateFormatter fail when run on some foreign systems.
