### PR TITLE
Fixed: When selector is only a ':' in a send message statement the new compiler crashed.

### DIFF
--- a/Objective-J/ObjJAcornCompiler.js
+++ b/Objective-J/ObjJAcornCompiler.js
@@ -1577,7 +1577,8 @@ MessageSendExpression: function(node, st, c) {
 
     var selectors = node.selectors,
         arguments = node.arguments,
-        selector = selectors[0].name;    // There is always at least one selector
+        firstSelector = selectors[0],
+        selector = firstSelector ? firstSelector.name : "";    // There is always at least one selector
 
     // Put together the selector. Maybe this should be done in the parser...
     for (var i = 0; i < arguments.length; i++)

--- a/Tests/Objective-J/Preprocessor/OutputTests/Messages/colon-selector.j
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Messages/colon-selector.j
@@ -1,0 +1,2 @@
+
+[object:argument];

--- a/Tests/Objective-J/Preprocessor/OutputTests/Messages/colon-selector.js
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Messages/colon-selector.js
@@ -1,0 +1,2 @@
+
+objj_msgSend(object, ":", argument);

--- a/Tests/Objective-J/Preprocessor/OutputTests/OutputTest.j
+++ b/Tests/Objective-J/Preprocessor/OutputTests/OutputTest.j
@@ -12,6 +12,7 @@ var FILENAMES = [
         "Messages/multiple-parameters",
         "Messages/ternary-operator-argument",
         "Messages/keyword-in-selector",
+        "Messages/colon-selector",
 
         "Misc/parenthesis-return",
         "Misc/preprocess-if-directives",


### PR DESCRIPTION
The program below crashed on the last line with a 'null is not an object' error message. Also added a test case.

``` objjc
@implementation MyObject {
- (int):(int)a {
  return a;
}
@end

var a = [[MyObject alloc] init];
var b = [a:3];
```
