### PR TITLE
Fixed: CPCollectionView range bounds exception if shift key was held for...

### DIFF
--- a/AppKit/CPCollectionView.j
+++ b/AppKit/CPCollectionView.j
@@ -784,6 +784,10 @@ var HORIZONTAL_MARGIN = 2;
                 var firstSelectedIndex = [[self selectionIndexes] firstIndex],
                     newSelectedRange = nil;
 
+                // This catches the case where the shift key is held down for the first selection.
+                if (firstSelectedIndex === CPNotFound)
+                    firstSelectedIndex = index;
+
                 if (index < firstSelectedIndex)
                     newSelectedRange = CPMakeRange(index, (firstSelectedIndex - index) + 1);
                 else


### PR DESCRIPTION
... first selection

Previously, if you held down the shift key while making the first selection in a CPCollectionView it would raise an exception claiming {-1, XXX} was out of range. This was because `firstIndex` returns CPNotFound (-1) if nothing is selected.

In Cocoa, holding down the shift key while making the initial selection behaves as if you made an initial selection.

This commit catches a CPNotFound and sets the first index to the index of the item under the mouse pointer.
