### PR TITLE
Fixed: removeTableColumn does not removes column from tableColumns array

### DIFF
--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -1045,7 +1045,6 @@ NOT YET IMPLEMENTED
         _dirtyTableColumnRangeIndex = MIN(index, _dirtyTableColumnRangeIndex);
 
     [_tableColumns removeObject:aTableColumn];
-    _reloadAllRows = YES;
 
     [self setNeedsLayout];
 }


### PR DESCRIPTION
Previously the tableView didn't correctly remove a given tableColumn. It was removed in the method load (who is called by the layoutSubviews).
Now the tableColumns is removed before the layoutSubviews (as in cocoa).
It fixed also another problem, before this fixe it wasn't possible to remove all of the columns of a tableView (the last column was always displayed). This is fixed also

Fixes #1913

You can test that with the app of @t00f
