### PR TITLE
Fixed: CPTableView Drag and drop in void causes a crash

### DIFF
--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -4966,7 +4966,7 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
     else if (_allowsMultipleSelection)
     {
         if (_selectionAnchorRow == CPNotFound)
-            _selectionAnchorRow =  [self numberOfRows] - 1;
+            _selectionAnchorRow = [self numberOfRows] - 1;
 
         newSelection = [CPIndexSet indexSetWithIndexesInRange:CPMakeRange(MIN(aRow, _selectionAnchorRow), ABS(aRow - _selectionAnchorRow) + 1)];
         shouldExtendSelection = [self mouseDownFlags] & CPShiftKeyMask &&


### PR DESCRIPTION
Previously the drag and drop and multiple selection from a void cells caused an exception.
With this fix, you can start a drag/drop and a multiple selection from a empty row.

Fixes #1857
