### PR TITLE
Fixed: selection in a tableView without column

### DIFF
--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -1273,7 +1273,8 @@ NOT YET IMPLEMENTED
 - (void)selectRowIndexes:(CPIndexSet)rows byExtendingSelection:(BOOL)shouldExtendSelection
 {
     if ([rows isEqualToIndexSet:_selectedRowIndexes] ||
-        (([rows firstIndex] != CPNotFound && [rows firstIndex] < 0) || [rows lastIndex] >= [self numberOfRows]))
+        (([rows firstIndex] != CPNotFound && [rows firstIndex] < 0) || [rows lastIndex] >= [self numberOfRows]) ||
+        [self numberOfColumns] <= 0)
         return;
 
     // We deselect all columns when selecting rows.
@@ -3071,7 +3072,7 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
 */
 - (BOOL)canDragRowsWithIndexes:(CPIndexSet)rowIndexes atPoint:(CGPoint)mouseDownPoint
 {
-    return [rowIndexes count] > 0 && [self numberOfRows] > 0;
+    return [rowIndexes count] > 0 && [self numberOfRows] > 0 && [self numberOfColumns] > 0;
 }
 
 /*!


### PR DESCRIPTION
Previously it was possible to select rows in a CPTableView even if there wasn't columns. It was also possible to make a drag/drop.
This PR fixes these both problems.
