### PR TITLE
Fixed: honour CPWindows contentView Autoresizes Subviews set in Cib 

### DIFF
--- a/AppKit/Cib/_CPCibWindowTemplate.j
+++ b/AppKit/Cib/_CPCibWindowTemplate.j
@@ -103,12 +103,14 @@
     //[result setHidesOnDeactivate:(_wtFlags&0x80000000)?YES:NO];
     [theWindow setTitle:_windowTitle];
 
-    // FIXME: we can't autoresize yet...
+    var contentViewAutoresizesSubviews = [_windowView autoresizesSubviews];
+
     [_windowView setAutoresizesSubviews:NO];
-
     [theWindow setContentView:_windowView];
-
     [_windowView setAutoresizesSubviews:YES];
+
+    [[theWindow contentView] setAutoresizesSubviews:contentViewAutoresizesSubviews];
+
 
     if ([_viewClass isKindOfClass:[CPToolbar class]])
        [theWindow setToolbar:_viewClass];


### PR DESCRIPTION
Currently when a window is decoded from a cib, the contentView is set to always auto resize its subviews regardless of the setting in IB.
