### PR TITLE
Fixed: unnecessary tableView dataSource warning when loading from cib

### DIFF
--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -1570,7 +1570,7 @@ NOT YET IMPLEMENTED
         _numberOfRows = [_dataSource numberOfRowsInTableView:self] || 0;
     else
     {
-        if (_dataSource)
+        if (_dataSource && _window)
             CPLog(@"no content binding established and data source " + [_dataSource description] + " does not implement numberOfRowsInTableView:");
         _numberOfRows = 0;
     }


### PR DESCRIPTION
As tableViews are loading from cibs with content bindings and dataSource
established in the cib, an unnecessary warning is displayed falsely indicating
that the tableView has no ContentBinding.
