### PR TITLE
When determining whether we're a local file request, see if we have a valid host before using the window's location.

### DIFF
--- a/Foundation/CPURLConnection.j
+++ b/Foundation/CPURLConnection.j
@@ -152,11 +152,13 @@ var CPURLConnectionDelegate = nil;
         _isCanceled = NO;
 
         var URL = [_request URL],
-            scheme = [URL scheme];
+            scheme = [URL scheme],
+            host = [URL host];
 
         // Browsers use "file:", Titanium uses "app:"
         _isLocalFileConnection =    scheme === "file" ||
                                     ((scheme === "http" || scheme === "https:") &&
+                                    (host === nil) &&
                                     window.location &&
                                     (window.location.protocol === "file:" || window.location.protocol === "app:"));
 


### PR DESCRIPTION
Before checking whether the request is local, we should first check to see if the original request had a host before assuming that we need to use the window's host.
