### PR TITLE
Fixed: Remove explicit use of Mac OS X 10.5 SDK, replace with "latest OS X"

### DIFF
--- a/Tools/fontinfo/fontinfo.xcodeproj/project.pbxproj
+++ b/Tools/fontinfo/fontinfo.xcodeproj/project.pbxproj
@@ -172,7 +172,7 @@
 				);
 				PREBINDING = NO;
 				PRODUCT_NAME = fontinfo;
-				SDKROOT = macosx10.5;
+				SDKROOT = macosx;
 				SYMROOT = "$(CAPP_BUILD)/Debug/CommonJS/cappuccino/bin";
 			};
 			name = Debug;
@@ -186,7 +186,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_NAME = fontinfo;
-				SDKROOT = macosx10.5;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};
@@ -199,7 +199,6 @@
 		E1D3CF6E12AFEE3900CBB79E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				MACOSX_DEPLOYMENT_TARGET = 10.5;
 			};
 			name = Release;
 		};

--- a/Tools/imagesize/imagesize.xcodeproj/project.pbxproj
+++ b/Tools/imagesize/imagesize.xcodeproj/project.pbxproj
@@ -170,7 +170,6 @@
 				);
 				PREBINDING = NO;
 				PRODUCT_NAME = imagesize;
-				SDKROOT = macosx10.5;
 				SYMROOT = "$(CAPP_BUILD)/Debug/CommonJS/cappuccino/bin";
 			};
 			name = Debug;
@@ -187,7 +186,6 @@
 				ONLY_ACTIVE_ARCH = NO;
 				PREBINDING = NO;
 				PRODUCT_NAME = imagesize;
-				SDKROOT = macosx10.5;
 			};
 			name = Release;
 		};
@@ -201,7 +199,6 @@
 		E1D3CF6E12AFEE3900CBB79E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				MACOSX_DEPLOYMENT_TARGET = 10.5;
 				PRODUCT_NAME = imagesize;
 			};
 			name = Release;


### PR DESCRIPTION
Fixed: Remove explicit use of Mac OS X 10.5 SDK, replace with "latest OS X"

The fontinfo and imagesize Xcode projects still explicitly refer to using the Mac OS X 10.5 SDK, while all other Xcode projects simply refer to the latest Mac OS X SDK, with no explicit OS version. This change modifies these two projects to mirror other Xcode projects in the project.

Fixes #1957
