### PR TITLE
Fixed: CPTimer number of seconds interval set to 0.1 if less than or equal to 0.0

### DIFF
--- a/Foundation/CPTimer.j
+++ b/Foundation/CPTimer.j
@@ -112,7 +112,7 @@
 
     if (self)
     {
-        _timeInterval = seconds;
+        _timeInterval = MAX(seconds,0.1);
         _invocation = anInvocation;
         _repeats = shouldRepeat;
         _isValid = YES;
@@ -150,7 +150,7 @@
 
     if (self)
     {
-        _timeInterval = seconds;
+        _timeInterval = MAX(seconds,0.1);
         _callback = aFunction;
         _repeats = shouldRepeat;
         _isValid = YES;


### PR DESCRIPTION
Cocoa specs here:
 https://developer.apple.com/library/mac/#documentation/Cocoa/Reference/Foundation/Classes/NSTimer_Class/Reference/NSTimer.html
...
"Parameters
seconds
The number of seconds between firings of the timer. If seconds is less than or equal to 0.0, this method chooses the nonnegative value of 0.1 milliseconds instead."
