### PR TITLE
Fixed: CPTimer don't allow to put the timeInterval below 0.1

### DIFF
--- a/Foundation/CPTimer.j
+++ b/Foundation/CPTimer.j
@@ -114,7 +114,7 @@ var CPTimerMinTimeInterval = 0.1;
 
     if (self)
     {
-        _timeInterval = MAX(seconds, CPTimerMinTimeInterval);
+        _timeInterval = (seconds <= 0) ? CPTimerMinTimeInterval : seconds;
         _invocation = anInvocation;
         _repeats = shouldRepeat;
         _isValid = YES;
@@ -152,7 +152,7 @@ var CPTimerMinTimeInterval = 0.1;
 
     if (self)
     {
-        _timeInterval = MAX(seconds, CPTimerMinTimeInterval);
+        _timeInterval = (seconds <= 0) ? CPTimerMinTimeInterval : seconds;
         _callback = aFunction;
         _repeats = shouldRepeat;
         _isValid = YES;


### PR DESCRIPTION
Previously it wasn't possible to set the timeInterval below 0.1.
Now you can do it and the timeInterval will set to 0.1 if the timeInterval is less or equal to 0 as in cocoa.

Cocoa specs here:
https://developer.apple.com/library/mac/#documentation/Cocoa/Reference/Foundation/Classes/NSTimer_Class/Reference/NSTimer.html
