### PR TITLE
Fixed: a disabled CPMenuItem could still have a selected background

### DIFF
--- a/AppKit/CPMenuItem/CPMenuItem.j
+++ b/AppKit/CPMenuItem/CPMenuItem.j
@@ -166,6 +166,9 @@ var CPMenuItemStringRepresentationDictionary = @{
     if (_isEnabled === isEnabled)
         return;
 
+    if (!isEnabled && [self isHighlighted])
+        [_menu _highlightItemAtIndex:CPNotFound];
+
     _isEnabled = !!isEnabled;
 
     [_menuItemView setDirty];


### PR DESCRIPTION
Previously it was possible to have a highlighted CPMenuItem for a disabled CPMenuItem. (To get that, select an item, close the menu, disabled the item manually and then open the menu again).
Now it is not possible to get this behavior.
