### PR TITLE
Fixed: Menu disappears when opening a submenu

### DIFF
--- a/AppKit/CPMenu/CPMenu.j
+++ b/AppKit/CPMenu/CPMenu.j
@@ -855,6 +855,9 @@ var _CPMenuBarVisible               = NO,
 
 + (void)popUpContextMenu:(CPMenu)aMenu withEvent:(CPEvent)anEvent forView:(CPView)aView withFont:(CPFont)aFont
 {
+    // This is needed when we are making several rights click
+    [[_CPMenuManager sharedMenuManager] cancelActiveMenu];
+
     [aMenu _menuWillOpen];
 
     if (!aFont)
@@ -862,8 +865,6 @@ var _CPMenuBarVisible               = NO,
 
     var theWindow = [aView window],
         menuWindow = [_CPMenuWindow menuWindowWithMenu:aMenu font:aFont];
-
-    [_CPMenuWindow poolMenuWindow:menuWindow];
 
     [menuWindow setBackgroundStyle:_CPMenuWindowPopUpBackgroundStyle];
 

--- a/AppKit/CPMenu/_CPMenuManager.j
+++ b/AppKit/CPMenu/_CPMenuManager.j
@@ -407,6 +407,15 @@ var STICKY_TIME_INTERVAL            = 0.4,
         [menu cancelTracking];
 }
 
+- (void)cancelActiveMenu
+{
+    if (CPApp._activeMenu)
+    {
+        [self completeTracking];
+        _menuContainerStack = [];
+    }
+}
+
 - (void)completeTracking
 {
     var trackingMenu = [self trackingMenu];

--- a/AppKit/CPMenu/_CPMenuWindow.j
+++ b/AppKit/CPMenu/_CPMenuWindow.j
@@ -72,7 +72,8 @@ _CPMenuWindowAttachedMenuBackgroundStyle    = 2;
 
 + (void)poolMenuWindow:(_CPMenuWindow)aMenuWindow
 {
-    if (!aMenuWindow || _CPMenuWindowPool.length >= _CPMenuWindowPoolCapacity)
+    // FIXME :the poolMenuWindow is called too many times somewhere....
+    if (!aMenuWindow || _CPMenuWindowPool.length >= _CPMenuWindowPoolCapacity || [_CPMenuWindowPool containsObject:aMenuWindow])
         return;
 
     _CPMenuWindowPool.push(aMenuWindow);


### PR DESCRIPTION
Previously when opening a submenu from a menu, the main menu disappears because a issue with the poolMenuWindow.
This PR fixes this bug.
It also handle more properly the case when an user is making several right clicks on a responder (origin problem with the ghost menu).

Fixed #1887
