### PR TITLE
Fixed: Compiler now generates correct empty statement after 'if (a);'

### DIFF
--- a/Objective-J/ObjJAcornCompiler.js
+++ b/Objective-J/ObjJAcornCompiler.js
@@ -580,7 +580,8 @@ IfStatement: function(node, st, c) {
       buffer.concat("if (");
     }
     c(node.test, st, "Expression");
-    if (generate) buffer.concat(")\n");
+    // We don't want EmptyStatements to generate an extra parenthesis except when it is in a while, for, ...
+    if (generate) buffer.concat(node.consequent.type === "EmptyStatement" ? ");\n" : ")\n");
     indentation += indentStep;
     c(node.consequent, st, "Statement");
     indentation = indentation.substring(indentationSpaces);
@@ -588,8 +589,10 @@ IfStatement: function(node, st, c) {
     if (alternate) {
       var alternateNotIf = alternate.type !== "IfStatement";
       if (generate) {
+        var emptyStatement = alternate.type === "EmptyStatement";
         buffer.concat(indentation);
-        buffer.concat(alternateNotIf ? "else\n" : "else ");
+        // We don't want EmptyStatements to generate an extra parenthesis except when it is in a while, for, ...
+        buffer.concat(alternateNotIf ? emptyStatement ? "else;\n" : "else\n" : "else ");
       }
       if (alternateNotIf)
         indentation += indentStep;

--- a/Tests/Objective-J/Preprocessor/OutputTests/Misc/empty-statements.j
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Misc/empty-statements.j
@@ -1,0 +1,7 @@
+function f(x) {
+	var a = 2, b = 1;
+	while (a < b);
+	for (;;);
+	if (a < b); else;
+	do {} while (a < b);
+}

--- a/Tests/Objective-J/Preprocessor/OutputTests/Misc/empty-statements.js
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Misc/empty-statements.js
@@ -1,0 +1,13 @@
+f = function(x)
+{
+    var a = 2,
+        b = 1;
+    while (a < b);
+    for (; ; );
+    if (a < b);
+    else;
+    do
+    {
+    }
+    while (a < b);
+}

--- a/Tests/Objective-J/Preprocessor/OutputTests/OutputTest.j
+++ b/Tests/Objective-J/Preprocessor/OutputTests/OutputTest.j
@@ -18,6 +18,7 @@ var FILENAMES = [
         "Misc/preprocess-if-directives",
         "Misc/regex-simple-char-classes",
         "Misc/empty-loops",
+        "Misc/empty-statements",
 ];
 
 @implementation OutputTest : OJTestCase


### PR DESCRIPTION
Earlier the compiler generated the 'if' without the last ';' when a empty statement is used, with sometimes devastating result. The same if an empty statement was after the 'else'.

I have also added a test case for some different empty statement senarios.
