### PR TITLE
A binding with 'NSNegateBoolean' transformer will not handle 'nil' correct

### DIFF
--- a/Tests/AppKit/CPCheckBoxTest.j
+++ b/Tests/AppKit/CPCheckBoxTest.j
@@ -77,7 +77,8 @@
     var content =
         [
             @{ @"state": YES },
-            @{ @"state": NO }
+            @{ @"state": NO },
+            @{}
         ],
         arrayController = [[CPArrayController alloc] initWithContent:content];
 
@@ -88,10 +89,18 @@
     [self assert:CPOffState equals:[control objectValue] message:"content[0] is negated"]
     [arrayController setSelectionIndexes:[CPIndexSet indexSetWithIndex:1]];
     [self assert:CPOnState equals:[control objectValue] message:"content[1] is negated"]
+    [arrayController setSelectionIndexes:[CPIndexSet indexSetWithIndex:2]];
+    [self assert:CPOnState equals:[control objectValue] message:"content[2] is negated"]
 
+    [arrayController setSelectionIndexes:[CPIndexSet indexSetWithIndex:1]];
     [control performClick:nil];
     [self assert:CPOffState equals:[control objectValue] message:"value was changed"]
     [self assert:YES equals:[content[1] valueForKey:@"state"] message:"content[1] was negated after change"]
+
+    [arrayController setSelectionIndexes:[CPIndexSet indexSetWithIndex:2]];
+    [control performClick:nil];
+    [self assert:CPOffState equals:[control objectValue] message:"value was changed"]
+    [self assert:YES equals:[content[2] valueForKey:@"state"] message:"content[2] was negated after change"]
 }
 
 @end


### PR DESCRIPTION
I have no fix for this as I have a hard time figuring out how to solve this. I have only done the test case. Any help in doing this should be highly appreciated.

The corresponding working Objective-C test case is here:

``` Objective-C
- (void)testTransformValueBinding {
    NSButton *control = [[NSButton alloc] initWithFrame:CGRectZero];
    [control setButtonType:NSSwitchButton];

    NSArray *content =
    @[
     [@{ @"state": @YES } mutableCopy],
     [@{ @"state": @NO } mutableCopy],
     [@{} mutableCopy]
     ];

    NSArrayController *arrayController = [[NSArrayController alloc] initWithContent:content];

    [control bind:NSValueBinding toObject:arrayController withKeyPath:@"selection.state" options:@{ NSValueTransformerNameBindingOption: @"NSNegateBoolean" }];

    [arrayController setSelectionIndexes:[NSIndexSet indexSetWithIndex:0]];
    STAssertEqualObjects([control objectValue], @(NSOffState), @"content[0] is negated");
    [arrayController setSelectionIndexes:[NSIndexSet indexSetWithIndex:1]];
    STAssertEqualObjects([control objectValue], @(NSOnState), @"content[1] is negated");
    [arrayController setSelectionIndexes:[NSIndexSet indexSetWithIndex:2]];
    STAssertEqualObjects([control objectValue], @(NSOnState), @"content[2] is negated");

    [arrayController setSelectionIndexes:[NSIndexSet indexSetWithIndex:1]];
    [control performClick:nil];
    STAssertEqualObjects([control objectValue], @(NSOffState), @"value was changed");
    STAssertEqualObjects([content[1] valueForKey:@"state"], @YES, @"content[1] was negated after change");

    [arrayController setSelectionIndexes:[NSIndexSet indexSetWithIndex:2]];
    [control performClick:nil];
    STAssertEqualObjects([control objectValue], @(NSOffState), @"value was changed");
    STAssertEqualObjects([content[2] valueForKey:@"state"], @YES, @"content[2] was negated after change");
}
```
