### PR TITLE
'valueForKeyPath:' method in CPObjectController returns 'null marker' instead of nil

### DIFF
--- a/Tests/AppKit/CPObjectControllerTest.j
+++ b/Tests/AppKit/CPObjectControllerTest.j
@@ -1,0 +1,21 @@
+@import <AppKit/AppKit.j>
+
+@implementation CPObjectControllerTest : OJTestCase
+{
+}
+
+- (void)setUp
+{
+}
+
+- (void)testObjectControllerSelectionWithNil
+{
+    var controller = [[CPObjectController alloc] init];
+    [controller setContent:@{@"name": @"Martin"}];
+    [self assert:@"Martin" equals:[[controller selection] valueForKeyPath:@"name"] message:@"name equals 'Martin'"];
+    [self assert:nil equals:[[controller selection] valueForKeyPath:@"lastName"] message:@"name equals 'nil'"];
+    [self assert:@"Martin" equals:[controller valueForKeyPath:@"selection.name"] message:@"selection.name equals 'Martin'"];
+    [self assert:nil equals:[controller valueForKeyPath:@"selection.lastName"] message:@"selection.name equals 'nil'"];
+}
+
+@end


### PR DESCRIPTION
CPObjectController will return 'null marker' instead of nil when 'myAttribute' is nil in the following code:

``` Objective-C
[objectController valueForKeyPath:@"selection.myAttribute"]
```

The class '_CPControllerObjectProxy' returns the 'null marker' but it does not do it in Cocoa. I have a hard time figuring out how to solve this. I have only done the test case. Any help in doing this should be highly appreciated.

This might be related to #1986.

Here is a corresponding working test case for Objective-C:

``` Objective-C
- (void)testObjectControllerSelectionWithNil
{
    NSObjectController *controller = [[NSObjectController alloc] init];
    [controller setContent:@{@"name": @"Martin"}];
    STAssertEqualObjects([[controller selection] valueForKeyPath:@"name"], @"Martin", @"name equals 'Martin'");
    STAssertEqualObjects([[controller selection] valueForKeyPath:@"lastName"], nil, @"name equals 'nil'");
    STAssertEqualObjects([controller valueForKeyPath:@"selection.name"], @"Martin", @"selection.name equals 'Martin'");
    STAssertEqualObjects([controller valueForKeyPath:@"selection.lastName"], nil, @"selection.name equals 'nil'");
}
```
