### PR TITLE
CPAnimation frame rate fixes.

### DIFF
--- a/AppKit/CPAnimation.j
+++ b/AppKit/CPAnimation.j
@@ -236,7 +236,9 @@ ACTUAL_FRAME_RATE = 0;
     ACTUAL_FRAME_RATE = 0;
     _lastTime = new Date();
 
-    _timer = [CPTimer scheduledTimerWithTimeInterval:0.0 target:self selector:@selector(animationTimerDidFire:) userInfo:nil repeats:YES];
+    var timerInterval = _frameRate <= 0.0 ? 0.0001 : 1.0/_frameRate;
+
+    _timer = [CPTimer scheduledTimerWithTimeInterval:timerInterval target:self selector:@selector(animationTimerDidFire:) userInfo:nil repeats:YES];
 }
 
 /*

--- a/Tests/AppKit/CPAnimationTest.j
+++ b/Tests/AppKit/CPAnimationTest.j
@@ -1,0 +1,47 @@
+@import <AppKit/CPApplication.j>
+@import <AppKit/CPAnimation.j>
+
+[CPApplication sharedApplication];
+
+@implementation CPAnimation (TestMethods)
+{
+}
+
+- (CPTimer)timer
+{
+    return _timer;
+}
+
+@end
+
+@implementation CPAnimationTest : OJTestCase
+{
+}
+
+- (void)testScheduleTimerWithIntervalBasedOnDefaultFrameRate
+{
+    var animation = [[CPAnimation alloc] initWithDuration:0.1 animationCurve:CPAnimationLinear];
+    [animation startAnimation];
+    
+    [self assert:1.0/60.0 equals:[[animation timer] timeInterval]];
+}
+
+- (void)testScheduleTimerWithIntervalBasedOnCustomFrameRate
+{
+    var animation = [[CPAnimation alloc] initWithDuration:0.1 animationCurve:CPAnimationLinear];
+    [animation setFrameRate:30];
+    [animation startAnimation];
+    
+    [self assert:1.0/30.0 equals:[[animation timer] timeInterval]];
+}
+
+- (void)testScheduleTimerWithIntervalBasedOnAsFastAsPossibleFrameRate
+{
+    var animation = [[CPAnimation alloc] initWithDuration:0.1 animationCurve:CPAnimationLinear];
+    [animation setFrameRate:0];
+    [animation startAnimation];
+    
+    [self assert:0.0001 equals:[[animation timer] timeInterval]];
+}
+
+@end


### PR DESCRIPTION
CPAnimation always schedules timers with a repeat interval of 0.0, regardless of previous calls to setFrameRate:. A while ago CPTimer was changed to treat a time interval of 0.0 as 0.1, correctly reflecting NSTimer behaviour. This causes all CPAnimations to look choppy.

Patch content:
- Respect frameRate when scheduling timer in CPAnimation.
- Treat a frameRate of 0 as "really fast" instead of CPTimer default (10 fps).
- Test cases
