### PR TITLE
Fixed: CPComboBox don't close when clicking on the scroll

### DIFF
--- a/AppKit/_CPPopUpList.j
+++ b/AppKit/_CPPopUpList.j
@@ -887,7 +887,7 @@ var _CPPopUpListDataSourceKey   = @"_CPPopUpListDataSourceKey",
 
     if (mouseWindow != self && !CGRectContainsPoint(rect, point))
         [[self delegate] close];
-    else if ([mouseWindow firstResponder] == [[self delegate] dataSource])
+    else
         [self _trapNextMouseDown];
 }
 


### PR DESCRIPTION
Previously CPComboBox doesn't close when clicking on the scroll, now it does

Fixed #1991
