### PR TITLE
Fixed: The delegate method shouldSelectItem doesn't work in CPOutlineView

### DIFF
--- a/AppKit/CPOutlineView.j
+++ b/AppKit/CPOutlineView.j
@@ -1603,7 +1603,7 @@ var CPOutlineViewCoalesceSelectionNotificationStateOff  = 0,
 
 /*!
     @ignore
-    Return YES if the delegate implements tableView:shouldSelectItem:
+    Return YES if the delegate implements outlineView:shouldSelectItem:
 */
 - (BOOL)_delegateRespondsToShouldSelectRow
 {


### PR DESCRIPTION
Previously the delegate method shouldSelectItem didn't work in CPOutlineView.
It didn't work because the checking method _delegateRespondsToSelectionIndexesForProposedSelection and _delegateRespondsToShouldSelectRow didn't check if the real delegate of the outlineView implemented the methods
