### PR TITLE
Fixed: Return a Number from CPNumber>>numberWithBool:

### DIFF
--- a/Foundation/CPNumber.j
+++ b/Foundation/CPNumber.j
@@ -50,7 +50,7 @@ var CPNumberUIDs    = new CFMutableDictionary();
 
 + (id)numberWithBool:(BOOL)aBoolean
 {
-    return aBoolean;
+    return aBoolean ? 1 : 0;
 }
 
 + (id)numberWithChar:(char)aChar


### PR DESCRIPTION
The Cocoa signature for this method
`+ (NSNumber *)numberWithBool:(BOOL)value`
implies that a number is being returned. In Cappuccino a Boolean is returned.

This leads to some problems e.g. in `addObserver:forKeyPath:options:context:` with `CPKeyValueObservingOptionPrior` and `observeValueForKeyPath:ofObject:change:context:` with `CPKeyValueChangeNotificationIsPriorKey`.

Setting `CPKeyValueObservingOptionPrior` leads to `CPKeyValueChangeNotificationIsPriorKey` being set to `1` (which should be equal to `[NSNumber numberWithBool:YES]` as documented in https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Protocols/NSKeyValueObserving_Protocol/Reference/Reference.html. The actual value though is `true` as `[CPNumber numberWithBool:YES]` does not return a number but a boolean. This commit fixes this issue.
