### PR TITLE
Fixed: editing textFields on different windows can clobber each others contents

### DIFF
--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -692,7 +692,7 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
 {
 #if PLATFORM(DOM)
     // We might have been the first responder without actually editing.
-    if (_isEditing)
+    if (_isEditing && CPTextFieldInputOwner === self)
     {
         var element = [self _inputElement],
             newValue = element.value,


### PR DESCRIPTION
Was caused by resignFirstResponder not checking that the input owner is self.
Full credits go to BlairDuncan

Fixes #1983
