### PR TITLE
Fixed: _editingCellIndex is currently not considered when table columns are pressed

### DIFF
--- a/AppKit/CPTableHeaderView.j
+++ b/AppKit/CPTableHeaderView.j
@@ -333,7 +333,7 @@ var _CPTableColumnHeaderViewStringValueKey = @"_CPTableColumnHeaderViewStringVal
         var headerView = [_tableView._tableColumns[column] headerView];
         [headerView setThemeState:CPThemeStateHighlighted];
 
-        if (_tableView._editingColumn == column)
+        if (_tableView._editingCellIndex || _tableView._editingColumn == column)
             [[self window] makeFirstResponder:_tableView];
     }
 


### PR DESCRIPTION
without this patch, in-place editing in CPTableViews may clobber data when sorting via table header during editing. Credits go to Blair for working out the fix.

Fixes #2012
