### PR TITLE
Fixed: when doubleClicking to open/close a sheet, issues with the parentWindow and the frameOrigin of the sheet

### DIFF
--- a/AppKit/CPWindow/CPWindow.j
+++ b/AppKit/CPWindow/CPWindow.j
@@ -1699,11 +1699,17 @@ CPTexturedBackgroundWindowMask
         switch (type)
         {
             case CPLeftMouseDown:
+
+                // This is needed when a doubleClick occurs when the sheet is closing or opening
+                if (!_parentWindow)
+                    return;
+
                 [_windowView mouseDown:anEvent];
 
                 // -dw- if the window is clicked, the sheet should come to front, and become key,
                 // and the window should be immediately behind
                 [sheet makeKeyAndOrderFront:self];
+
                 return;
 
             case CPMouseMoved:


### PR DESCRIPTION
When opening a sheet, with a double click the frame origin of the sheet changed and the parent disappeared.
This PR fix this issue.

Test app in Tests/Manual/AttachedSheet/AppController.j
