### PR TITLE
Fixed: textual CPDatePicker with only date and not time breaks tab-navigation through the keyView loop

### DIFF
--- a/AppKit/CPDatePicker/_CPDatePickerTextField.j
+++ b/AppKit/CPDatePicker/_CPDatePickerTextField.j
@@ -318,7 +318,7 @@ var CPZeroKeyCode = 48,
             if (peek=[_lastTextField nextKeyView])
             {   while ([peek isDescendantOf: _datePicker] && (peek=[peek nextKeyView])) {}
                 if (![peek canBecomeKeyView])
-                    peek= nextValidKeyView;
+                    peek=nextValidKeyView;
                 [[self window] makeFirstResponder: peek];
             }
             return YES;


### PR DESCRIPTION
Without this patch, the selection is stuck in the CPDatePicker.
With this pull request applied, you can tab-cylcle to the next textfield after the CPDatePicker as expected.
