### PR TITLE
Fixed: CPNumber>>numberWithBool: breaks CPComparisonPredicate

### DIFF
--- a/Foundation/CPPredicate/CPComparisonPredicate.j
+++ b/Foundation/CPPredicate/CPComparisonPredicate.j
@@ -374,6 +374,9 @@ var CPComparisonPredicateModifier,
     var leftValue = [_left expressionValueWithObject:object context:variables],
         rightValue = [_right expressionValueWithObject:object context:variables];
 
+    leftValue = (typeof leftValue == "boolean") ? [CPNumber numberWithBool:leftValue] : leftValue;
+    rightValue = (typeof rightValue == "boolean") ? [CPNumber numberWithBool:rightValue] : rightValue;
+
     if (_modifier == CPDirectPredicateModifier)
         return [self _evaluateValue:leftValue rightValue:rightValue];
     else


### PR DESCRIPTION
Commit df2be92 breaks CPComparisonPredicate if one side of the comparison is a property which returns a BOOL.

CPPredicateParser parses literal BOOLs (YES/NO) into 0/1 using CPNumber>>numberWithBool:. CPComparisonPredicate however does not cast a BOOL from a property using numberWithBool:. E.g.

[[YES,NO] filteredArrayUsingPredicate:[CPPredicate predicateWithFormat:'self = YES']]
used to return [true], now it returns [].

This fix addresses the issue by "typecasting" the lhs/rhs values to numbers using CPNumber>>numberWithBool: if they are of type boolean.

Fixes #2028
