### PR TITLE
Fixed: CPTextField raised Error when using CPDateFormatter with ""

### DIFF
--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -1134,7 +1134,8 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
 
             // Formatting failed, get an "empty" object by formatting an empty string.
             // If that fails, the value is undefined.
-            if ([formatter getObjectValue:@ref(value) forString:@"" errorDescription:nil] === NO)
+            var formatterErrorMessage;
+            if ([formatter getObjectValue:@ref(value) forString:@"" errorDescription:@ref(formatterErrorMessage)] === NO)
                 value = undefined;
 
             [super setObjectValue:value];


### PR DESCRIPTION
CPDateFormatter expects a CPStringRef as error description. CPTextField did only provide nil which raised an error because it couldn't be @deref'ed.

This fix replaces nil with a @ref'ed variable.
