### PR TITLE
New: Added bidirectional CPLevelIndicator behaviour

### DIFF
--- a/AppKit/CPLevelIndicator.j
+++ b/AppKit/CPLevelIndicator.j
@@ -105,10 +105,21 @@ CPRatingLevelIndicatorStyle                 = 3;
     var filledColor = [self valueForThemeAttribute:@"color-normal"],
         value = [self doubleValue];
 
-    if (value <= _criticalValue)
-        filledColor = [self valueForThemeAttribute:@"color-critical"];
-    else if (value <= _warningValue)
-        filledColor = [self valueForThemeAttribute:@"color-warning"];
+    if (_warningValue < _criticalValue)
+    {
+        if (value >= _criticalValue)
+            filledColor = [self valueForThemeAttribute:@"color-critical"];
+        else if (value >= _warningValue)
+            filledColor = [self valueForThemeAttribute:@"color-warning"];
+    }
+    else
+    {
+        if (value <= _criticalValue)
+            filledColor = [self valueForThemeAttribute:@"color-critical"];
+        else if (value <= _warningValue)
+            filledColor = [self valueForThemeAttribute:@"color-warning"];
+    }
+
 
     for (var i = 0; i < segmentCount; i++)
     {


### PR DESCRIPTION
Depending on whether min < max or max > min CPLevelIndicator changes the order of the normal/warning/critical color. This commit enables this behavior for both cases.
