### PR TITLE
FIXED: CPSegementedControl with nib2cib crashes

### DIFF
--- a/AppKit/CPSegmentedControl.j
+++ b/AppKit/CPSegmentedControl.j
@@ -476,10 +476,13 @@ CPSegmentSwitchTrackingMomentary = 2;
 */
 - (void)drawSegmentBezel:(int)aSegment highlight:(BOOL)shouldHighlight
 {
-    if (shouldHighlight)
-        _themeStates[aSegment] = _themeStates[aSegment].and(CPThemeStateHighlighted);
-    else
-        _themeStates[aSegment] = _themeStates[aSegment].without(CPThemeStateHighlighted);
+    if(aSegment<_themeStates.length)
+    {
+        if (shouldHighlight)
+            _themeStates[aSegment] = _themeStates[aSegment].and(CPThemeStateHighlighted);
+        else
+            _themeStates[aSegment] = _themeStates[aSegment].without(CPThemeStateHighlighted);
+    }
 
     [self setNeedsLayout];
     [self setNeedsDisplay:YES];


### PR DESCRIPTION
When having a CPSegmentedControl within a a XIB files, nib2cib crashes with the following error:

```
'undefined' is not an object (evaluating 'self._themeStates[aSegment].without')
```

This pull request fixes the problem by making sure that the drawBezel method is called with a valid segment index when accessing the themeState.

Reduction: https://dl.dropboxusercontent.com/u/14629300/BugCPSegmentedControl.zip
