### PR TITLE
New: Graphical CPDatePicker clicking on the arrows with key mask Command/Control/Alternate

### DIFF
--- a/AppKit/CPDatePicker/_CPDatePickerCalendar.j
+++ b/AppKit/CPDatePicker/_CPDatePickerCalendar.j
@@ -30,6 +30,7 @@
 
 @class CPDatePicker
 
+@global CPApp
 @global CPSingleDateMode
 @global CPRangeDateMode
 
@@ -42,6 +43,10 @@
 @global CPYearMonthDatePickerElementFlag
 @global CPYearMonthDayDatePickerElementFlag
 @global CPEraDatePickerElementFlag
+
+@global CPAlternateKeyMask
+@global CPCommandKeyMask
+@global CPControlKeyMask
 
 var CPShortWeekDayNameArrayEn = [@"Mo", @"Tu", @"We", @"Th", @"Fr", @"Sa", @"Su"],
     CPShortWeekDayNameArrayUS = [@"Su", @"Mo", @"Tu", @"We", @"Th", @"Fr", @"Sa"],
@@ -223,16 +228,62 @@ var CPShortWeekDayNameArrayEn = [@"Mo", @"Tu", @"We", @"Th", @"Fr", @"Sa", @"Su"
 
 /*! Move to the nextMonth without changing the dateValue of the datePicker
 */
-- (void)_nextMonth:(id)sender
+- (void)_clickArrowNext:(id)sender
 {
-    [self setDateValue:[_monthView nextMonth]];
+    var currentEvent = [CPApp currentEvent],
+        modifierFlags = [currentEvent modifierFlags];
+
+    if (modifierFlags & (CPCommandKeyMask | CPControlKeyMask | CPAlternateKeyMask))
+    {
+        var date = [[_monthView monthDate] copy];
+        date.setDate(1);
+
+        if (modifierFlags & CPAlternateKeyMask)
+            date.setUTCFullYear(date.getUTCFullYear() + 10);
+        else
+            date.setUTCFullYear(date.getUTCFullYear() + 1);
+
+        [self setDateValue:date];
+    }
+    else
+    {
+         [self _displayNextMonth];
+    }
+}
+
+- (void)_displayNextMonth
+{
+     [self setDateValue:[_monthView nextMonth]];
+}
+
+- (void)_displayPreviousMonth
+{
+    [self setDateValue:[_monthView previousMonth]];
 }
 
 /*! Move to the previous month without changing the dateValue of the datePicker
 */
-- (void)_previousMonth:(id)sender
+- (void)_clickArrowPrevious:(id)sender
 {
-    [self setDateValue:[_monthView previousMonth]];
+    var currentEvent = [CPApp currentEvent],
+        modifierFlags = [currentEvent modifierFlags];
+
+    if (modifierFlags & (CPCommandKeyMask | CPControlKeyMask | CPAlternateKeyMask))
+    {
+        var date = [[_monthView monthDate] copy];
+        date.setDate(1);
+
+        if (modifierFlags & CPAlternateKeyMask)
+            date.setUTCFullYear(date.getUTCFullYear() - 10);
+        else
+            date.setUTCFullYear(date.getUTCFullYear() - 1);
+
+        [self setDateValue:date];
+    }
+    else
+    {
+         [self _displayPreviousMonth];
+    }
 }
 
 /*! Move to the current selected day
@@ -334,10 +385,10 @@ var CPShortWeekDayNameArrayEn = [@"Mo", @"Tu", @"We", @"Th", @"Fr", @"Sa", @"Su"
         [self addSubview:_currentButton];
 
         [_previousButton setTarget:aDelegate];
-        [_previousButton setAction:@selector(_previousMonth:)];
+        [_previousButton setAction:@selector(_clickArrowPrevious:)];
 
         [_nextButton setTarget:aDelegate];
-        [_nextButton setAction:@selector(_nextMonth:)];
+        [_nextButton setAction:@selector(_clickArrowNext:)];
 
         [_currentButton setTarget:aDelegate];
         [_currentButton setAction:@selector(_currentMonth:)];
@@ -861,9 +912,9 @@ var CPShortWeekDayNameArrayEn = [@"Mo", @"Tu", @"We", @"Th", @"Fr", @"Sa", @"Su"
     {
         // Check the year and the month. The year is usefull when changing from Jan to Dec.
         if (_date.getMonth() - [dayTile date].getMonth() == 1 || _date.getFullYear() - [dayTile date].getFullYear() == 1)
-            [_delegate _previousMonth:self];
+            [_delegate _displayPreviousMonth];
         else
-            [_delegate _nextMonth:self];
+            [_delegate _displayNextMonth];
     }
 }
 
@@ -899,9 +950,9 @@ var CPShortWeekDayNameArrayEn = [@"Mo", @"Tu", @"We", @"Th", @"Fr", @"Sa", @"Su"
 
             // Check the year and the month. The year is usefull when changing from Jan to Dec.
             if (_date.getMonth() - [dayTile date].getMonth() == 1 || _date.getFullYear() - [dayTile date].getFullYear() == 1)
-                [_delegate _previousMonth:self];
+                [_delegate _displayPreviousMonth];
             else
-                [_delegate _nextMonth:self];
+                [_delegate _displayNextMonth];
         }
     }
     else
@@ -944,7 +995,7 @@ var CPShortWeekDayNameArrayEn = [@"Mo", @"Tu", @"We", @"Th", @"Fr", @"Sa", @"Su"
     if (_isMonthJustChanged)
     {
         _dragDate.setMonth(_date.getMonth() + 1);
-        [_delegate _nextMonth:self];
+        [_delegate _displayNextMonth];
     }
 }
 
@@ -953,7 +1004,7 @@ var CPShortWeekDayNameArrayEn = [@"Mo", @"Tu", @"We", @"Th", @"Fr", @"Sa", @"Su"
     if (_isMonthJustChanged)
     {
         _dragDate.setMonth(_date.getMonth() - 1);
-        [_delegate _previousMonth:self];
+        [_delegate _displayPreviousMonth];
     }
 }
 

--- a/AppKit/CPDatePicker/_CPDatePickerTextField.j
+++ b/AppKit/CPDatePicker/_CPDatePickerTextField.j
@@ -525,7 +525,7 @@ var CPZeroKeyCode = 48,
 #pragma mark -
 #pragma mark Responder methods
 
-- (BOOL)acceptFirstResponder
+- (BOOL)acceptsFirstResponder
 {
     return NO;
 }


### PR DESCRIPTION
Now when clicking on the arrows with the key mask Command/Control or Alternate change the date to 1 year or 10 years as in Cocoa.

Fixed a typo in _CPDatePickerTextField.j also.
