### PR TITLE
Fixed: editing textFields on different windows can clobber each others contents

### DIFF
--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -1148,7 +1148,7 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
 
 #if PLATFORM(DOM)
 
-    if (CPTextFieldInputOwner === self || [[self window] firstResponder] === self)
+    if ((CPTextFieldInputOwner === self || [[self window] firstResponder] === self) && [[self window] isKeyWindow])
         [self _inputElement].value = _stringValue;
 
 #endif


### PR DESCRIPTION
before this patch, textfields with bindings would clobber content when switching windows under certain circumstances. this is because the shared fieldeditor must not be overwritten when beeing firstresponder but not in the key window.
after this patch, the issue is fixed.
