### PR TITLE
Fixed: path is wrong with local copy

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -206,6 +206,7 @@ done
 
 github_project="$github_user-cappuccino-base"
 github_path="$github_user/cappuccino-base"
+local_project="cappuccino-base"
 
 # The purpose of bootstrap is to install Cappuccino.
 install_cappuccino="yes"
@@ -317,9 +318,9 @@ if [ "$install_cappuccino" ]; then
         unzip $quiet_arg "$local_distrib" -d "$install_directory"
         check_and_exit
 
-        mv "$install_directory/$github_project-"*/* "$install_directory/."
+        mv "$install_directory/$local_project-"*/* "$install_directory/."
         check_and_exit
-        rm -rf "$install_directory/$github_project-"*
+        rm -rf "$install_directory/$local_project-"*
         check_and_exit
     else
         zip_ball="https://github.com/$github_path/zipball/$github_ref"


### PR DESCRIPTION
Previously when using a local copy to install Cappuccino, we used to copy the local capp-base at /usr/local/narwhal and then we tried to move /usr/local/narwhal/cappuccino-cappuccino-base_/_ to /usr/local/narwhal/. .
Now we move /usr/local/narwhal/cappuccino-base_/_ to /usr/local/narwhal/. .
