### PR TITLE
Have CPWindow setContentView check that the new view is not the same as the existing content view

### DIFF
--- a/AppKit/CPWindow/CPWindow.j
+++ b/AppKit/CPWindow/CPWindow.j
@@ -1110,7 +1110,7 @@ CPTexturedBackgroundWindowMask
 */
 - (void)setContentView:(CPView)aView
 {
-    if (_contentView)
+    if (_contentView && _contentView !== aView)
         [_contentView removeFromSuperview];
 
     var bounds = CGRectMake(0.0, 0.0, CGRectGetWidth(_frame), CGRectGetHeight(_frame));


### PR DESCRIPTION
Not doing this check results in a lot of unnecessary removeFromSuperview calls.  

Other than the performance hit, the other problem is that popover windows lose their first responder.  This happens because this code always calls setContentView on the popoverWindow even if the content view hasn't changed:

https://github.com/cappuccino/cappuccino/blob/master/AppKit/CPPopover.j#L247

The first time a popover is created, this is fine, because the first responder gets set by this:

https://github.com/cappuccino/cappuccino/blob/master/AppKit/CPWindow/CPWindow.j#L1481

However, the next time you open the popover, CPWindow ends up re-setting the content view to the same thing.  This is mostly fine, except it also clears out its first responder here when the content view first gets removed from its superview:

https://github.com/cappuccino/cappuccino/blob/master/AppKit/CPView.j#L719

And then when you re-add the content view and open the popover, _hasBecomeKeyWindow is true for the Window (since it's not a new window), so the code path that sets up the first responder again never gets hit.  This means you end up with the _CPPopoverWindow becoming the first responder.
