### PR TITLE
New: capp_lint is installed with jake install

### DIFF
--- a/Tools/Jakefile
+++ b/Tools/Jakefile
@@ -2,6 +2,6 @@
 require("../common.jake");
 
 // nib2cib uses fontinfo and imagesize and capp uses nib2cib
-subtasks(["fontinfo", "imagesize", "nib2cib", "capp", "dump_theme", "NativeHost", "XcodeCapp"], ["build"/*, "clean", "clobber"*/]);
+subtasks(["fontinfo", "imagesize", "nib2cib", "capp", "capp_lint", "dump_theme", "NativeHost", "XcodeCapp"], ["build"/*, "clean", "clobber"*/]);
 
 subtasks(["fontinfo", "imagesize"], ["clean", "clobber"]);

--- a/Tools/capp_lint/Jakefile
+++ b/Tools/capp_lint/Jakefile
@@ -1,0 +1,12 @@
+
+require ("../../common.jake");
+
+var OS = require("os"),
+    task = require("jake").task;
+
+task ("build", function()
+{
+    sudo(["./install.sh"]);
+});
+
+task ("default", ["build"]);

--- a/Tools/capp_lint/install.sh
+++ b/Tools/capp_lint/install.sh
@@ -2,11 +2,11 @@
 
 chmod +x capp_lint
 
-if [[ ! -d /usr/local/bin ]]; then
-    sudo mkdir -p /usr/local/bin
+if [[ ! -d /usr/local/narwhal/bin ]]; then
+    sudo mkdir -p /usr/local/narwhal/bin
 fi
 
-sudo cp capp_lint /usr/local/bin
+sudo cp capp_lint /usr/local/narwhal/bin
 
 if [[ ! -d /usr/local/share/man/man1 ]]; then
     sudo mkdir -p /usr/local/share/man/man1


### PR DESCRIPTION
Previously we had to install capp_lint separately from Cappuccino.
Now capp_lint will be installed with Cappuccino.
Before capp_lint was installed in /urs/local/bin/, now it is in /usr/local/narwhal/bin/.
