### PR TITLE
Fixed: Variable scope in CPSegmentedControl.j

### DIFF
--- a/AppKit/CPSegmentedControl.j
+++ b/AppKit/CPSegmentedControl.j
@@ -679,7 +679,7 @@ CPSegmentSwitchTrackingMomentary = 2;
 
     var segment = _segments[aSegment],
         segmentWidth = [segment width],
-        themeState = _themeState.hasThemeState(CPThemeStateDisabled) ? _themeStates[aSegment].and(CPThemeStateDisabled) : _themeStates[aSegment];
+        themeState = _themeState.hasThemeState(CPThemeStateDisabled) ? _themeStates[aSegment].and(CPThemeStateDisabled) : _themeStates[aSegment],
         contentInset = [self valueForThemeAttribute:@"content-inset" inState:themeState],
         font = [self font];
 


### PR DESCRIPTION
Previously, an errant semicolon resulted in improperly scoped variables in CPSegmentedControl.

This fix removes the semicolon in favour of a comma.

Fixes #2117
