### PR TITLE
Fixed: bootstrap doesn't handle specific OpenJDK Runtime Environment version

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -134,8 +134,8 @@ function check_install_environment () {
     java_version=$(java -version 2>&1)
     echo $java_version | grep OpenJDK > /dev/null
     if [ "$?" = "0" ]; then # OpenJDK: make sure >= 6b18
-        openjdk_version=$(echo $java_version | egrep -o '[0-9]b[0-9]+')
-        if [ $(echo $openjdk_version | tr -d 'b') -lt 618 ]; then
+        openjdk_version=$(echo $java_version | egrep -o '[0-9]\-?b[0-9]+')
+        if [ $(echo $openjdk_version | tr -d 'b' | tr -d '-') -lt 618 ]; then
             echo "Error: Narwhal is not compatible with your version of OpenJDK: $openjdk_version."
             echo "Please upgrade to OpenJDK >= 6b18 or switch to the Sun JVM. Then re-run bootstrap.sh."
             exit 1


### PR DESCRIPTION
Previously, bootstrap didn't handle some OpenJDK Runtime Environment version as: rhel-2.4.7.1.el6_5-x86_64 u55-b13.
Now it did, the regular expression to catch the version of the jdk was wrong.

Fixes #2113
