### PR TITLE
Fixed: CPDatePicker firstResponder issue

### DIFF
--- a/AppKit/CPDatePicker/CPDatePicker.j
+++ b/AppKit/CPDatePicker/CPDatePicker.j
@@ -533,7 +533,7 @@ CPEraDatePickerElementFlag              = 0x0100;
 {
     if (_datePickerStyle == CPTextFieldAndStepperDatePickerStyle || _datePickerStyle == CPTextFieldDatePickerStyle)
     {
-        if ([super becomeFirstResponder])
+        if (![super becomeFirstResponder])
             return NO;
 
         [_datePickerTextfield _selecteTextFieldWithFlags:[[CPApp currentEvent] modifierFlags]];

--- a/AppKit/CPDatePicker/_CPDatePickerTextField.j
+++ b/AppKit/CPDatePicker/_CPDatePickerTextField.j
@@ -1226,14 +1226,14 @@ var CPMonthDateType = 0,
     CPTimer _timerEdition;
 }
 
-
-#pragma mark -
-#pragma mark Getter Setter methods
-
-- (BOOL)acceptFirstResponder
+- (id)init
 {
-    _firstEvent = YES;
-    return NO;
+    if (self = [super init])
+    {
+        _firstEvent = YES;
+    }
+
+    return self;
 }
 
 /*! Set the dateType of the textField


### PR DESCRIPTION
Previously, the textual datePicker didn't work because it couldn't become the firstResponder.
This PR fixed another issue as well. Previously it wasn't possible to modify a date when moving only with tab and when the datePicker came firstResponder with tabulation.
