### PR TITLE
Fixed: CPComboBox doesn't work in modal.

### DIFF
--- a/AppKit/_CPPopUpList.j
+++ b/AppKit/_CPPopUpList.j
@@ -863,6 +863,15 @@ var _CPPopUpListDataSourceKey   = @"_CPPopUpListDataSourceKey",
     return self;
 }
 
+/*!
+    Returns \c YES if the receiver is able to receive input events
+    even when a modal session is active.
+*/
+- (BOOL)worksWhenModal
+{
+    return YES;
+}
+
 - (void)sendEvent:(CPEvent)anEvent
 {
     var type = [anEvent type];


### PR DESCRIPTION
Previously a CPComboBox didn't work when its parent window was in modal. Now it works.

Fixed #2122
