### PR TITLE
NEW: support for documentVisibleRect

### DIFF
--- a/AppKit/CPClipView.j
+++ b/AppKit/CPClipView.j
@@ -230,6 +230,11 @@
     return [self scrollToPoint:CGPointMake(bounds.origin.x - deltaX, bounds.origin.y - deltaY)];
 }
 
+- (CGRect)documentVisibleRect
+{
+    return [self convertRect:[self bounds] fromView:_documentView];
+}
+
 @end
 
 

--- a/AppKit/CPScrollView.j
+++ b/AppKit/CPScrollView.j
@@ -1262,6 +1262,10 @@ Notifies the delegate when the scroll view has finished scrolling.
     [self reflectScrolledClipView:_contentView];
 }
 
+- (CGRect)documentVisibleRect
+{
+    return [_contentView documentVisibleRect];
+}
 
 #pragma mark -
 #pragma mark Overrides


### PR DESCRIPTION
currently, both scrollview and clipview do not support the documentVisibleRect method.
this is fixed by this PR.
all credits for the implementation go to cacaodev.
