### PR TITLE
Fixed: Crash of press tool due to theme attribute not set

### DIFF
--- a/AppKit/CPTheme.j
+++ b/AppKit/CPTheme.j
@@ -774,7 +774,7 @@ function CPThemeAttributeDecode(aCoder, anAttributeName, aDefaultValue, aTheme, 
     {
         var attribute = [aCoder decodeObjectForKey:key];
 
-        if (!attribute.isa || ![attribute isKindOfClass:[_CPThemeAttribute class]])
+        if (!attribute || !attribute.isa || ![attribute isKindOfClass:[_CPThemeAttribute class]])
         {
             var themeAttribute = [[_CPThemeAttribute alloc] initWithName:anAttributeName defaultValue:aDefaultValue];
 


### PR DESCRIPTION
When using the press tool, it can happen that one of the theme attribute is not set as not everything is instantiated. 

This fix makes sure that the attribute is set before accessing it to avoid any crash of the press tool.
