### PR TITLE
Fixed: Crash of press tool when having a CPWebView in a CIB

### DIFF
--- a/AppKit/CPWebView.j
+++ b/AppKit/CPWebView.j
@@ -363,7 +363,9 @@ CPWebViewAppKitScrollMaxPollCount                  = 3;
 
 - (void)_setEffectiveScrollMode:(int)aScrollMode
 {
-     if(!_iframe) return; // _iframe is not set when the class is instantiated in a CIB from the press tool.
+    // _iframe is not set when the class is instantiated in a CIB from the press tool.
+    if(!_iframe)
+        return;
      
     _effectiveScrollMode = aScrollMode;
 


### PR DESCRIPTION
This fixes the crash of the press tool when a CPWebView is included into a CIB.

In this case, the view is not added at all to the DOM so _iframe is not created but the scroll change method is anyway called. This fix makes sure that the _iframe is not accessed in this case.
