### PR TITLE
FIXED: CPCollectionView height is too low [+1]

### DIFF
--- a/AppKit/CPCollectionView.j
+++ b/AppKit/CPCollectionView.j
@@ -623,7 +623,7 @@ var HORIZONTAL_MARGIN = 2;
 
     height = MAX(height, numberOfRows * (_minItemSize.height + _verticalMargin));
 
-    var itemSizeHeight = itemSize.height;
+    var itemSizeHeight = FLOOR(height / numberOfRows) - _verticalMargin;
 
     if (maxItemSizeHeight > 0)
         itemSizeHeight = MIN(itemSizeHeight, maxItemSizeHeight);


### PR DESCRIPTION
Previously, the vertical margin was erroneously added to the item height.
this resulted in a truncation of  CPCollectionViewItems at the bottom.

this patch corrects this by subtracting the vertical margin from the calculated height.

this fixes #2145
