### PR TITLE
Fixed: escape on a panel or popover breaks the key chain event

### DIFF
--- a/AppKit/CPPanel.j
+++ b/AppKit/CPPanel.j
@@ -126,10 +126,17 @@ CPDocModalWindowMask    = 1 << 6;
 /*!
     @ignore
 */
-- (BOOL)_shouldCloseOnEscape
+- (void)cancelOperation:(id)sender
 {
-    [self performClose:self];
-    return YES;
+    if ([[CPApp currentEvent] _couldBeKeyEquivalent] && [self performKeyEquivalent:[CPApp currentEvent]])
+        return;
+
+    [[self firstResponder] tryToPerform:@selector(cancel:) with:self];
+}
+
+- (void)cancel:(id)sender
+{
+    [self performClose:sender];
 }
 
 @end

--- a/AppKit/CPWindow/CPWindow.j
+++ b/AppKit/CPWindow/CPWindow.j
@@ -1795,7 +1795,7 @@ CPTexturedBackgroundWindowMask
                 }
                 return didTabBack;
             }
-            else if ([anEvent charactersIgnoringModifiers] === CPEscapeFunctionKey && [self _shouldCloseOnEscape])
+            else if ([anEvent charactersIgnoringModifiers] == CPEscapeFunctionKey && [self _processKeyboardUIKey:anEvent])
             {
                 return;
             }
@@ -3021,28 +3021,9 @@ CPTexturedBackgroundWindowMask
     if ([selectors count] <= 0)
         return NO;
 
-    if (character !== CPEscapeFunctionKey)
-    {
-        var selector = [selectors objectAtIndex:0];
-        return [[self firstResponder] tryToPerform:selector with:self];
-    }
-    else
-    {
-        /*
-            Cocoa sends complete: for the escape key (instead of the default cancelOperation:). This is also the only action that is not sent directly to the first responder, but through doCommandBySelector. The difference is that doCommandBySelector: will also send the action to the window and application delegates.
-        */
-        [[self firstResponder] doCommandBySelector:@selector(complete:)];
-    }
+    var selector = [selectors objectAtIndex:0];
 
-    return NO;
-}
-
-/*!
-    @ignore
-*/
-- (BOOL)_shouldCloseOnEscape
-{
-    return NO;
+    return [[self firstResponder] tryToPerform:selector with:self];
 }
 
 - (void)_dirtyKeyViewLoop

--- a/AppKit/_CPPopoverWindow.j
+++ b/AppKit/_CPPopoverWindow.j
@@ -432,12 +432,18 @@ var _CPPopoverWindow_shouldClose_    = 1 << 4,
 /*!
     @ignore
 */
-- (BOOL)_shouldCloseOnEscape
+- (void)cancelOperation:(id)sender
+{
+    if ([[CPApp currentEvent] _couldBeKeyEquivalent] && [self performKeyEquivalent:[CPApp currentEvent]])
+        return;
+
+    [self cancel:self];
+}
+
+- (void)cancel:(id)sender
 {
     if (_closeOnBlur)
-        [[self delegate] performClose:self];
-
-    return YES;
+        [[self delegate] performClose:sender];
 }
 
 /*!


### PR DESCRIPTION
Previously when hitting escape on a CPPanel, the key chain event was broken.
Now when the user hit escape, cappuccino do the following process
- Check if the firstResponder or the chain of the nextResponder implement cancelOperation:
- If not, performKeyEquivalent on the firstResponder and so on
- If not, call the method cancel: on the firstResponder and the chain (not in the case of the CPPopover)

Previously, a complete: method was called if the user hit escape on a void window. This is not a feature of Cocoa, @aparajita  or @aljungberg can you confirm that ?

This commit is related to the commit #2139
