### PR TITLE
Fixed: #2157 - fixed issue with InvalidStateError when using CPURLConnection in IE11

### DIFF
--- a/Objective-J/CFHTTPRequest.js
+++ b/Objective-J/CFHTTPRequest.js
@@ -99,6 +99,7 @@ GLOBAL(CFHTTPRequest) = function()
     this._isOpen = false;
     this._requestHeaders = {};
     this._mimeType = null;
+    this._withCredentials = false;
 
     this._eventDispatcher = new EventDispatcher(this);
     this._nativeRequest = new NativeRequest();
@@ -224,7 +225,9 @@ CFHTTPRequest.prototype.open = function(/*String*/ aMethod, /*String*/ aURL, /*B
     this._method = aMethod;
     this._user = aUser;
     this._password = aPassword;
-    return this._nativeRequest.open(aMethod, aURL, isAsynchronous, aUser, aPassword);
+    var result = this._nativeRequest.open(aMethod, aURL, isAsynchronous, aUser, aPassword);
+    this._nativeRequest.withCredentials = this._withCredentials;
+    return result;
 };
 
 CFHTTPRequest.prototype.send = function(/*Object*/ aBody)
@@ -233,6 +236,7 @@ CFHTTPRequest.prototype.send = function(/*Object*/ aBody)
     {
         delete this._nativeRequest.onreadystatechange;
         this._nativeRequest.open(this._method, this._URL, this._async, this._user, this._password);
+        this._nativeRequest.withCredentials = this._withCredentials;
         this._nativeRequest.onreadystatechange = this._stateChangeHandler;
     }
 
@@ -276,12 +280,12 @@ CFHTTPRequest.prototype.removeEventListener = function(/*String*/ anEventName, /
 
 CFHTTPRequest.prototype.setWithCredentials = function(/*Boolean*/ willSendWithCredentials) 
 {
-    this._nativeRequest.withCredentials = willSendWithCredentials;
+    this.withCredentials = willSendWithCredentials;
 };
 
 CFHTTPRequest.prototype.getWithCredentials = function() 
 {
-    return this._nativeRequest.withCredentials;
+    return this.withCredentials;
 };
 
 function determineAndDispatchHTTPRequestEvents(/*CFHTTPRequest*/ aRequest)


### PR DESCRIPTION
Possible bug in XMLHTTPRequest with IE11.  Using CPURLConnection connectionWithRequest:delegate was throwing an InvalidStateError.  Apparently, this is a bug with IE11 - setting the credentials flag of XMLHTTPRequest must be done AFTER opening it.  I simply added an instance variable to CFHTTPRequest to act as the credential flag, then used that to set the credentials flag after opening XMLHTTPRequest.

Thanks to hmsimmonds for locating the following:

http://connect.microsoft.com/IE/feedback/details/795580/ie11-xmlhttprequest-incorrectly-throws-invalidstateerror-when-setting-responsetype

https://github.com/enyo/dropzone/issues/179

Refs: #2157
