### PR TITLE
set CPDatePicker elements to days, months, year when used within a CPPre...

### DIFF
--- a/AppKit/CPRuleEditor/CPPredicateEditorRowTemplate.j
+++ b/AppKit/CPRuleEditor/CPPredicateEditorRowTemplate.j
@@ -708,7 +708,10 @@ CPTransformableAttributeType = 1800;
         view = [[CPCheckBox alloc] initWithFrame:CGRectMake(0, 0, 50, 26)];
     }
     else if (attributeType == CPDateAttributeType)
+    {
         view = [[CPDatePicker alloc] initWithFrame:CGRectMake(0, 0, 180, 26)];
+        [view setDatePickerElements:CPYearMonthDayDatePickerElementFlag];
+    }
     else
         return nil;
 


### PR DESCRIPTION
In Cocoa, when creating a `CPPredicateEditor` with `rightExpressionAttributeType` parameter set to `CPDateAttributeType`, it shows a CPDatePicker with with days, months and years elements only.

This PR remove hours, minutes, seconds elements from the `CPPredicateEditorRowTemplate`.
