### PR TITLE
Fixed: textField bindings delete data in case of multiple selection after tabbing out with no editing

### DIFF
--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -1960,12 +1960,12 @@ var CPTextFieldIsEditableKey            = "CPTextFieldIsEditableKey",
 - (void)reverseSetValueFor:(CPString)aBinding
 {
     var destination = [_info objectForKey:CPObservedObjectKey],
-        keyPath = [_info objectForKey:CPObservedKeyPathKey],
-        options = [_info objectForKey:CPOptionsKey],
-        newValue = [self valueForBinding:aBinding],
-        value = [destination valueForKeyPath:keyPath];
+        keyPath     = [_info objectForKey:CPObservedKeyPathKey],
+        options     = [_info objectForKey:CPOptionsKey],
+        newValue    = [self valueForBinding:aBinding],
+        value       = [destination valueForKeyPath:keyPath];
 
-    if (CPIsControllerMarker(value) && newValue == nil) return;
+    if (CPIsControllerMarker(value) && newValue === nil) return;
 
     newValue = [self reverseTransformValue:newValue withOptions:options];
 


### PR DESCRIPTION
when an arraycontroller is bound to a textfield, we get a multiple selection placeholder when multiple rows are selected. when you click into this placeholder and tab out, this field is deleted in all selected rows.
this should happen only if editing actually took place.
the fix is to handle this cornercase by means of implementing reverseSetValueFor: in _CPTextFieldValueBinder

fixes #1514
