### PR TITLE
Fixed: Checking if a CPTextField is usable in a CPPlatformWindow

### DIFF
--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -1847,7 +1847,7 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
     if (!wind)
         return NO;
 
-    var frame = [self convertRectToBase:[self bounds]],
+    var frame = [self convertRectToBase:[self contentRectForBounds:[self bounds]]],
         usableRect = [[wind platformWindow] usableContentFrame];
 
     frame.origin = [wind convertBaseToGlobal:frame.origin];


### PR DESCRIPTION
Previously, when a CPTextField was in a CPPlatformWindow, the checking of if the CPTextField was usable or not (depending on its position) in a CPPlatformWindow didn't take in account the content-inset of the CPTextField. Now it does.
