### PR TITLE
Fixed: activateIgnoringOtherApps:shouldIgnoreOthe... missed call to _didBecomeActive 

### DIFF
--- a/AppKit/CPApplication.j
+++ b/AppKit/CPApplication.j
@@ -1173,7 +1173,7 @@ var CPMainCibFile               = @"CPMainCibFile",
         [[self keyWindow] orderFront:self];
     else if ([self mainWindow])
         [[self mainWindow] makeKeyAndOrderFront:self];
-    else
+    else if ([self mainMenu])
         [[self mainMenu]._menuWindow makeKeyWindow]; //FIXME this may not actually work
 
     _previousKeyWindow = nil;


### PR DESCRIPTION
Previously, - (void)activateIgnoringOtherApps:(BOOL)shouldIgnoreOtherApps failed to call _didBecomeActive but erroneously called _willResignActive at the end.
this is fixed by this PR.

all credits go to blair.

fixes #2156
