### PR TITLE
Fixed: delegate popover did show not called with a none animate CPPopover

### DIFF
--- a/AppKit/CPPopover.j
+++ b/AppKit/CPPopover.j
@@ -260,7 +260,7 @@ Set the behavior of the CPPopover. It can be:
     [_popoverWindow positionRelativeToRect:positioningRect ofView:positioningView preferredEdge:preferredEdge];
 
     if (![self isShown])
-        [self _popoverDidShow];
+        [self _popoverWindowDidShow];
 }
 
 - (unsigned)_styleMaskForBehavior


### PR DESCRIPTION
Previously, the delegate popoverDidShow wasn't called with an none animated CPPopover.
