### PR TITLE
Fixed: It cannot execute "jake" commands correctly in the Cappuccino rep...

### DIFF
--- a/narwhal.local.conf
+++ b/narwhal.local.conf
@@ -1,5 +1,11 @@
-if [ -z "$NARWHAL_ENGINE" ] && [ -d "$NARWHAL_HOME/packages/narwhal-jsc" ]; then
-	export NARWHAL_ENGINE=jsc
+if [ -z "$NARWHAL_ENGINE" ] && [ `uname` == "Darwin" ]; then
+    # We should check "narwhal-jsc.conf" and the corresponding executable to make sure JSC can be "$NARWHAL_ENGINE".
+    if [ -f "$NARWHAL_HOME/packages/narwhal-jsc/narwhal-jsc.conf" ]; then
+        source "$NARWHAL_HOME/packages/narwhal-jsc/narwhal-jsc.conf"
+    fi
+    if [ "$NARWHAL_JSC_MODE" ] && [ -f "$NARWHAL_HOME/packages/narwhal-jsc/bin/narwhal-$NARWHAL_JSC_MODE" ]; then
+        export NARWHAL_ENGINE=jsc
+    fi
 fi
 
 if [ "$NARWHAL_ENGINE" == jsc ] && [ `ulimit -n` -lt 1024 ]; then


### PR DESCRIPTION
...ository directory when it's not Apple OS.

When running "jake" commands in the repository directory, it will print:
$ jake --help
narwhal/packages/narwhal-jsc/bin/narwhal-jsc: line 33: narwhal/packages/narwhal-jsc/bin/narwhal-jscore: No such file or directory

Fixes #2181
