### PR TITLE
Fixed: wrong text-color for CPDatePicker

### DIFF
--- a/AppKit/Themes/Aristo/ThemeDescriptors.j
+++ b/AppKit/Themes/Aristo/ThemeDescriptors.j
@@ -1271,7 +1271,6 @@ var themedButtonValues = nil,
             [@"bezel-color",        bezelDisabledColor,                                         [CPThemeStateBezeled, CPThemeStateDisabled]],
 
             [@"font",               [CPFont boldSystemFontOfSize:13.0]],
-            [@"text-color",         [CPColor colorWithWhite:0.2 alpha:0.8]],
             [@"text-color",         textDisabledColor,                                          CPThemeStateDisabled],
 
             [@"content-inset",      CGInsetMake(6.0, 0.0, 0.0, 3.0),                            CPThemeStateNormal],

--- a/AppKit/Themes/Aristo2/ThemeDescriptors.j
+++ b/AppKit/Themes/Aristo2/ThemeDescriptors.j
@@ -837,8 +837,6 @@ var themedButtonValues = nil,
             [@"bezel-color",        bezelColor["disabled"],                                     [CPThemeStateBezeled, CPThemeStateDisabled]],
 
             [@"font",               [CPFont systemFontOfSize:CPFontCurrentSystemSize]],
-
-            [@"text-color",         [CPColor colorWithWhite:0.2 alpha:0.8]],
             [@"text-color",         [CPColor colorWithWhite:0.2 alpha:0.5],                     CPThemeStateDisabled],
 
             [@"content-inset",      CGInsetMake(6.0, 0.0, 0.0, 3.0),                            CPThemeStateNormal],


### PR DESCRIPTION
Previously the color of a CPDatePicker wasn't black as a CPTextField

Fixed #2188
