### PR TITLE
Fixed: CPDatePicker textual and graphical doesn't work in a CPTableView

### DIFF
--- a/AppKit/CPDatePicker/CPDatePicker.j
+++ b/AppKit/CPDatePicker/CPDatePicker.j
@@ -206,14 +206,10 @@ CPEraDatePickerElementFlag              = 0x0100;
         _locale = [CPLocale currentLocale];
 
     _datePickerTextfield = [[_CPDatePickerTextField alloc] initWithFrame:[self bounds] withDatePicker:self];
-
     [_datePickerTextfield setDateValue:_dateValue];
-    [self addSubview:_datePickerTextfield];
 
     _datePickerCalendar = [[_CPDatePickerCalendar alloc] initWithFrame:[self bounds] withDatePicker:self];
     [_datePickerCalendar setDateValue:_dateValue];
-    [_datePickerCalendar setHidden:YES];
-    [self addSubview:_datePickerCalendar];
 
     // We might have been unarchived in a disabled state.
     [_datePickerTextfield setEnabled:[self isEnabled]];
@@ -259,21 +255,30 @@ CPEraDatePickerElementFlag              = 0x0100;
 */
 - (void)layoutSubviews
 {
-
     [super layoutSubviews];
 
     if (_datePickerStyle == CPTextFieldAndStepperDatePickerStyle || _datePickerStyle == CPTextFieldDatePickerStyle)
     {
-        [_datePickerTextfield setHidden:NO];
-        [_datePickerCalendar setHidden:YES];
+        if (![_datePickerTextfield superview])
+            [self addSubview:_datePickerTextfield];
+
+        if ([_datePickerCalendar superview])
+            [_datePickerCalendar removeFromSuperview];
+
         [_datePickerTextfield setControlSize:[self controlSize]];
         [_datePickerTextfield setNeedsLayout];
+        [_datePickerTextfield setNeedsDisplay:YES];
     }
     else
     {
-        [_datePickerCalendar setHidden:NO];
-        [_datePickerTextfield setHidden:YES];
+        if (![_datePickerCalendar superview])
+            [self addSubview:_datePickerCalendar];
+
+        if ([_datePickerTextfield superview])
+            [_datePickerTextfield removeFromSuperview];
+
         [_datePickerCalendar setNeedsLayout];
+        [_datePickerCalendar setNeedsDisplay:YES];
     }
 }
 

--- a/AppKit/CPDatePicker/_CPDatePickerCalendar.j
+++ b/AppKit/CPDatePicker/_CPDatePickerCalendar.j
@@ -85,6 +85,7 @@ var CPShortWeekDayNameArrayEn = [@"Mo", @"Tu", @"We", @"Th", @"Fr", @"Sa", @"Su"
         _datePicker = aDatePicker
         [self _init];
     }
+
     return self;
 }
 
@@ -215,6 +216,8 @@ var CPShortWeekDayNameArrayEn = [@"Mo", @"Tu", @"We", @"Th", @"Fr", @"Sa", @"Su"
         [_headerView setHidden:YES];
         [_monthView setHidden:YES];
     }
+
+    [self setFrameSize:[_datePicker frameSize]];
 }
 
 
@@ -381,9 +384,11 @@ var CPShortWeekDayNameArrayEn = [@"Mo", @"Tu", @"We", @"Th", @"Fr", @"Sa", @"Su"
 
         [_previousButton setTarget:aDelegate];
         [_previousButton setAction:@selector(_clickArrowPrevious:)];
+        [_previousButton setContinuous:YES];
 
         [_nextButton setTarget:aDelegate];
         [_nextButton setAction:@selector(_clickArrowNext:)];
+        [_nextButton setContinuous:YES];
 
         [_currentButton setTarget:aDelegate];
         [_currentButton setAction:@selector(_currentMonth:)];
@@ -1258,14 +1263,6 @@ var CPShortWeekDayNameArrayEn = [@"Mo", @"Tu", @"We", @"Th", @"Fr", @"Sa", @"Su"
     CPDatePicker _datePicker @accessors(property=datePicker);
 }
 
-- (id)init
-{
-    if (self = [super init])
-    {
-    }
-    return self;
-}
-
 - (void)drawRect:(CGRect)aRect
 {
     [super drawRect:aRect];
@@ -1279,10 +1276,10 @@ var CPShortWeekDayNameArrayEn = [@"Mo", @"Tu", @"We", @"Th", @"Fr", @"Sa", @"Su"
         CGContextSetStrokeColor(context, [_datePicker valueForThemeAttribute:@"border-color" inState:[_datePicker themeState]]);
         CGContextSetLineWidth(context,  [_datePicker valueForThemeAttribute:@"border-width"]);
 
-        CGContextMoveToPoint(context, borderWidth,borderWidth);
-        CGContextAddLineToPoint(context, aRect.size.width - borderWidth,borderWidth);
-        CGContextAddLineToPoint(context, aRect.size.width - borderWidth,aRect.size.height - borderWidth);
-        CGContextAddLineToPoint(context, borderWidth,aRect.size.height - borderWidth);
+        CGContextMoveToPoint(context, borderWidth, borderWidth);
+        CGContextAddLineToPoint(context, aRect.size.width - borderWidth, borderWidth);
+        CGContextAddLineToPoint(context, aRect.size.width - borderWidth, aRect.size.height - borderWidth);
+        CGContextAddLineToPoint(context, borderWidth, aRect.size.height - borderWidth);
         CGContextAddLineToPoint(context, borderWidth,borderWidth);
 
         CGContextStrokePath(context);
@@ -1300,6 +1297,5 @@ var CPShortWeekDayNameArrayEn = [@"Mo", @"Tu", @"We", @"Th", @"Fr", @"Sa", @"Su"
     else
         [self setBackgroundColor:[CPColor clearColor]];
 }
-
 
 @end


### PR DESCRIPTION
Previously, when using a textual or graphical CPDatePicker in a CPTableView Cappuccino crashed.
This PR fix this issue by adding the subviews of a CPDatePicker in the method layoutSubviews instead of in the initialization.

This PR add another feature on the graphical CPDatePicker, the button next and previous month are now in the mode continuous as in Cocoa.
