### PR TITLE
Fixed: divs with negative z-indices are causing display issues in some versions of chrome.

### DIFF
--- a/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
@@ -1280,7 +1280,7 @@ var PreventScroll = true;
             insertionIndex = _windowLevels[middle] > aLevel ? middle : middle + 1
 
         [_windowLevels insertObject:aLevel atIndex:insertionIndex];
-        layer._DOMElement.style.zIndex = aLevel + 1;
+        layer._DOMElement.style.zIndex = aLevel + 1;  // adding one avoids negative zIndices. These have been causing issues in Chrome
 
         _DOMBodyElement.appendChild(layer._DOMElement);
     }


### PR DESCRIPTION
this is a workaround that simply bumps the zIndex by 1 in order to avoid the level -1.
see @primalmotion ' s comment at https://groups.google.com/forum/#!topic/objectivej/SBwWcl75CqI
