### PR TITLE
Fixed: backspace on a none editable/enable field trigger the browser's page back button

### DIFF
--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -981,6 +981,9 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
 
 - (void)keyDown:(CPEvent)anEvent
 {
+    if (!([self isEnabled] && [self isEditable]))
+        return;
+
     // CPTextField uses an HTML input element to take the input so we need to
     // propagate the dom event so the element is updated. This has to be done
     // before interpretKeyEvents: though so individual commands have a chance


### PR DESCRIPTION
Previously, when hitting the backspace key on a none editable/enable field, this triggered the browser's back button.
Now it does not anymore.

All credits for @apajarita

Fixed #2189
