### PR TITLE
Fixed: CPBinder unbindAllForObject did not work.

### DIFF
--- a/AppKit/CPKeyValueBinding.j
+++ b/AppKit/CPKeyValueBinding.j
@@ -116,7 +116,7 @@ var CPBindingOperationAnd = 0,
         count = allKeys.length;
 
     while (count--)
-        [anObject unbind:[bindings objectForKey:allKeys[count]]];
+        [anObject unbind:allKeys[count]];
 
     [bindingsMap removeObjectForKey:[anObject UID]];
 }


### PR DESCRIPTION
Previously, calling CPBinder unbindObjectForKey would not actually unbind each of the bindings because it was passing the wrong object to the unbind method which would silently ignore the issue. The commit passes the correct parameter to allow unbinding to actually take place.

Fixes #2197.
