### PR TITLE
Fixed: autocomplete and spellcheck attributes introduce cross-browser inconsistencies

### DIFF
--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -255,8 +255,9 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
         CPTextFieldDOMInputElement.style.whiteSpace = "pre";
         CPTextFieldDOMInputElement.style.background = "transparent";
         CPTextFieldDOMInputElement.style.outline = "none";
-	CPTextFieldDOMInputElement.setAttribute("autocomplete", "off");
-	CPTextFieldDOMInputElement.setAttribute("spellcheck", false);
+
+        CPTextFieldDOMInputElement.setAttribute("autocomplete", "off");
+        CPTextFieldDOMInputElement.setAttribute("spellcheck", false);
 
         CPTextFieldBlurHandler = function(anEvent)
         {


### PR DESCRIPTION
This PR simply turns these (non-standard?) properties off.

We already have autocompletion with CPComboBox
If we wanted spell-checking, we would have to go with CPSpellChecker anyway.

Fixes #571
