### PR TITLE
Fixed: withCredentials IE fix (#2158) fails with Firefox

### DIFF
--- a/Foundation/CPURLConnection.j
+++ b/Foundation/CPURLConnection.j
@@ -114,9 +114,11 @@ var CPURLConnectionDelegate = nil;
 
 + (CPData)_sendSynchronousRequest:(CPURLRequest)aRequest returningResponse:(/*{*/CPURLResponse/*}*/)aURLResponse withCFHTTPRequest:(CFHTTPRequest)aCFHTTPRequest
 {
+    var isIE = CPBrowserIsEngine(CPInternetExplorerBrowserEngine);
+
     try
     {
-        aCFHTTPRequest.open([aRequest HTTPMethod], [[aRequest URL] absoluteString], NO);
+        aCFHTTPRequest.open([aRequest HTTPMethod], [[aRequest URL] absoluteString], NO, isIE);
 
         var fields = [aRequest allHTTPHeaderFields],
             key = nil,
@@ -219,9 +221,11 @@ var CPURLConnectionDelegate = nil;
 
     _HTTPRequest.setWithCredentials(_withCredentials);
 
+    var isIE = CPBrowserIsEngine(CPInternetExplorerBrowserEngine);
+
     try
     {
-        _HTTPRequest.open([_request HTTPMethod], [[_request URL] absoluteString], YES);
+        _HTTPRequest.open([_request HTTPMethod], [[_request URL] absoluteString], YES, nil, nil, isIE);
 
         _HTTPRequest.onreadystatechange = function() { [self _readyStateDidChange]; };
 


### PR DESCRIPTION
Further work had to be done on this issue due to Firefox not liking the IE11 fix.  I've isolated the IE fix for only IE browsers.  CFHTTPRequest now takes an "isIE" flag to decide whether to set withCredentials before (not IE) or after (IE) opening the XMLHTTPRequest.

Refs: #2157
