### PR TITLE
Fixed: CPDatePicker send an action with the methods setObjectValue: and setDateValue: [+1]

### DIFF
--- a/AppKit/CPDatePicker/CPDatePicker.j
+++ b/AppKit/CPDatePicker/CPDatePicker.j
@@ -75,6 +75,7 @@ CPEraDatePickerElementFlag              = 0x0100;
     CPInteger       _datePickerStyle    @accessors(property=datePickerStyle);
     CPInteger       _timeInterval       @accessors(property=timeInterval);
 
+    BOOL                    _invokedByUserEvent;
     _CPDatePickerTextField  _datePickerTextfield;
     _CPDatePickerCalendar   _datePickerCalendar;
     unsigned                _implementedCDatePickerDelegateMethods;
@@ -312,6 +313,7 @@ CPEraDatePickerElementFlag              = 0x0100;
     if (aDateValue == nil)
         return;
 
+    _invokedByUserEvent = NO;
     [self _setDateValue:aDateValue timeInterval:_timeInterval];
 }
 
@@ -359,7 +361,8 @@ CPEraDatePickerElementFlag              = 0x0100;
     _timeInterval = (_datePickerMode == CPSingleDateMode)? 0 : aTimeInterval;
     [self didChangeValueForKey:@"timeInterval"];
 
-    [self sendAction:[self action] to:[self target]];
+    if (_invokedByUserEvent)
+        [self sendAction:[self action] to:[self target]];
 
     if (_datePickerStyle == CPTextFieldAndStepperDatePickerStyle || _datePickerStyle == CPTextFieldDatePickerStyle)
         [_datePickerTextfield setDateValue:_dateValue];

--- a/AppKit/CPDatePicker/_CPDatePickerCalendar.j
+++ b/AppKit/CPDatePicker/_CPDatePickerCalendar.j
@@ -896,6 +896,8 @@ var CPShortWeekDayNameArrayEn = [@"Mo", @"Tu", @"We", @"Th", @"Fr", @"Sa", @"Su"
     _indexDayTile = -1;
     _eventDragged = nil
 
+    _datePicker._invokedByUserEvent = YES;
+
     // Check if we have to change or not the month of the component
     if ([dayTile date].getMonth() == _date.getMonth())
     {
@@ -948,6 +950,8 @@ var CPShortWeekDayNameArrayEn = [@"Mo", @"Tu", @"We", @"Th", @"Fr", @"Sa", @"Su"
         else
             [_delegate _displayNextMonth];
     }
+
+    _datePicker._invokedByUserEvent = NO;
 }
 
 /*! Mouse dragged event
@@ -964,6 +968,8 @@ var CPShortWeekDayNameArrayEn = [@"Mo", @"Tu", @"We", @"Th", @"Fr", @"Sa", @"Su"
     _dragDate = [dateTile copy];
     _indexDayTile = [self indexOfTileForEvent:anEvent];
     _eventDragged = anEvent;
+
+    _datePicker._invokedByUserEvent = YES;
 
     if ([_datePicker datePickerMode] == CPSingleDateMode)
     {
@@ -1006,6 +1012,8 @@ var CPShortWeekDayNameArrayEn = [@"Mo", @"Tu", @"We", @"Th", @"Fr", @"Sa", @"Su"
                 [_datePicker _setDateValue:[self _hoursMinutesSecondsFromDatePickerForDate:_clickDate] timeInterval:[dateTile timeIntervalSinceDate:dateValueAtMidnight]];
         }
     }
+
+    _datePicker._invokedByUserEvent = NO;
 }
 
 - (void)mouseUp:(CPEvent)anEvent

--- a/AppKit/CPDatePicker/_CPDatePickerTextField.j
+++ b/AppKit/CPDatePicker/_CPDatePickerTextField.j
@@ -679,7 +679,9 @@ var CPZeroKeyCode = 48,
             dateValue.setHours(dateValue.getHours() - 12);
     }
 
-    [_datePicker setDateValue:dateValue];
+    _datePicker._invokedByUserEvent = YES;
+    [_datePicker _setDateValue:dateValue timeInterval:[_datePicker timeInterval]];
+    _datePicker._invokedByUserEvent = NO;
 }
 
 
@@ -1636,7 +1638,9 @@ var CPMonthDateType = 0,
         newDateValue.setSeconds(newDateValue.getSeconds() + secondsFromGMT - secondsFromGMTTimeZone);
     }
 
-    [_datePicker setDateValue:newDateValue];
+    _datePicker._invokedByUserEvent = YES;
+    [_datePicker _setDateValue:newDateValue timeInterval:[_datePicker timeInterval]];
+    _datePicker._invokedByUserEvent = NO;
 }
 
 


### PR DESCRIPTION
Previously, the CPDatePicker sent an action to the target when the method setObjectValue: and setDateValue were called.
Now it sends the action only when the user makes an action.

Fixed #2206
