### PR TITLE
Fixed: objj.vim is too old and has some bugs.

### DIFF
--- a/Tools/Editors/Vim/c.vim
+++ b/Tools/Editors/Vim/c.vim
@@ -1,0 +1,427 @@
+" Vim syntax file
+" Language:	C
+" Maintainer:	Bram Moolenaar <Bram@vim.org>
+" Last Change:	2012 Jan 14
+
+" Quit when a (custom) syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+" A bunch of useful C keywords
+syn keyword	cStatement	goto break return continue asm
+syn keyword	cLabel		case default
+syn keyword	cConditional	if else switch
+syn keyword	cRepeat		while for do
+
+syn keyword	cTodo		contained TODO FIXME XXX
+
+" It's easy to accidentally add a space after a backslash that was intended
+" for line continuation.  Some compilers allow it, which makes it
+" unpredicatable and should be avoided.
+syn match	cBadContinuation contained "\\\s\+$"
+
+" cCommentGroup allows adding matches for special things in comments
+syn cluster	cCommentGroup	contains=cTodo,cBadContinuation
+
+" String and Character constants
+" Highlight special characters (those which have a backslash) differently
+syn match	cSpecial	display contained "\\\(x\x\+\|\o\{1,3}\|.\|$\)"
+if !exists("c_no_utf")
+  syn match	cSpecial	display contained "\\\(u\x\{4}\|U\x\{8}\)"
+endif
+if exists("c_no_cformat")
+  syn region	cString		start=+L\="+ skip=+\\\\\|\\"+ end=+"+ contains=cSpecial,@Spell
+  " cCppString: same as cString, but ends at end of line
+  syn region	cCppString	start=+L\="+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end='$' contains=cSpecial,@Spell
+else
+  if !exists("c_no_c99") " ISO C99
+    syn match	cFormat		display "%\(\d\+\$\)\=[-+' #0*]*\(\d*\|\*\|\*\d\+\$\)\(\.\(\d*\|\*\|\*\d\+\$\)\)\=\([hlLjzt]\|ll\|hh\)\=\([aAbdiuoxXDOUfFeEgGcCsSpn]\|\[\^\=.[^]]*\]\)" contained
+  else
+    syn match	cFormat		display "%\(\d\+\$\)\=[-+' #0*]*\(\d*\|\*\|\*\d\+\$\)\(\.\(\d*\|\*\|\*\d\+\$\)\)\=\([hlL]\|ll\)\=\([bdiuoxXDOUfeEgGcCsSpn]\|\[\^\=.[^]]*\]\)" contained
+  endif
+  syn match	cFormat		display "%%" contained
+  syn region	cString		start=+L\="+ skip=+\\\\\|\\"+ end=+"+ contains=cSpecial,cFormat,@Spell
+  " cCppString: same as cString, but ends at end of line
+  syn region	cCppString	start=+L\="+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end='$' contains=cSpecial,cFormat,@Spell
+endif
+
+syn match	cCharacter	"L\='[^\\]'"
+syn match	cCharacter	"L'[^']*'" contains=cSpecial
+if exists("c_gnu")
+  syn match	cSpecialError	"L\='\\[^'\"?\\abefnrtv]'"
+  syn match	cSpecialCharacter "L\='\\['\"?\\abefnrtv]'"
+else
+  syn match	cSpecialError	"L\='\\[^'\"?\\abfnrtv]'"
+  syn match	cSpecialCharacter "L\='\\['\"?\\abfnrtv]'"
+endif
+syn match	cSpecialCharacter display "L\='\\\o\{1,3}'"
+syn match	cSpecialCharacter display "'\\x\x\{1,2}'"
+syn match	cSpecialCharacter display "L'\\x\x\+'"
+
+if !exists("c_no_c11") " ISO C11
+  if exists("c_no_cformat")
+    syn region	cString		start=+\%(U\|u8\=\)"+ skip=+\\\\\|\\"+ end=+"+ contains=cSpecial,@Spell
+  else
+    syn region	cString		start=+\%(U\|u8\=\)"+ skip=+\\\\\|\\"+ end=+"+ contains=cSpecial,cFormat,@Spell
+  endif
+  syn match	cCharacter	"[Uu]'[^\\]'"
+  syn match	cCharacter	"[Uu]'[^']*'" contains=cSpecial
+  if exists("c_gnu")
+    syn match	cSpecialError	"[Uu]'\\[^'\"?\\abefnrtv]'"
+    syn match	cSpecialCharacter "[Uu]'\\['\"?\\abefnrtv]'"
+  else
+    syn match	cSpecialError	"[Uu]'\\[^'\"?\\abfnrtv]'"
+    syn match	cSpecialCharacter "[Uu]'\\['\"?\\abfnrtv]'"
+  endif
+  syn match	cSpecialCharacter display "[Uu]'\\\o\{1,3}'"
+  syn match	cSpecialCharacter display "[Uu]'\\x\x\+'"
+endif
+
+"when wanted, highlight trailing white space
+if exists("c_space_errors")
+  if !exists("c_no_trail_space_error")
+    syn match	cSpaceError	display excludenl "\s\+$"
+  endif
+  if !exists("c_no_tab_space_error")
+    syn match	cSpaceError	display " \+\t"me=e-1
+  endif
+endif
+
+" This should be before cErrInParen to avoid problems with #define ({ xxx })
+if exists("c_curly_error")
+  syntax match cCurlyError "}"
+  syntax region	cBlock		start="{" end="}" contains=ALLBUT,cBadBlock,cCurlyError,@cParenGroup,cErrInParen,cCppParen,cErrInBracket,cCppBracket,cCppString,@Spell fold
+else
+  syntax region	cBlock		start="{" end="}" transparent fold
+endif
+
+"catch errors caused by wrong parenthesis and brackets
+" also accept <% for {, %> for }, <: for [ and :> for ] (C99)
+" But avoid matching <::.
+syn cluster	cParenGroup	contains=cParenError,cIncluded,cSpecial,cCommentSkip,cCommentString,cComment2String,@cCommentGroup,cCommentStartError,cUserCont,cUserLabel,cBitField,cOctalZero,@cCppOutInGroup,cFormat,cNumber,cFloat,cOctal,cOctalError,cNumbersCom
+if exists("c_no_curly_error")
+  syn region	cParen		transparent start='(' end=')' end='}'me=s-1 contains=ALLBUT,cBlock,@cParenGroup,cCppParen,cCppString,@Spell
+  " cCppParen: same as cParen but ends at end-of-line; used in cDefine
+  syn region	cCppParen	transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@cParenGroup,cParen,cString,@Spell
+  syn match	cParenError	display ")"
+  syn match	cErrInParen	display contained "^[{}]\|^<%\|^%>"
+elseif exists("c_no_bracket_error")
+  syn region	cParen		transparent start='(' end=')' end='}'me=s-1 contains=ALLBUT,cBlock,@cParenGroup,cCppParen,cCppString,@Spell
+  " cCppParen: same as cParen but ends at end-of-line; used in cDefine
+  syn region	cCppParen	transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@cParenGroup,cParen,cString,@Spell
+  syn match	cParenError	display ")"
+  syn match	cErrInParen	display contained "[{}]\|<%\|%>"
+else
+  syn region	cParen		transparent start='(' end=')' end='}'me=s-1 contains=ALLBUT,cBlock,@cParenGroup,cCppParen,cErrInBracket,cCppBracket,cCppString,@Spell
+  " cCppParen: same as cParen but ends at end-of-line; used in cDefine
+  syn region	cCppParen	transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@cParenGroup,cErrInBracket,cParen,cBracket,cString,@Spell
+  syn match	cParenError	display "[\])]"
+  syn match	cErrInParen	display contained "[\]{}]\|<%\|%>"
+  syn region	cBracket	transparent start='\[\|<::\@!' end=']\|:>' end='}'me=s-1 contains=ALLBUT,cBlock,@cParenGroup,cErrInParen,cCppParen,cCppBracket,cCppString,@Spell
+  " cCppBracket: same as cParen but ends at end-of-line; used in cDefine
+  syn region	cCppBracket	transparent start='\[\|<::\@!' skip='\\$' excludenl end=']\|:>' end='$' contained contains=ALLBUT,@cParenGroup,cErrInParen,cParen,cBracket,cString,@Spell
+  syn match	cErrInBracket	display contained "[);{}]\|<%\|%>"
+endif
+
+syntax region	cBadBlock	keepend extend start="{" end="}" contained containedin=cParen,cBracket,cBadBlock transparent fold
+
+"integer number, or floating point number without a dot and with "f".
+syn case ignore
+syn match	cNumbers	display transparent "\<\d\|\.\d" contains=cNumber,cFloat,cOctalError,cOctal
+" Same, but without octal error (for comments)
+syn match	cNumbersCom	display contained transparent "\<\d\|\.\d" contains=cNumber,cFloat,cOctal
+syn match	cNumber		display contained "\d\+\(u\=l\{0,2}\|ll\=u\)\>"
+"hex number
+syn match	cNumber		display contained "0x\x\+\(u\=l\{0,2}\|ll\=u\)\>"
+" Flag the first zero of an octal number as something special
+syn match	cOctal		display contained "0\o\+\(u\=l\{0,2}\|ll\=u\)\>" contains=cOctalZero
+syn match	cOctalZero	display contained "\<0"
+syn match	cFloat		display contained "\d\+f"
+"floating point number, with dot, optional exponent
+syn match	cFloat		display contained "\d\+\.\d*\(e[-+]\=\d\+\)\=[fl]\="
+"floating point number, starting with a dot, optional exponent
+syn match	cFloat		display contained "\.\d\+\(e[-+]\=\d\+\)\=[fl]\=\>"
+"floating point number, without dot, with exponent
+syn match	cFloat		display contained "\d\+e[-+]\=\d\+[fl]\=\>"
+if !exists("c_no_c99")
+  "hexadecimal floating point number, optional leading digits, with dot, with exponent
+  syn match	cFloat		display contained "0x\x*\.\x\+p[-+]\=\d\+[fl]\=\>"
+  "hexadecimal floating point number, with leading digits, optional dot, with exponent
+  syn match	cFloat		display contained "0x\x\+\.\=p[-+]\=\d\+[fl]\=\>"
+endif
+
+" flag an octal number with wrong digits
+syn match	cOctalError	display contained "0\o*[89]\d*"
+syn case match
+
+if exists("c_comment_strings")
+  " A comment can contain cString, cCharacter and cNumber.
+  " But a "*/" inside a cString in a cComment DOES end the comment!  So we
+  " need to use a special type of cString: cCommentString, which also ends on
+  " "*/", and sees a "*" at the start of the line as comment again.
+  " Unfortunately this doesn't very well work for // type of comments :-(
+  syntax match	cCommentSkip	contained "^\s*\*\($\|\s\+\)"
+  syntax region cCommentString	contained start=+L\=\\\@<!"+ skip=+\\\\\|\\"+ end=+"+ end=+\*/+me=s-1 contains=cSpecial,cCommentSkip
+  syntax region cComment2String	contained start=+L\=\\\@<!"+ skip=+\\\\\|\\"+ end=+"+ end="$" contains=cSpecial
+  syntax region  cCommentL	start="//" skip="\\$" end="$" keepend contains=@cCommentGroup,cComment2String,cCharacter,cNumbersCom,cSpaceError,@Spell
+  if exists("c_no_comment_fold")
+    " Use "extend" here to have preprocessor lines not terminate halfway a
+    " comment.
+    syntax region cComment	matchgroup=cCommentStart start="/\*" end="\*/" contains=@cCommentGroup,cCommentStartError,cCommentString,cCharacter,cNumbersCom,cSpaceError,@Spell extend
+  else
+    syntax region cComment	matchgroup=cCommentStart start="/\*" end="\*/" contains=@cCommentGroup,cCommentStartError,cCommentString,cCharacter,cNumbersCom,cSpaceError,@Spell fold extend
+  endif
+else
+  syn region	cCommentL	start="//" skip="\\$" end="$" keepend contains=@cCommentGroup,cSpaceError,@Spell
+  if exists("c_no_comment_fold")
+    syn region	cComment	matchgroup=cCommentStart start="/\*" end="\*/" contains=@cCommentGroup,cCommentStartError,cSpaceError,@Spell extend
+  else
+    syn region	cComment	matchgroup=cCommentStart start="/\*" end="\*/" contains=@cCommentGroup,cCommentStartError,cSpaceError,@Spell fold extend
+  endif
+endif
+" keep a // comment separately, it terminates a preproc. conditional
+syntax match	cCommentError	display "\*/"
+syntax match	cCommentStartError display "/\*"me=e-1 contained
+
+syn keyword	cOperator	sizeof
+if exists("c_gnu")
+  syn keyword	cStatement	__asm__
+  syn keyword	cOperator	typeof __real__ __imag__
+endif
+syn keyword	cType		int long short char void
+syn keyword	cType		signed unsigned float double
+if !exists("c_no_ansi") || exists("c_ansi_typedefs")
+  syn keyword   cType		size_t ssize_t off_t wchar_t ptrdiff_t sig_atomic_t fpos_t
+  syn keyword   cType		clock_t time_t va_list jmp_buf FILE DIR div_t ldiv_t
+  syn keyword   cType		mbstate_t wctrans_t wint_t wctype_t
+endif
+if !exists("c_no_c99") " ISO C99
+  syn keyword	cType		_Bool bool _Complex complex _Imaginary imaginary
+  syn keyword	cType		int8_t int16_t int32_t int64_t
+  syn keyword	cType		uint8_t uint16_t uint32_t uint64_t
+  syn keyword	cType		int_least8_t int_least16_t int_least32_t int_least64_t
+  syn keyword	cType		uint_least8_t uint_least16_t uint_least32_t uint_least64_t
+  syn keyword	cType		int_fast8_t int_fast16_t int_fast32_t int_fast64_t
+  syn keyword	cType		uint_fast8_t uint_fast16_t uint_fast32_t uint_fast64_t
+  syn keyword	cType		intptr_t uintptr_t
+  syn keyword	cType		intmax_t uintmax_t
+endif
+if exists("c_gnu")
+  syn keyword	cType		__label__ __complex__ __volatile__
+endif
+
+syn keyword	cStructure	struct union enum typedef
+syn keyword	cStorageClass	static register auto volatile extern const
+if exists("c_gnu")
+  syn keyword	cStorageClass	inline __attribute__
+endif
+if !exists("c_no_c99")
+  syn keyword	cStorageClass	inline restrict
+endif
+if !exists("c_no_c11")
+  syn keyword	cStorageClass	_Alignas alignas
+  syn keyword	cOperator	_Alignof alignof
+  syn keyword	cStorageClass	_Atomic
+  syn keyword	cOperator	_Generic
+  syn keyword	cStorageClass	_Noreturn noreturn
+  syn keyword	cOperator	_Static_assert static_assert
+  syn keyword	cStorageClass	_Thread_local thread_local
+  syn keyword   cType		char16_t char32_t
+endif
+
+if !exists("c_no_ansi") || exists("c_ansi_constants") || exists("c_gnu")
+  if exists("c_gnu")
+    syn keyword cConstant __GNUC__ __FUNCTION__ __PRETTY_FUNCTION__ __func__
+  endif
+  syn keyword cConstant __LINE__ __FILE__ __DATE__ __TIME__ __STDC__
+  syn keyword cConstant __STDC_VERSION__
+  syn keyword cConstant CHAR_BIT MB_LEN_MAX MB_CUR_MAX
+  syn keyword cConstant UCHAR_MAX UINT_MAX ULONG_MAX USHRT_MAX
+  syn keyword cConstant CHAR_MIN INT_MIN LONG_MIN SHRT_MIN
+  syn keyword cConstant CHAR_MAX INT_MAX LONG_MAX SHRT_MAX
+  syn keyword cConstant SCHAR_MIN SINT_MIN SLONG_MIN SSHRT_MIN
+  syn keyword cConstant SCHAR_MAX SINT_MAX SLONG_MAX SSHRT_MAX
+  if !exists("c_no_c99")
+    syn keyword cConstant __func__
+    syn keyword cConstant LLONG_MIN LLONG_MAX ULLONG_MAX
+    syn keyword cConstant INT8_MIN INT16_MIN INT32_MIN INT64_MIN
+    syn keyword cConstant INT8_MAX INT16_MAX INT32_MAX INT64_MAX
+    syn keyword cConstant UINT8_MAX UINT16_MAX UINT32_MAX UINT64_MAX
+    syn keyword cConstant INT_LEAST8_MIN INT_LEAST16_MIN INT_LEAST32_MIN INT_LEAST64_MIN
+    syn keyword cConstant INT_LEAST8_MAX INT_LEAST16_MAX INT_LEAST32_MAX INT_LEAST64_MAX
+    syn keyword cConstant UINT_LEAST8_MAX UINT_LEAST16_MAX UINT_LEAST32_MAX UINT_LEAST64_MAX
+    syn keyword cConstant INT_FAST8_MIN INT_FAST16_MIN INT_FAST32_MIN INT_FAST64_MIN
+    syn keyword cConstant INT_FAST8_MAX INT_FAST16_MAX INT_FAST32_MAX INT_FAST64_MAX
+    syn keyword cConstant UINT_FAST8_MAX UINT_FAST16_MAX UINT_FAST32_MAX UINT_FAST64_MAX
+    syn keyword cConstant INTPTR_MIN INTPTR_MAX UINTPTR_MAX
+    syn keyword cConstant INTMAX_MIN INTMAX_MAX UINTMAX_MAX
+    syn keyword cConstant PTRDIFF_MIN PTRDIFF_MAX SIG_ATOMIC_MIN SIG_ATOMIC_MAX
+    syn keyword cConstant SIZE_MAX WCHAR_MIN WCHAR_MAX WINT_MIN WINT_MAX
+  endif
+  syn keyword cConstant FLT_RADIX FLT_ROUNDS
+  syn keyword cConstant FLT_DIG FLT_MANT_DIG FLT_EPSILON
+  syn keyword cConstant DBL_DIG DBL_MANT_DIG DBL_EPSILON
+  syn keyword cConstant LDBL_DIG LDBL_MANT_DIG LDBL_EPSILON
+  syn keyword cConstant FLT_MIN FLT_MAX FLT_MIN_EXP FLT_MAX_EXP
+  syn keyword cConstant FLT_MIN_10_EXP FLT_MAX_10_EXP
+  syn keyword cConstant DBL_MIN DBL_MAX DBL_MIN_EXP DBL_MAX_EXP
+  syn keyword cConstant DBL_MIN_10_EXP DBL_MAX_10_EXP
+  syn keyword cConstant LDBL_MIN LDBL_MAX LDBL_MIN_EXP LDBL_MAX_EXP
+  syn keyword cConstant LDBL_MIN_10_EXP LDBL_MAX_10_EXP
+  syn keyword cConstant HUGE_VAL CLOCKS_PER_SEC NULL
+  syn keyword cConstant LC_ALL LC_COLLATE LC_CTYPE LC_MONETARY
+  syn keyword cConstant LC_NUMERIC LC_TIME
+  syn keyword cConstant SIG_DFL SIG_ERR SIG_IGN
+  syn keyword cConstant SIGABRT SIGFPE SIGILL SIGHUP SIGINT SIGSEGV SIGTERM
+  " Add POSIX signals as well...
+  syn keyword cConstant SIGABRT SIGALRM SIGCHLD SIGCONT SIGFPE SIGHUP
+  syn keyword cConstant SIGILL SIGINT SIGKILL SIGPIPE SIGQUIT SIGSEGV
+  syn keyword cConstant SIGSTOP SIGTERM SIGTRAP SIGTSTP SIGTTIN SIGTTOU
+  syn keyword cConstant SIGUSR1 SIGUSR2
+  syn keyword cConstant _IOFBF _IOLBF _IONBF BUFSIZ EOF WEOF
+  syn keyword cConstant FOPEN_MAX FILENAME_MAX L_tmpnam
+  syn keyword cConstant SEEK_CUR SEEK_END SEEK_SET
+  syn keyword cConstant TMP_MAX stderr stdin stdout
+  syn keyword cConstant EXIT_FAILURE EXIT_SUCCESS RAND_MAX
+  " Add POSIX errors as well
+  syn keyword cConstant E2BIG EACCES EAGAIN EBADF EBADMSG EBUSY
+  syn keyword cConstant ECANCELED ECHILD EDEADLK EDOM EEXIST EFAULT
+  syn keyword cConstant EFBIG EILSEQ EINPROGRESS EINTR EINVAL EIO EISDIR
+  syn keyword cConstant EMFILE EMLINK EMSGSIZE ENAMETOOLONG ENFILE ENODEV
+  syn keyword cConstant ENOENT ENOEXEC ENOLCK ENOMEM ENOSPC ENOSYS
+  syn keyword cConstant ENOTDIR ENOTEMPTY ENOTSUP ENOTTY ENXIO EPERM
+  syn keyword cConstant EPIPE ERANGE EROFS ESPIPE ESRCH ETIMEDOUT EXDEV
+  " math.h
+  syn keyword cConstant M_E M_LOG2E M_LOG10E M_LN2 M_LN10 M_PI M_PI_2 M_PI_4
+  syn keyword cConstant M_1_PI M_2_PI M_2_SQRTPI M_SQRT2 M_SQRT1_2
+endif
+if !exists("c_no_c99") " ISO C99
+  syn keyword cConstant true false
+endif
+
+" Accept %: for # (C99)
+syn region	cPreCondit	start="^\s*\(%:\|#\)\s*\(if\|ifdef\|ifndef\|elif\)\>" skip="\\$" end="$" keepend contains=cComment,cCommentL,cCppString,cCharacter,cCppParen,cParenError,cNumbers,cCommentError,cSpaceError
+syn match	cPreConditMatch	display "^\s*\(%:\|#\)\s*\(else\|endif\)\>"
+if !exists("c_no_if0")
+  syn cluster	cCppOutInGroup	contains=cCppInIf,cCppInElse,cCppInElse2,cCppOutIf,cCppOutIf2,cCppOutElse,cCppInSkip,cCppOutSkip
+  syn region	cCppOutWrapper	start="^\s*\(%:\|#\)\s*if\s\+0\+\s*\($\|//\|/\*\|&\)" end=".\@=\|$" contains=cCppOutIf,cCppOutElse fold
+  syn region	cCppOutIf	contained start="0\+" matchgroup=cCppOutWrapper end="^\s*\(%:\|#\)\s*endif\>" contains=cCppOutIf2,cCppOutElse
+  if !exists("c_no_if0_fold")
+    syn region	cCppOutIf2	contained matchgroup=cCppOutWrapper start="0\+" end="^\s*\(%:\|#\)\s*\(else\>\|elif\s\+\(0\+\s*\($\|//\|/\*\|&\)\)\@!\|endif\>\)"me=s-1 contains=cSpaceError,cCppOutSkip fold
+  else
+    syn region	cCppOutIf2	contained matchgroup=cCppOutWrapper start="0\+" end="^\s*\(%:\|#\)\s*\(else\>\|elif\s\+\(0\+\s*\($\|//\|/\*\|&\)\)\@!\|endif\>\)"me=s-1 contains=cSpaceError,cCppOutSkip
+  endif
+  syn region	cCppOutElse	contained matchgroup=cCppOutWrapper start="^\s*\(%:\|#\)\s*\(else\|elif\)" end="^\s*\(%:\|#\)\s*endif\>"me=s-1 contains=TOP,cPreCondit
+  syn region	cCppInWrapper	start="^\s*\(%:\|#\)\s*if\s\+0*[1-9]\d*\s*\($\|//\|/\*\||\)" end=".\@=\|$" contains=cCppInIf,cCppInElse fold
+  syn region	cCppInIf	contained matchgroup=cCppInWrapper start="\d\+" end="^\s*\(%:\|#\)\s*endif\>" contains=TOP,cPreCondit
+  if !exists("c_no_if0_fold")
+    syn region	cCppInElse	contained start="^\s*\(%:\|#\)\s*\(else\>\|elif\s\+\(0*[1-9]\d*\s*\($\|//\|/\*\||\)\)\@!\)" end=".\@=\|$" containedin=cCppInIf contains=cCppInElse2 fold
+  else
+    syn region	cCppInElse	contained start="^\s*\(%:\|#\)\s*\(else\>\|elif\s\+\(0*[1-9]\d*\s*\($\|//\|/\*\||\)\)\@!\)" end=".\@=\|$" containedin=cCppInIf contains=cCppInElse2
+  endif
+  syn region	cCppInElse2	contained matchgroup=cCppInWrapper start="^\s*\(%:\|#\)\s*\(else\|elif\)\([^/]\|/[^/*]\)*" end="^\s*\(%:\|#\)\s*endif\>"me=s-1 contains=cSpaceError,cCppOutSkip
+  syn region	cCppOutSkip	contained start="^\s*\(%:\|#\)\s*\(if\>\|ifdef\>\|ifndef\>\)" skip="\\$" end="^\s*\(%:\|#\)\s*endif\>" contains=cSpaceError,cCppOutSkip
+  syn region	cCppInSkip	contained matchgroup=cCppInWrapper start="^\s*\(%:\|#\)\s*\(if\s\+\(\d\+\s*\($\|//\|/\*\||\|&\)\)\@!\|ifdef\>\|ifndef\>\)" skip="\\$" end="^\s*\(%:\|#\)\s*endif\>" containedin=cCppOutElse,cCppInIf,cCppInSkip contains=TOP,cPreProc
+endif
+syn region	cIncluded	display contained start=+"+ skip=+\\\\\|\\"+ end=+"+
+syn match	cIncluded	display contained "<[^>]*>"
+syn match	cInclude	display "^\s*\(%:\|#\)\s*include\>\s*["<]" contains=cIncluded
+"syn match cLineSkip	"\\$"
+syn cluster	cPreProcGroup	contains=cPreCondit,cIncluded,cInclude,cDefine,cErrInParen,cErrInBracket,cUserLabel,cSpecial,cOctalZero,cCppOutWrapper,cCppInWrapper,@cCppOutInGroup,cFormat,cNumber,cFloat,cOctal,cOctalError,cNumbersCom,cString,cCommentSkip,cCommentString,cComment2String,@cCommentGroup,cCommentStartError,cParen,cBracket,cMulti
+syn region	cDefine		start="^\s*\(%:\|#\)\s*\(define\|undef\)\>" skip="\\$" end="$" keepend contains=ALLBUT,@cPreProcGroup,@Spell
+syn region	cPreProc	start="^\s*\(%:\|#\)\s*\(pragma\>\|line\>\|warning\>\|warn\>\|error\>\)" skip="\\$" end="$" keepend contains=ALLBUT,@cPreProcGroup,@Spell
+
+" Highlight User Labels
+syn cluster	cMultiGroup	contains=cIncluded,cSpecial,cCommentSkip,cCommentString,cComment2String,@cCommentGroup,cCommentStartError,cUserCont,cUserLabel,cBitField,cOctalZero,cCppOutWrapper,cCppInWrapper,@cCppOutInGroup,cFormat,cNumber,cFloat,cOctal,cOctalError,cNumbersCom,cCppParen,cCppBracket,cCppString
+syn region	cMulti		transparent start='?' skip='::' end=':' contains=ALLBUT,@cMultiGroup,@Spell
+" Avoid matching foo::bar() in C++ by requiring that the next char is not ':'
+syn cluster	cLabelGroup	contains=cUserLabel
+syn match	cUserCont	display "^\s*\I\i*\s*:$" contains=@cLabelGroup
+syn match	cUserCont	display ";\s*\I\i*\s*:$" contains=@cLabelGroup
+syn match	cUserCont	display "^\s*\I\i*\s*:[^:]"me=e-1 contains=@cLabelGroup
+syn match	cUserCont	display ";\s*\I\i*\s*:[^:]"me=e-1 contains=@cLabelGroup
+
+syn match	cUserLabel	display "\I\i*" contained
+
+" Avoid recognizing most bitfields as labels
+syn match	cBitField	display "^\s*\I\i*\s*:\s*[1-9]"me=e-1 contains=cType
+syn match	cBitField	display ";\s*\I\i*\s*:\s*[1-9]"me=e-1 contains=cType
+
+if exists("c_minlines")
+  let b:c_minlines = c_minlines
+else
+  if !exists("c_no_if0")
+    let b:c_minlines = 50	" #if 0 constructs can be long
+  else
+    let b:c_minlines = 15	" mostly for () constructs
+  endif
+endif
+if exists("c_curly_error")
+  syn sync fromstart
+else
+  exec "syn sync ccomment cComment minlines=" . b:c_minlines
+endif
+
+" Define the default highlighting.
+" Only used when an item doesn't have highlighting yet
+hi def link cFormat		cSpecial
+hi def link cCppString		cString
+hi def link cCommentL		cComment
+hi def link cCommentStart	cComment
+hi def link cLabel		Label
+hi def link cUserLabel		Label
+hi def link cConditional	Conditional
+hi def link cRepeat		Repeat
+hi def link cCharacter		Character
+hi def link cSpecialCharacter	cSpecial
+hi def link cNumber		Number
+hi def link cOctal		Number
+hi def link cOctalZero		PreProc	 " link this to Error if you want
+hi def link cFloat		Float
+hi def link cOctalError		cError
+hi def link cParenError		cError
+hi def link cErrInParen		cError
+hi def link cErrInBracket	cError
+hi def link cCommentError	cError
+hi def link cCommentStartError	cError
+hi def link cSpaceError		cError
+hi def link cSpecialError	cError
+hi def link cCurlyError		cError
+hi def link cOperator		Operator
+hi def link cStructure		Structure
+hi def link cStorageClass	StorageClass
+hi def link cInclude		Include
+hi def link cPreProc		PreProc
+hi def link cDefine		Macro
+hi def link cIncluded		cString
+hi def link cError		Error
+hi def link cStatement		Statement
+hi def link cCppInWrapper	cCppOutWrapper
+hi def link cCppOutWrapper	cPreCondit
+hi def link cPreConditMatch	cPreCondit
+hi def link cPreCondit		PreCondit
+hi def link cType		Type
+hi def link cConstant		Constant
+hi def link cCommentString	cString
+hi def link cComment2String	cString
+hi def link cCommentSkip	cComment
+hi def link cString		String
+hi def link cComment		Comment
+hi def link cSpecial		SpecialChar
+hi def link cTodo		Todo
+hi def link cBadContinuation	Error
+hi def link cCppOutSkip		cCppOutIf2
+hi def link cCppInElse2		cCppOutIf2
+hi def link cCppOutIf2		cCppOut2  " Old syntax group for #if 0 body
+hi def link cCppOut2		cCppOut  " Old syntax group for #if of #if 0
+hi def link cCppOut		Comment
+
+let b:current_syntax = "c"
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+" vim: ts=8

--- a/Tools/Editors/Vim/javascript.vim
+++ b/Tools/Editors/Vim/javascript.vim
@@ -1,0 +1,135 @@
+" Vim syntax file
+" Language:	JavaScript
+" Maintainer:	Claudio Fleiner <claudio@fleiner.com>
+" Updaters:	Scott Shattuck (ss) <ss@technicalpursuit.com>
+" URL:		http://www.fleiner.com/vim/syntax/javascript.vim
+" Changes:	(ss) added keywords, reserved words, and other identifiers
+"		(ss) repaired several quoting and grouping glitches
+"		(ss) fixed regex parsing issue with multiple qualifiers [gi]
+"		(ss) additional factoring of keywords, globals, and members
+" Last Change:	2010 Mar 25
+
+" For version 5.x: Clear all syntax items
+" For version 6.x: Quit when a syntax file was already loaded
+" tuning parameters:
+" unlet javaScript_fold
+
+if !exists("main_syntax")
+  if version < 600
+    syntax clear
+  elseif exists("b:current_syntax")
+    finish
+  endif
+  let main_syntax = 'javascript'
+endif
+
+" Drop fold if it set but vim doesn't support it.
+if version < 600 && exists("javaScript_fold")
+  unlet javaScript_fold
+endif
+
+
+syn keyword javaScriptCommentTodo      TODO FIXME XXX TBD contained
+syn match   javaScriptLineComment      "\/\/.*" contains=@Spell,javaScriptCommentTodo
+syn match   javaScriptCommentSkip      "^[ \t]*\*\($\|[ \t]\+\)"
+syn region  javaScriptComment	       start="/\*"  end="\*/" contains=@Spell,javaScriptCommentTodo
+syn match   javaScriptSpecial	       "\\\d\d\d\|\\."
+syn region  javaScriptStringD	       start=+"+  skip=+\\\\\|\\"+  end=+"\|$+	contains=javaScriptSpecial,@htmlPreproc
+syn region  javaScriptStringS	       start=+'+  skip=+\\\\\|\\'+  end=+'\|$+	contains=javaScriptSpecial,@htmlPreproc
+
+syn match   javaScriptSpecialCharacter "'\\.'"
+syn match   javaScriptNumber	       "-\=\<\d\+L\=\>\|0[xX][0-9a-fA-F]\+\>"
+syn region  javaScriptRegexpString     start=+/[^/*]+me=e-1 skip=+\\\\\|\\/+ end=+/[gi]\{0,2\}\s*$+ end=+/[gi]\{0,2\}\s*[;.,)\]}]+me=e-1 contains=@htmlPreproc oneline
+
+syn keyword javaScriptConditional	if else switch
+syn keyword javaScriptRepeat		while for do in
+syn keyword javaScriptBranch		break continue
+syn keyword javaScriptOperator		new delete instanceof typeof
+syn keyword javaScriptType		Array Boolean Date Function Number Object String RegExp
+syn keyword javaScriptStatement		return with
+syn keyword javaScriptBoolean		true false
+syn keyword javaScriptNull		null undefined
+syn keyword javaScriptIdentifier	arguments this var let
+syn keyword javaScriptLabel		case default
+syn keyword javaScriptException		try catch finally throw
+syn keyword javaScriptMessage		alert confirm prompt status
+syn keyword javaScriptGlobal		self window top parent
+syn keyword javaScriptMember		document event location 
+syn keyword javaScriptDeprecated	escape unescape
+syn keyword javaScriptReserved		abstract boolean byte char class const debugger double enum export extends final float goto implements import int interface long native package private protected public short static super synchronized throws transient volatile 
+
+if exists("javaScript_fold")
+    syn match	javaScriptFunction	"\<function\>"
+    syn region	javaScriptFunctionFold	start="\<function\>.*[^};]$" end="^\z1}.*$" transparent fold keepend
+
+    syn sync match javaScriptSync	grouphere javaScriptFunctionFold "\<function\>"
+    syn sync match javaScriptSync	grouphere NONE "^}"
+
+    setlocal foldmethod=syntax
+    setlocal foldtext=getline(v:foldstart)
+else
+    syn keyword javaScriptFunction	function
+    syn match	javaScriptBraces	   "[{}\[\]]"
+    syn match	javaScriptParens	   "[()]"
+endif
+
+syn sync fromstart
+syn sync maxlines=100
+
+if main_syntax == "javascript"
+  syn sync ccomment javaScriptComment
+endif
+
+" Define the default highlighting.
+" For version 5.7 and earlier: only when not done already
+" For version 5.8 and later: only when an item doesn't have highlighting yet
+if version >= 508 || !exists("did_javascript_syn_inits")
+  if version < 508
+    let did_javascript_syn_inits = 1
+    command -nargs=+ HiLink hi link <args>
+  else
+    command -nargs=+ HiLink hi def link <args>
+  endif
+  HiLink javaScriptComment		Comment
+  HiLink javaScriptLineComment		Comment
+  HiLink javaScriptCommentTodo		Todo
+  HiLink javaScriptSpecial		Special
+  HiLink javaScriptStringS		String
+  HiLink javaScriptStringD		String
+  HiLink javaScriptCharacter		Character
+  HiLink javaScriptSpecialCharacter	javaScriptSpecial
+  HiLink javaScriptNumber		javaScriptValue
+  HiLink javaScriptConditional		Conditional
+  HiLink javaScriptRepeat		Repeat
+  HiLink javaScriptBranch		Conditional
+  HiLink javaScriptOperator		Operator
+  HiLink javaScriptType			Type
+  HiLink javaScriptStatement		Statement
+  HiLink javaScriptFunction		Function
+  HiLink javaScriptBraces		Function
+  HiLink javaScriptError		Error
+  HiLink javaScrParenError		javaScriptError
+  HiLink javaScriptNull			Keyword
+  HiLink javaScriptBoolean		Boolean
+  HiLink javaScriptRegexpString		String
+
+  HiLink javaScriptIdentifier		Identifier
+  HiLink javaScriptLabel		Label
+  HiLink javaScriptException		Exception
+  HiLink javaScriptMessage		Keyword
+  HiLink javaScriptGlobal		Keyword
+  HiLink javaScriptMember		Keyword
+  HiLink javaScriptDeprecated		Exception 
+  HiLink javaScriptReserved		Keyword
+  HiLink javaScriptDebug		Debug
+  HiLink javaScriptConstant		Label
+
+  delcommand HiLink
+endif
+
+let b:current_syntax = "javascript"
+if main_syntax == 'javascript'
+  unlet main_syntax
+endif
+
+" vim: ts=8

--- a/Tools/Editors/Vim/objj.vim
+++ b/Tools/Editors/Vim/objj.vim
@@ -1,51 +1,86 @@
 " Vim syntax file
-" Language:	Objective-J
-" Maintainer:	Shawn MacIntyre <sdm@openradical.com>
-" Updaters:	
-" URL:		
-" Changes:	(sm) merged javascript syntax Claudio Fleiner and Scott Shattuck and objc syntax by Kazunobu Kuriyama and Anthony Hodsdon 
-" Last Change:	2008 Sep 8
+" Language:             Objective-J
+" Maintainer:           Shawn MacIntyre <sdm@openradical.com>
+" First Author:         Shawn MacIntyre <sdm@openradical.com>
+" Updaters:             Kevin Xu <kevin.xu.1982.02.06@gmail.com>
+" Changes:              (sm) merged JavaScript syntax by
+"                          Claudio Fleiner & Scott Shattuck and
+"                          Objective-C syntax by
+"                          Valentino Kyriakides, Anthony Hodsdon & Kazunobu Kuriyama
+"                       (sm) modified 'objc.vim' to our 'objj.vim'
+"                          which reads 'javascript.vim' in the beginning.
+" Last Change:          2014 Sep 29
 
 " For version 5.x: Clear all syntax items
 " For version 6.x: Quit when a syntax file was already loaded
-" tuning parameters:
-" unlet objj_fold
-
-if !exists("main_syntax")
-  if version < 600
-    syntax clear
-  elseif exists("b:current_syntax")
-    finish
-  endif
-  let main_syntax = 'objj'
+if version < 600
+  syntax clear
+elseif exists("b:current_syntax")
+  finish
 endif
 
-" Drop fold if it set but vim doesn't support it.
-if version < 600 && exists("objj_fold")
-  unlet objj_fold
+" Read the JavaScript syntax to start with
+if version < 600
+  source <sfile>:p:h/javascript.vim
+else
+  runtime! syntax/javascript.vim
+  unlet b:current_syntax
 endif
 
-syn case ignore
+" Modify some syntax from 'javascript.vim'.
+syn clear javaScriptParens
+syn clear javaScriptBraces
 
-" objj keywords, types, type qualifiers etc.
+" TODO: The '{}' & '[]' representing the JavaScript 'object' & 'array'
+" should be highlighted.
+
+" Read the C syntax to start with
+if version < 600
+  source <sfile>:p:h/c.vim
+else
+  runtime! syntax/c.vim
+  unlet b:current_syntax
+endif
+
+" FIXME: The highlighting the common special-notice 'TBD'
+" for comments in JavaScript
+" is broken by c.vim.
+
+" Objective-J extentions follow below
+"
+" NOTE: Objective-J is abbreviated to ObjJ/objj
+" and uses *.j as file extensions!
+
+
+" ObjJ keywords, types, type qualifiers etc.
 syn keyword objjStatement	self super _cmd
+syn keyword objjStatement	property getter setter readwrite readonly copy
 syn keyword objjType		id Class SEL IMP BOOL
-"syn keyword objjTypeModifier	bycopy in out inout oneway
-syn keyword objjConstant	nil Nil
+syn keyword objjTypeModifier	bycopy in out inout oneway
+syn keyword objjConstant	nil Nil NULL NO YES
 
-" Match the objj #import directive (like C's #include)
+" Match the ObjJ @import directive
+syn match  objjDirective    "@import"
+
+" Match the ObjJ #import directive (like C's #include)
 syn region objjImported display contained start=+"+  skip=+\\\\\|\\"+  end=+"+
-syn match  objjImported display contained "<[_0-9a-zA-Z.\/]*>"
-syn match  objjImport display "^\s*\(%:\|#\)\s*import\>\s*["<]" contains=objjImported
+syn match  objjImported display contained "<[-_0-9a-zA-Z.\/]*>"
+syn match  objjImport display "^\s*\(%:\|#\|@\)\s*import\>\s*["<]" contains=objjImported
 
-" Match the important objj directives
-syn match  objjScopeDecl    "@public\|@private\|@protected"
-syn match  objjDirective    "@interface\|@implementation"
-syn match  objjDirective    "@class\|@end\|@defs"
-syn match  objjDirective    "@encode\|@protocol\|@selector"
+" Match the important ObjJ directives
+syn match  objjDirective    "@interface\|@implementation\|@protocol\|@end"
+syn match  objjScopeDecl    "@public\|@protected\|@private\|@package"
+syn match  objjScopeDecl    "@required\|@optional"
+syn match  objjDirective    "@property\|@synthesize\|@dynamic"
+syn match  objjDirective    "@outlet\|@accessors"
+syn match  objjDirective    "@action\|@selector"
+syn match  objjDirective    "@defs"
+syn match  objjDirective    "@global\|@class"
+syn match  objjDirective    "@encode"
+syn match  objjDirective    "@ref\|@deref"
 syn match  objjDirective    "@try\|@catch\|@finally\|@throw\|@synchronized"
 
-" Match the ObjC method types
+" Match the ObjJ method types
 "
 " NOTE: here I match only the indicators, this looks
 " much nicer and reduces cluttering color highlightings.
@@ -56,123 +91,38 @@ syn match objjInstMethod    "^\s*-\s*"
 syn match objjFactMethod    "^\s*+\s*"
 
 " To distinguish from a header inclusion from a protocol list.
-"syn match objjProtocol display "<[_a-zA-Z][_a-zA-Z0-9]*>" contains=objjType,cType,Type
+syn match objjProtocol display "<[_a-zA-Z][_a-zA-Z0-9]*>" contains=objjType,cType,Type
 
 
 " To distinguish labels from the keyword for a method's parameter.
 syn region objjKeyForMethodParam display
     \ start="^\s*[_a-zA-Z][_a-zA-Z0-9]*\s*:\s*("
     \ end=")\s*[_a-zA-Z][_a-zA-Z0-9]*"
-    \ contains=objjType,Type
+    \ contains=objjType,objjTypeModifier,cType,cStructure,cStorageClass,Type
 
-" Objective-C Constant Strings
+" Objective-J Constant Strings
 syn match objjSpecial display "%@" contained
-syn region objjString start=+\(@"\|"\)+ skip=+\\\\\|\\"+ end=+"+ contains=cFormat,cSpecial,objcSpecial
+syn region objjString start=+\(@"\|"\)+ skip=+\\\\\|\\"+ end=+"+ contains=cFormat,cSpecial,objjSpecial
 
-" Objective-C Message Expressions
-syn region objjMessage display start="\[" end="\]" contains=objjMessage,objjStatement,objjType,objjTypeModifier,objjString,objjConstant,objjDirective
+" Objective-J Message Expressions
+syn region objjMessage display start="\[" end="\]" contains=objjMessage,objjStatement,objjType,objjTypeModifier,objjString,objjConstant,objjDirective,cType,cStructure,cStorageClass,cString,cCharacter,cSpecialCharacter,cNumbers,cConstant,cOperator,cComment,cCommentL,Type
 
 syn cluster cParenGroup add=objjMessage
 syn cluster cPreProcGroup add=objjMessage
 
-
-syn keyword objjCommentTodo    TODO FIXME XXX TBD contained
-syn match   objjLineComment    "\/\/.*" contains=objjCommentTodo
-syn match   objjCommentSkip    "^[ \t]*\*\($\|[ \t]\+\)"
-syn region  objjComment	       start="/\*"  end="\*/" contains=objjCommentTodo
-syn match   objjSpecial	       "\\\d\d\d\|\\."
-syn region  objjStringD	       start=+"+  skip=+\\\\\|\\"+  end=+"\|$+  contains=objjSpecial,@htmlPreproc
-syn region  objjStringS	       start=+'+  skip=+\\\\\|\\'+  end=+'\|$+  contains=objjSpecial,@htmlPreproc
-
-syn match   objjSpecialCharacter "'\\.'"
-syn match   objjNumber	       "-\=\<\d\+L\=\>\|0[xX][0-9a-fA-F]\+\>"
-syn region  objjRegexpString     start=+/[^/*]+me=e-1 skip=+\\\\\|\\/+ end=+/[gi]\{0,2\}\s*$+ end=+/[gi]\{0,2\}\s*[;.,)\]}]+me=e-1 contains=@htmlPreproc oneline
-
-syn keyword objjConditional	if else switch
-syn keyword objjRepeat		while for do in
-syn keyword objjBranch		break continue
-syn keyword objjOperator	new delete instanceof typeof
-syn keyword objjType		Array Boolean Date Function Number Object String RegExp
-syn keyword objjStatement	return with
-syn keyword objjBoolean		true false
-syn keyword objjNull		null undefined
-syn keyword objjIdentifier	arguments this var
-syn keyword objjLabel		case default
-syn keyword objjException	try catch finally throw
-syn keyword objjMessage		alert confirm prompt status
-syn keyword objjGlobal		self window top parent
-syn keyword objjMember		document event location 
-syn keyword objjDeprecated	escape unescape
-syn keyword objjReserved	abstract boolean byte char class const debugger double enum export extends final float goto implements import int interface long native package private protected public short static super synchronized throws transient volatile 
-
-if exists("objj_fold")
-    syn match	objjFunction      "\<function\>"
-    syn region	objjFunctionFold	start="\<function\>.*[^};]$" end="^\z1}.*$" transparent fold keepend
-
-    syn sync match objjSync	grouphere objjFunctionFold "\<function\>"
-    syn sync match objjSync	grouphere NONE "^}"
-
-    setlocal foldmethod=syntax
-    setlocal foldtext=getline(v:foldstart)
-else
-    syn keyword	objjFunction      function
-    syn match	objjBraces	   "[{}\[\]]"
-    syn match	objjParens	   "[()]"
-endif
-
-syn sync fromstart
-syn sync maxlines=100
-
-if main_syntax == "objj"
-  syn sync ccomment objjComment
-endif
-
 " Define the default highlighting.
 " For version 5.7 and earlier: only when not done already
 " For version 5.8 and later: only when an item doesn't have highlighting yet
-if version >= 508 || !exists("did_objj_syn_inits")
+if version >= 508 || !exists("did_objj_syntax_inits")
   if version < 508
-    let did_objj_syn_inits = 1
+    let did_objj_syntax_inits = 1
     command -nargs=+ HiLink hi link <args>
   else
     command -nargs=+ HiLink hi def link <args>
   endif
-  HiLink objjComment		Comment
-  HiLink objjLineComment	Comment
-  HiLink objjCommentTodo	Todo
-  HiLink objjSpecial		Special
-  HiLink objjStringS		String
-  HiLink objjStringD		String
-  HiLink objjCharacter		Character
-  HiLink objjSpecialCharacter	objjSpecial
-  HiLink objjNumber		objjValue
-  HiLink objjConditional	Conditional
-  HiLink objjRepeat		Repeat
-  HiLink objjBranch		Conditional
-  HiLink objjOperator		Operator
-  HiLink objjType		Type
-  HiLink objjStatement		Statement
-  HiLink objjFunction		Function
-  HiLink objjBraces		Function
-  HiLink objjError		Error
-  HiLink javaScrParenError	objjError
-  HiLink objjNull		Keyword
-  HiLink objjBoolean		Boolean
-  HiLink objjRegexpString	String
-
-  HiLink objjIdentifier		Identifier
-  HiLink objjLabel		Label
-  HiLink objjException		Exception
-  HiLink objjMessage		Keyword
-  HiLink objjGlobal		Keyword
-  HiLink objjMember		Keyword
-  HiLink objjDeprecated		Exception 
-  HiLink objjReserved		Keyword
-  HiLink objjDebug		Debug
-  HiLink objjConstant		Label
 
   HiLink objjImport		Include
-  HiLink objjImported		String
+  HiLink objjImported		cString
   HiLink objjTypeModifier	objjType
   HiLink objjType		Type
   HiLink objjScopeDecl		Statement
@@ -181,17 +131,14 @@ if version >= 508 || !exists("did_objj_syn_inits")
   HiLink objjStatement		Statement
   HiLink objjDirective		Statement
   HiLink objjKeyForMethodParam	None
-  HiLink objjString		String
+  HiLink objjString		cString
   HiLink objjSpecial		Special
   HiLink objjProtocol		None
-  HiLink objjConstant		Constant
+  HiLink objjConstant		cConstant
 
   delcommand HiLink
 endif
 
 let b:current_syntax = "objj"
-if main_syntax == 'objj'
-  unlet main_syntax
-endif
 
 " vim: ts=8


### PR DESCRIPTION
objj.vim cannot highlight much syntax correctly, and it should be updated. I've modified objc.vim to objj.vim which reads javascript.vim in the beginning, and now it looks good. Because javascript.vim & c.vim must be loaded into objj.vim, so they should also be committed.

Fixes #2211
