### PR TITLE
Fixed: CPThemeStateSelectedDataView still set when removing a view

### DIFF
--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -3950,6 +3950,9 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
     // FIXME: yuck!
     var identifier = [aDataView identifier];
 
+    if ([aDataView hasThemeState:CPThemeStateSelectedDataView])
+        [aDataView unsetThemeState:CPThemeStateSelectedDataView];
+
     if (!_cachedDataViews[identifier])
         _cachedDataViews[identifier] = [aDataView];
     else


### PR DESCRIPTION
Previously, when removing a view from a CPTableView, the themeState CPThemeStateSelectedDataView wasn't unset. Now it does.
