### PR TITLE
Fixed: CPImageView no longer leaks due to image load notification.

### DIFF
--- a/AppKit/CPImageView.j
+++ b/AppKit/CPImageView.j
@@ -178,6 +178,7 @@ var CPImageViewEmptyPlaceholderImage = nil;
 
 - (void)imageDidLoad:(CPNotification)aNotification
 {
+    [[CPNotificationCenter defaultCenter] removeObserver:self name:CPImageDidLoadNotification object:[self objectValue]];
     [self hideOrDisplayContents];
 
     [self setNeedsLayout];


### PR DESCRIPTION
Previously, CPImageView would sometimes attach a notification to CPImageDidLoadNotification when the image was set, but would never remove this notification. The view could then leak memory as the notification center would be keeping a reference even if the view was no longer being used.

This commit fixes that issue by removing the observation once the image has loaded.

Fixes #2198.
