### PR TITLE
Fixed: It cannot execute the "jake" commands correctly in the Cappuccino...

### DIFF
--- a/narwhal.local.conf
+++ b/narwhal.local.conf
@@ -1,5 +1,14 @@
-if [ -z "$NARWHAL_ENGINE" ] && [ -d "$NARWHAL_HOME/packages/narwhal-jsc" ]; then
-	export NARWHAL_ENGINE=jsc
+if [ -z "$NARWHAL_ENGINE" ] && [ `uname` == "Darwin" ]; then
+    # We should check "narwhal-jsc.conf" and the corresponding executable to determine whether JSC can be "$NARWHAL_ENGINE".
+    if [ -f "$NARWHAL_HOME/packages/narwhal-jsc/narwhal-jsc.conf" ]; then
+        source "$NARWHAL_HOME/packages/narwhal-jsc/narwhal-jsc.conf"
+    fi
+    if [ -z "$NARWHAL_JSC_MODE" ]; then
+        NARWHAL_JSC_MODE="jscore"
+    fi
+    if [ -f "$NARWHAL_HOME/packages/narwhal-jsc/bin/narwhal-$NARWHAL_JSC_MODE" ]; then
+        export NARWHAL_ENGINE=jsc
+    fi
 fi
 
 if [ "$NARWHAL_ENGINE" == jsc ] && [ `ulimit -n` -lt 1024 ]; then


### PR DESCRIPTION
... repository directory when it's not the Apple OS.

When running the "jake" commands in the repository directory, it would print:
$ jake --help
narwhal/packages/narwhal-jsc/bin/narwhal-jsc: line 33: narwhal/packages/narwhal-jsc/bin/narwhal-jscore: No such file or directory
Now, it will print:
$ pwd
/home/kevin/workspace/Cappuccino
$ jake --help
Usage: jake [OPTIONS] targets...
-f --jakefile FILE: Use FILE as the jakefile.
-T --tasks: Display the tasks with descriptions, then exit.
-D --describe: Describe the tasks then exit.
-P --prereqs: Display the tasks and dependencies, then exit.
    -v --verbose: Log message to standard output.
-h --help: displays usage information (final option)

Fixes #2181
