### PR TITLE
Fixed: No line information for compiler errors on the first line of a file

### DIFF
--- a/Objective-J/ObjJAcornCompiler.js
+++ b/Objective-J/ObjJAcornCompiler.js
@@ -383,7 +383,7 @@ var ObjJAcornCompiler = function(/*String*/ aString, /*CFURL*/ aURL, /*unsigned*
         this.tokens = exports.acorn.parse(aString);
     }
     catch (e) {
-        if (e.lineStart)
+        if (e.lineStart != null)
         {
             var message = this.prettifyMessage(e, "ERROR");
 #ifdef BROWSER


### PR DESCRIPTION
When an error was on the first line of a file the compiler would not give any line information.

This was shown:

```
SyntaxError: Unexpected token
```

Instead of:

```
<<<<<<< HEAD:CPView.j
^
ERROR line 1 in http://martin-2.local/dev/office/LocalDeploy/Applications/Office/AppController.j: Unexpected token
SyntaxError: Unexpected token
```

I found this when debugging #2220
