### PR TITLE
Fixed: firstResponder is lost when adding a firstResponder view to the same window

### DIFF
--- a/AppKit/CPView.j
+++ b/AppKit/CPView.j
@@ -751,7 +751,7 @@ var CPViewFlags                     = { },
     [[self window] _dirtyKeyViewLoop];
 
     // Clear out first responder if we're the first responder and leaving.
-    if ([_window firstResponder] === self)
+    if ([_window firstResponder] === self && _window != aWindow)
         [_window makeFirstResponder:nil];
 
     // Notify the view and its subviews


### PR DESCRIPTION
Previously, when adding a view (which is the firstResponder of the window) to the same window, the firstResponder was set to nil.
Now it keeps the same firstResponder.
