### PR TITLE
Fixed: Several views of _CPTableDrawView created when encoding and decoding a CPTableView

### DIFF
--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -6025,6 +6025,11 @@ var CPTableViewDataSourceKey                = @"CPTableViewDataSourceKey",
 {
     [super encodeWithCoder:aCoder];
 
+    // We do this in order to avoid encoding the _tableDrawView, which
+    // should just automatically be created programmatically as needed.
+    if (_tableDrawView)
+        [_tableDrawView removeFromSuperview];
+
     [aCoder encodeObject:_dataSource forKey:CPTableViewDataSourceKey];
     [aCoder encodeObject:_delegate forKey:CPTableViewDelegateKey];
 


### PR DESCRIPTION
Previously, when encoding and decoding a CPTableView, the tableView had several _CPTableDrawView (in the subviews).
Now when encoding, we make sure to remove _CPTableDrawView from its superview.
