### PR TITLE
Fixed: constructor of CPDate can take string param

### DIFF
--- a/Foundation/CPDate.j
+++ b/Foundation/CPDate.j
@@ -75,7 +75,7 @@ var CPDateReferenceDate = new Date(Date.UTC(2001, 0, 1, 0, 0, 0, 0));
 - (id)initWithTimeIntervalSinceNow:(CPTimeInterval)seconds
 {
     if (!_isNumberType(seconds))
-        [CPException raise:CPInvalidArgumentException reason:@"The parameter of the method initWithTimeIntervalSinceNow: has to be an integer"];
+        [CPException raise:CPInvalidArgumentException reason:@"The parameter of the method initWithTimeIntervalSinceNow: has to be an integer or a float"];
 
     self = new Date((new Date()).getTime() + seconds * 1000);
     return self;
@@ -84,7 +84,7 @@ var CPDateReferenceDate = new Date(Date.UTC(2001, 0, 1, 0, 0, 0, 0));
 - (id)initWithTimeIntervalSince1970:(CPTimeInterval)seconds
 {
     if (!_isNumberType(seconds))
-        [CPException raise:CPInvalidArgumentException reason:@"The parameter of the method initWithTimeIntervalSince1970: has to be an integer"];
+        [CPException raise:CPInvalidArgumentException reason:@"The parameter of the method initWithTimeIntervalSince1970: has to be an integer or a float"];
 
     self = new Date(seconds * 1000);
     return self;
@@ -93,7 +93,7 @@ var CPDateReferenceDate = new Date(Date.UTC(2001, 0, 1, 0, 0, 0, 0));
 - (id)initWithTimeIntervalSinceReferenceDate:(CPTimeInterval)seconds
 {
     if (!_isNumberType(seconds))
-        [CPException raise:CPInvalidArgumentException reason:@"The parameter of the method initWithTimeIntervalSinceReferenceDate: has to be an integer"];
+        [CPException raise:CPInvalidArgumentException reason:@"The parameter of the method initWithTimeIntervalSinceReferenceDate: has to be an integer or a float"];
 
     self = [self initWithTimeInterval:seconds sinceDate:CPDateReferenceDate];
     return self;
@@ -102,7 +102,7 @@ var CPDateReferenceDate = new Date(Date.UTC(2001, 0, 1, 0, 0, 0, 0));
 - (id)initWithTimeInterval:(CPTimeInterval)seconds sinceDate:(CPDate)refDate
 {
     if (!_isNumberType(seconds))
-        [CPException raise:CPInvalidArgumentException reason:@"The parameter of the method initWithTimeInterval:sinceDate: has to be an integer"];
+        [CPException raise:CPInvalidArgumentException reason:@"The parameter of the method initWithTimeInterval:sinceDate: has to be an integer or a float"];
 
     self = new Date(refDate.getTime() + seconds * 1000);
     return self;

--- a/Foundation/CPDate.j
+++ b/Foundation/CPDate.j
@@ -74,24 +74,36 @@ var CPDateReferenceDate = new Date(Date.UTC(2001, 0, 1, 0, 0, 0, 0));
 
 - (id)initWithTimeIntervalSinceNow:(CPTimeInterval)seconds
 {
+    if (!_isNumberType(seconds))
+        [CPException raise:CPInvalidArgumentException reason:@"The parameter of the method initWithTimeIntervalSinceNow: has to be an integer"];
+
     self = new Date((new Date()).getTime() + seconds * 1000);
     return self;
 }
 
 - (id)initWithTimeIntervalSince1970:(CPTimeInterval)seconds
 {
+    if (!_isNumberType(seconds))
+        [CPException raise:CPInvalidArgumentException reason:@"The parameter of the method initWithTimeIntervalSince1970: has to be an integer"];
+
     self = new Date(seconds * 1000);
     return self;
 }
 
 - (id)initWithTimeIntervalSinceReferenceDate:(CPTimeInterval)seconds
 {
+    if (!_isNumberType(seconds))
+        [CPException raise:CPInvalidArgumentException reason:@"The parameter of the method initWithTimeIntervalSinceReferenceDate: has to be an integer"];
+
     self = [self initWithTimeInterval:seconds sinceDate:CPDateReferenceDate];
     return self;
 }
 
 - (id)initWithTimeInterval:(CPTimeInterval)seconds sinceDate:(CPDate)refDate
 {
+    if (!_isNumberType(seconds))
+        [CPException raise:CPInvalidArgumentException reason:@"The parameter of the method initWithTimeInterval:sinceDate: has to be an integer"];
+
     self = new Date(refDate.getTime() + seconds * 1000);
     return self;
 }
@@ -275,3 +287,11 @@ Date.parseISO8601 = function (date)
 };
 
 Date.prototype.isa = CPDate;
+
+function _isNumberType(value)
+{
+    if (typeof value === 'number')
+        return YES;
+    else
+        return NO;
+}

--- a/Foundation/CPDate.j
+++ b/Foundation/CPDate.j
@@ -75,7 +75,7 @@ var CPDateReferenceDate = new Date(Date.UTC(2001, 0, 1, 0, 0, 0, 0));
 - (id)initWithTimeIntervalSinceNow:(CPTimeInterval)seconds
 {
     if (!_isNumberType(seconds))
-        [CPException raise:CPInvalidArgumentException reason:@"The parameter of the method initWithTimeIntervalSinceNow: has to be an integer or a float"];
+        CPLog.warn(@"The parameter of the method initWithTimeIntervalSinceNow: should be an integer or a float");
 
     self = new Date((new Date()).getTime() + seconds * 1000);
     return self;
@@ -84,7 +84,7 @@ var CPDateReferenceDate = new Date(Date.UTC(2001, 0, 1, 0, 0, 0, 0));
 - (id)initWithTimeIntervalSince1970:(CPTimeInterval)seconds
 {
     if (!_isNumberType(seconds))
-        [CPException raise:CPInvalidArgumentException reason:@"The parameter of the method initWithTimeIntervalSince1970: has to be an integer or a float"];
+        CPLog.warn(@"The parameter of the method initWithTimeIntervalSince1970: should be an integer or a float");
 
     self = new Date(seconds * 1000);
     return self;
@@ -93,7 +93,7 @@ var CPDateReferenceDate = new Date(Date.UTC(2001, 0, 1, 0, 0, 0, 0));
 - (id)initWithTimeIntervalSinceReferenceDate:(CPTimeInterval)seconds
 {
     if (!_isNumberType(seconds))
-        [CPException raise:CPInvalidArgumentException reason:@"The parameter of the method initWithTimeIntervalSinceReferenceDate: has to be an integer or a float"];
+        CPLog.warn(@"The parameter of the method initWithTimeIntervalSinceReferenceDate: should be an integer or a float");
 
     self = [self initWithTimeInterval:seconds sinceDate:CPDateReferenceDate];
     return self;
@@ -102,7 +102,7 @@ var CPDateReferenceDate = new Date(Date.UTC(2001, 0, 1, 0, 0, 0, 0));
 - (id)initWithTimeInterval:(CPTimeInterval)seconds sinceDate:(CPDate)refDate
 {
     if (!_isNumberType(seconds))
-        [CPException raise:CPInvalidArgumentException reason:@"The parameter of the method initWithTimeInterval:sinceDate: has to be an integer or a float"];
+        CPLog.warn(@"The parameter of the method initWithTimeInterval:sinceDate: should be an integer or a float");
 
     self = new Date(refDate.getTime() + seconds * 1000);
     return self;


### PR DESCRIPTION
Previously, when making a CPDate with some constructors, we could pass a string or nil to create a date. For example it was allowed to do var date = [CPDate dateWithTimeIntervalSince1970:"10"];

Now this is not possible anymore and it works like in Cocoa, only number are authorized.