### PR TITLE
Fixed: prototype of method unfocusedSelectionGradientColors is void

### DIFF
--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -962,7 +962,7 @@ NOT YET IMPLEMENTED
 </pre>
 */
 
-- (void)unfocusedSelectionGradientColors
+- (CPColor)unfocusedSelectionGradientColors
 {
     if (!_unfocusedSourceListSelectionColor)
     {


### PR DESCRIPTION
Previously the prototype method of unfocusedSelectionGradientColors as void, now it's CPColor
