### PR TITLE
Fixed: CPWindow keeps a reference of its firstResponder when closing a window

### DIFF
--- a/AppKit/CPWindow/CPWindow.j
+++ b/AppKit/CPWindow/CPWindow.j
@@ -981,6 +981,7 @@ CPTexturedBackgroundWindowMask
     [_platformWindow order:CPWindowOut window:self relativeTo:nil];
 #endif
 
+    [self makeFirstResponder:nil];
     [self _updateMainAndKeyWindows];
 }
 


### PR DESCRIPTION
Previously, when closing a CPWindow, the window kept a reference of the firstResponder. This things raised an issue when opening a window again and asking the window to make the first responder to the same element as the one we had.

Now when closing a window, the window will update its firstResponder to nil.
