### PR TITLE
Fixed: bezeled is set to yes when making a right click on a non-selectable CPTextField in a cell of a CPTableView

### DIFF
--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -5177,7 +5177,7 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
     // This makes sure the theming effects of a focused table remain in effect even as cells are being edited in it.
     [self _notifyViewDidBecomeFirstResponder];
 
-    if (_editingRow !== CPNotFound && [responder isKindOfClass:[CPTextField class]] && ![responder isBezeled])
+    if (_editingRow !== CPNotFound && [responder isKindOfClass:[CPTextField class]] && ![responder isBezeled] && [responder isEditable])
     {
         [responder setBezeled:YES];
         [self _registerForEndEditingNote:responder];


### PR DESCRIPTION
Previously, when making a right click on a non-selectable CPTextField which is contained in a dataView of a CPTableView set the bezel attribute to yes.

Now, when making this things, Cappuccino will check if the CPTextField if editable or not.
