### PR TITLE
Fixed: hitTest method returns the wrong view in the CPTableView when the  selectionStyle is set to CPTableViewSelectionHighlightStyleNone

### DIFF
--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -5123,7 +5123,12 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
     var hit = [super hitTest:aPoint];
 
     if ([[CPApp currentEvent] type] == CPLeftMouseDown && [hit acceptsFirstResponder] && ![self isRowSelected:[self rowForView:hit]])
+    {
+        if (_selectionHighlightStyle == CPTableViewSelectionHighlightStyleNone)
+            return hit;
+
         return self;
+    }
 
     return hit;
 }


### PR DESCRIPTION
Previously, when having a CPTableView with a selectionStyle set to CPTableViewSelectionHighlightStyleNone, we needed two clicks to be able to select or click on a control of the cell. Now we only need one click as in Cocoa.

This is fixed by changing the method hitTest and returning the good view which can become the firstResponder.
