### PR TITLE
Fixed: CPSecureTextField size was not calculated correctly in nib2cib.

### DIFF
--- a/Tools/nib2cib/NSSecureTextField.j
+++ b/Tools/nib2cib/NSSecureTextField.j
@@ -37,6 +37,7 @@
     {
         var cell = [aCoder decodeObjectForKey:@"NSCell"];
         [self NS_initWithCell:cell];
+        [self _adjustNib2CibSize];
     }
 
     return self;


### PR DESCRIPTION
Previously, the Secure Text Field size was slightly smaller when placed using Interface Builder.

This commit adjusts the size in nib2cib by ensuring CPTextField _adjustNib2CibSize is called on CPSecureTextField.
