### PR TITLE
Fixed: cursor of CPTextField is not updated to default

### DIFF
--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -1148,6 +1148,12 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
         self._DOMElement.style.cursor = "text";
 #endif
     }
+    else
+    {
+#if PLATFORM(DOM)
+        self._DOMElement.style.cursor = "default";
+#endif
+    }
 }
 
 /*!


### PR DESCRIPTION
Previously, when changing the mode of the CPTextField from editable to non-editable, the cursor wasn't set to default. Now it does.
