### PR TITLE
Reinstate #2158

### DIFF
--- a/Objective-J/CFHTTPRequest.js
+++ b/Objective-J/CFHTTPRequest.js
@@ -99,6 +99,7 @@ GLOBAL(CFHTTPRequest) = function()
     this._isOpen = false;
     this._requestHeaders = {};
     this._mimeType = null;
+    this._withCredentials = false;
 
     this._eventDispatcher = new EventDispatcher(this);
     this._nativeRequest = new NativeRequest();
@@ -224,7 +225,9 @@ CFHTTPRequest.prototype.open = function(/*String*/ aMethod, /*String*/ aURL, /*B
     this._method = aMethod;
     this._user = aUser;
     this._password = aPassword;
-    return this._nativeRequest.open(aMethod, aURL, isAsynchronous, aUser, aPassword);
+    var result = this._nativeRequest.open(aMethod, aURL, isAsynchronous, aUser, aPassword);
+    this._nativeRequest.withCredentials = this._withCredentials;
+    return result;
 };
 
 CFHTTPRequest.prototype.send = function(/*Object*/ aBody)
@@ -233,6 +236,7 @@ CFHTTPRequest.prototype.send = function(/*Object*/ aBody)
     {
         delete this._nativeRequest.onreadystatechange;
         this._nativeRequest.open(this._method, this._URL, this._async, this._user, this._password);
+        this._nativeRequest.withCredentials = this._withCredentials;
         this._nativeRequest.onreadystatechange = this._stateChangeHandler;
     }
 
@@ -276,12 +280,12 @@ CFHTTPRequest.prototype.removeEventListener = function(/*String*/ anEventName, /
 
 CFHTTPRequest.prototype.setWithCredentials = function(/*Boolean*/ willSendWithCredentials) 
 {
-    this._nativeRequest.withCredentials = willSendWithCredentials;
+    this.withCredentials = willSendWithCredentials;
 };
 
 CFHTTPRequest.prototype.getWithCredentials = function() 
 {
-    return this._nativeRequest.withCredentials;
+    return this.withCredentials;
 };
 
 function determineAndDispatchHTTPRequestEvents(/*CFHTTPRequest*/ aRequest)


### PR DESCRIPTION
PR #2158 fixes an issue where withCredentials must be set after calling open in IE. This change was reverted though.

I did some testing and IE11, Chrome 38 and Firefox 33 do not throw errors if you set withCredentials before calling open. However IE10 will throw an InvalidStateError, preventing this feature from working.

This PR reapplies the patch from #2158 which I have tested in IE11, Chrome 38 and Firefox 33 and does not appear to cause any regressions or warnings, but does fix the InvalidStateError in IE10.

It would be nice to fix this issue in IE10, seeing as I cannot recreate any of the regressions noted in the original PR (unless somebody else can?), so there would appear to be no downsides.

Fixes #2157.
