### PR TITLE
NEW: Environment variable to disable CommonJS environement building

### DIFF
--- a/Objective-J/CommonJS/lib/objective-j/jake/bundletask.js
+++ b/Objective-J/CommonJS/lib/objective-j/jake/bundletask.js
@@ -35,7 +35,12 @@ function BundleTask(aName, anApplication)
 {
     Task.apply(this, arguments);
 
-    this.setEnvironments([environment.Browser, environment.CommonJS]);
+    var ignoreCommonJS = system.env["CAPP_IGNORE_COMMONJS_ENV"];
+
+    if (ignoreCommonJS && ignoreCommonJS.toLowerCase() == "no" || ignoreCommonJS == "1")
+        this.setEnvironments([environment.Browser]);
+    else
+        this.setEnvironments([environment.Browser, environment.CommonJS]);
 
     this._author = null;
     this._email = null;


### PR DESCRIPTION
This patch allows user to disable the commonJS build phase by setting the system environement variable IGNORE_ENV_COMMONJS.

For instance `export IGNORE_ENV_COMMONJS=1`

I'm not sure why we are building this CommonJS environment. It's taking time and sometime prevent our build to work with random compilator error. This patch allows to deactivate it. (credits to @dogild) 

Anyone knows what CommonJS env is exactly?
