### PR TITLE
Fixed: NativeHost is no longer built by default

### DIFF
--- a/Tools/Jakefile
+++ b/Tools/Jakefile
@@ -2,6 +2,6 @@
 require("../common.jake");
 
 // nib2cib uses fontinfo and imagesize and capp uses nib2cib
-subtasks(["fontinfo", "imagesize", "nib2cib", "capp", "capp_lint", "dump_theme", "NativeHost", "XcodeCapp"], ["build"/*, "clean", "clobber"*/]);
+subtasks(["fontinfo", "imagesize", "nib2cib", "capp", "capp_lint", "dump_theme", "XcodeCapp"], ["build", /*"clean", "clobber"*/]);
 
 subtasks(["fontinfo", "imagesize"], ["clean", "clobber"]);


### PR DESCRIPTION
This commit removes NativeHost from the 'Tools' Jakefile, ensuring that it does not get built by default.

Fixes #2239
