### PR TITLE
Fixed: wrong content-inset for CPComboBox

### DIFF
--- a/AppKit/Themes/Aristo/ThemeDescriptors.j
+++ b/AppKit/Themes/Aristo/ThemeDescriptors.j
@@ -1820,8 +1820,8 @@ var themedButtonValues = nil,
 
             // The right border inset has to make room for the focus ring and popup button
             [@"content-inset",              CGInsetMake(8.0, 27.0, 7.0, 8.0),           [CPThemeStateBezeled, CPComboBoxStateButtonBordered]],
-            [@"content-inset",              CGInsetMake(8.0, 24.0, 7.0, 8.0),           CPThemeStateBezeled],
-            [@"content-inset",              CGInsetMake(8.0, 24.0, 7.0, 8.0),           [CPThemeStateBezeled, CPThemeStateEditing]],
+            [@"content-inset",              CGInsetMake(8.0, 27.0, 7.0, 8.0),           CPThemeStateBezeled],
+            [@"content-inset",              CGInsetMake(8.0, 27.0, 7.0, 8.0),           [CPThemeStateBezeled, CPThemeStateEditing]],
 
             [@"popup-button-size",          CGSizeMake(21.0, 23.0),                     [CPThemeStateBezeled, CPComboBoxStateButtonBordered]],
             [@"popup-button-size",          CGSizeMake(17.0, 23.0),                     CPThemeStateBezeled],

--- a/AppKit/Themes/Aristo2/ThemeDescriptors.j
+++ b/AppKit/Themes/Aristo2/ThemeDescriptors.j
@@ -1312,9 +1312,9 @@ var themedButtonValues = nil,
             [@"bezel-inset",        CGInsetMake(3.0, 5.0, 3.0, 4.0),            [CPThemeStateBezeled, CPThemeStateDisabled]],
 
             // The right border inset has to make room for the focus ring and popup button
-            [@"content-inset",      CGInsetMake(9.0, 26.0, 7.0, 10.0),          [CPThemeStateBezeled, CPComboBoxStateButtonBordered]],
-            [@"content-inset",      CGInsetMake(9.0, 26.0, 7.0, 10.0),          CPThemeStateBezeled],
-            [@"content-inset",      CGInsetMake(9.0, 24.0, 7.0, 10.0),          [CPThemeStateBezeled, CPThemeStateEditing]],
+            [@"content-inset",      CGInsetMake(9.0, 30.0, 7.0, 10.0),          [CPThemeStateBezeled, CPComboBoxStateButtonBordered]],
+            [@"content-inset",      CGInsetMake(9.0, 30.0, 7.0, 10.0),          CPThemeStateBezeled],
+            [@"content-inset",      CGInsetMake(9.0, 28.0, 7.0, 10.0),          [CPThemeStateBezeled, CPThemeStateEditing]],
 
             [@"popup-button-size",  CGSizeMake(21.0, 23.0),                     [CPThemeStateBezeled, CPComboBoxStateButtonBordered]],
             [@"popup-button-size",  CGSizeMake(17.0, 23.0),                     CPThemeStateBezeled],


### PR DESCRIPTION
Previously, the content-inset of a CPComboBox was wrong, the text of the controller was over the popUPButton.
