### PR TITLE
Fixed: CPWindow doesn't take the event when moving from another platformWindow

### DIFF
--- a/AppKit/CPWindow/CPWindow.j
+++ b/AppKit/CPWindow/CPWindow.j
@@ -1846,6 +1846,12 @@ CPTexturedBackgroundWindowMask
             if (_leftMouseDownView !== _firstResponder && [_leftMouseDownView acceptsFirstResponder])
                 [self makeFirstResponder:_leftMouseDownView];
 
+            var keyWindow = [CPApp keyWindow];
+
+            // This is only when we move from a platform to another one
+            if ([keyWindow platformWindow] != [self platformWindow])
+                [self makeKeyAndOrderFront:self];
+
             [CPApp activateIgnoringOtherApps:YES];
 
             var theWindow = [anEvent window],
@@ -2477,7 +2483,7 @@ CPTexturedBackgroundWindowMask
                 if (currentWindow === self || currentWindow === menuWindow)
                     continue;
 
-                if ([currentWindow isVisible] && [currentWindow canBecomeKeyWindow])
+                if ([currentWindow isVisible] && [currentWindow canBecomeKeyWindow] && [currentWindow platformWindow] == [keyWindow platformWindow])
                 {
                     [currentWindow makeKeyWindow];
                     break;


### PR DESCRIPTION
Previously, when moving from platformWindow to another platformWindow, the targeted window didn't get the new event because the keyWindow of the application was still set to the other platformWindow.

This PR fixes another issue about opening panel in a platformWindow. When opening a panel in a platformWindow, cappuccino set the new key window to the wrong platformWindow.
