### PR TITLE
Fixed: Enable CPTextField to have a specific height

### DIFF
--- a/AppKit/CPControl.j
+++ b/AppKit/CPControl.j
@@ -260,10 +260,20 @@ var CPControlBlackColor = [CPColor blackColor];
         maxSize = [self currentValueForThemeAttribute:@"max-size"];
 
     if (minSize.width > 0)
+    {
         frameSize.width = MAX(minSize.width, frameSize.width);
 
+        if (maxSize.width > 0)
+            frameSize.width = MIN(maxSize.width, frameSize.width);
+    }
+
     if (minSize.height > 0)
-        frameSize.height = minSize.height;
+    {
+        frameSize.height = MAX(minSize.height, frameSize.height);
+
+        if (maxSize.height > 0)
+            frameSize.height = MIN(maxSize.height, frameSize.height);
+    }
 
     [self setFrameSize:frameSize];
 }

--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -240,8 +240,8 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
         [self _sizeToControlSize];
 }
 
-#pragma mark -
 
+#pragma mark -
 
 #if PLATFORM(DOM)
 - (DOMElement)_inputElement

--- a/AppKit/Themes/Aristo2/ThemeDescriptors.j
+++ b/AppKit/Themes/Aristo2/ThemeDescriptors.j
@@ -374,7 +374,7 @@ var themedButtonValues = nil,
             [@"font",                       [CPFont boldSystemFontOfSize:11.0]],
 
             [@"min-size",                   CGSizeMake(32.0, 20.0),                 CPThemeStateControlSizeSmall],
-            [@"max-size",                   CGSizeMake(1.0, 20.0),                  CPThemeStateControlSizeSmall],
+            [@"max-size",                   CGSizeMake(-1.0, 20.0),                 CPThemeStateControlSizeSmall],
             [@"nib2cib-adjustment-frame",   CGRectMake(3.0, 4.0, -6.0, 0.0),        CPThemeStateControlSizeSmall],
 
             // CPThemeStateControlSizeMini
@@ -386,7 +386,7 @@ var themedButtonValues = nil,
 
             [@"min-size",                   CGSizeMake(32.0, 16.0),                 CPThemeStateControlSizeMini],
             [@"max-size",                   CGSizeMake(-1.0, 16.0),                 CPThemeStateControlSizeMini],
-            [@"nib2cib-adjustment-frame",   CGRectMake(1.0, 10.0, -3.0, 0.0),        CPThemeStateControlSizeMini]
+            [@"nib2cib-adjustment-frame",   CGRectMake(1.0, 10.0, -3.0, 0.0),       CPThemeStateControlSizeMini]
         ];
 
     [self registerThemeValues:themeValues forView:button];


### PR DESCRIPTION
When setting controlSize, CPTextfield height was forced to min-size height.
Now we check that the frame size is between the min and the max size. It allows to constrain
a CPControl to have a fixed height by specifying a min-size equivalent to the max-size attribute
In CPTextField case, we only have a min-size which enable us to have a specific size.
