### PR TITLE
Fixed: CPMenu crash when opening a menu with items and then opening the menu without items

### DIFF
--- a/AppKit/CPMenu/_CPMenuWindow.j
+++ b/AppKit/CPMenu/_CPMenuWindow.j
@@ -410,7 +410,7 @@ _CPMenuWindowAttachedMenuBackgroundStyle    = 2;
 {
     // Don't return indexes of items that aren't visible.
     if (!CGRectContainsPoint([_menuClipView bounds], [_menuClipView convertPoint:aPoint fromView:nil]))
-        return NO;
+        return CPNotFound;
 
     return [_menuView itemIndexAtPoint:[_menuView convertPoint:aPoint fromView:nil]];
 }


### PR DESCRIPTION
Previously, when opening a menu with items and then opening another menu without items, Cappuccino simply crashed. Now it works !
