### PR TITLE
New: added method addObserverForName:object::usingBlock: in CPNotificationCenter

### DIFF
--- a/Foundation/CPNotificationCenter.j
+++ b/Foundation/CPNotificationCenter.j
@@ -92,9 +92,10 @@ var CPNotificationDefaultCenter = nil;
     Adds an entry to the receiver’s dispatch table with a block, and optional criteria: notification name and sender.
     @param aNotificationName the name of the notification the observer wants to watch
     @param anObject the object in the notification the observer wants to watch
+    @param queue is ignored for the moment
     @param block the block to be executed when the notification is received.
 */
-- (id <CPObject>)addObserverForName:(CPString)aNotificationName object:(id)anObject usingBlock:(Function)block
+- (id <CPObject>)addObserverForName:(CPString)aNotificationName object:(id)anObject queue:(id)queue usingBlock:(Function)block
 {
     var registry = [self _registryForNotificationName:aNotificationName],
         observer = [[_CPNotificationObserver alloc] initWithBlock:block];
@@ -156,10 +157,7 @@ var CPNotificationDefaultCenter = nil;
         [_unnamedRegistry removeObserver:anObserver object:anObject];
     }
     else
-    {
         [[_namedRegistries objectForKey:aNotificationName] removeObserver:anObserver object:anObject];
-    }
-
 }
 
 /*!

--- a/Tests/Foundation/CPNotificationCenterTest.j
+++ b/Tests/Foundation/CPNotificationCenterTest.j
@@ -62,8 +62,8 @@ var TestNotification = @"TestNotification";
         notificationCount += 1;
     };
 
-    var observer2 = [center addObserverForName:TestNotification object:2 usingBlock:notificationBlock],
-        observer25 = [center addObserverForName:TestNotification object:25 usingBlock:notificationBlock];
+    var observer2 = [center addObserverForName:TestNotification object:2 queue:nil usingBlock:notificationBlock],
+        observer25 = [center addObserverForName:TestNotification object:25 queue:nil usingBlock:notificationBlock];
 
     [center postNotificationName:TestNotification object:self];
     [self assert:0 equals:notificationCount message:@"observer should only be notified for object '2'"];
@@ -71,7 +71,7 @@ var TestNotification = @"TestNotification";
     [center postNotificationName:TestNotification object:2];
     [self assert:1 equals:notificationCount message:@"observer should be notified for object '2'"];
 
-    var observerNil = [center addObserverForName:TestNotification object:nil usingBlock:notificationBlock];
+    var observerNil = [center addObserverForName:TestNotification object:nil queue:nil usingBlock:notificationBlock];
 
     [center postNotificationName:TestNotification object:2];
     [self assert:3 equals:notificationCount message:@"observer should be notified for object '2' and for any object"];
@@ -81,7 +81,7 @@ var TestNotification = @"TestNotification";
     [self assert:4 equals:notificationCount message:@"observer should be notified only for any object"];
 
     // At this point we have TestNofication:nil observer and a TestNotification:25 observer.
-    observer2 = [center addObserverForName:nil object:2 usingBlock:notificationBlock];
+    observer2 = [center addObserverForName:nil object:2 queue:nil usingBlock:notificationBlock];
 
     [center postNotificationName:TestNotification object:2];
     [self assert:6 equals:notificationCount message:@"observer should be notified for TestNofication and for object '2' (TestNotification)"];


### PR DESCRIPTION
Previously, the method addObserverForName:object::usingBlock: didn't exist in Cappuccino.
Now it does.

To observe, you need to use the method - (id <CPObject>)addObserverForName:(CPString)aNotificationName object:(id)anObject usingBlock:(Function)block

To unregister observations, you pass the object returned by this method to removeObserver:. You must invoke removeObserver: or removeObserver:name:object:.

Test /Tests/Foundation/CPNotificationCenterTest.j

Fixed #2259
