### PR TITLE
Fixed: z-index of -1000 caused a blank screen in some browsers [+1]

### DIFF
--- a/Tools/capp/Resources/Templates/Application/index-debug.html
+++ b/Tools/capp/Resources/Templates/Application/index-debug.html
@@ -102,7 +102,7 @@
                 width: 100%;
 
                 /* Put it at the bottom of the stack so it doesn't interfere with UI */
-                z-index: -1000;
+                z-index: 0;
             }
 
             #cappuccino-body .container {

--- a/Tools/capp/Resources/Templates/Application/index.html
+++ b/Tools/capp/Resources/Templates/Application/index.html
@@ -72,7 +72,7 @@
                 width: 100%;
 
                 /* Put it at the bottom of the stack so it doesn't interfere with UI */
-                z-index: -1000;
+                z-index: 0;
             }
 
             #cappuccino-body .container {

--- a/Tools/capp/Resources/Templates/NibApplication/index-debug.html
+++ b/Tools/capp/Resources/Templates/NibApplication/index-debug.html
@@ -102,7 +102,7 @@
                 width: 100%;
 
                 /* Put it at the bottom of the stack so it doesn't interfere with UI */
-                z-index: -1000;
+                z-index: 0;
             }
 
             #cappuccino-body .container {

--- a/Tools/capp/Resources/Templates/NibApplication/index.html
+++ b/Tools/capp/Resources/Templates/NibApplication/index.html
@@ -72,7 +72,7 @@
                 width: 100%;
 
                 /* Put it at the bottom of the stack so it doesn't interfere with UI */
-                z-index: -1000;
+                z-index: 0;
             }
 
             #cappuccino-body .container {


### PR DESCRIPTION
Previously, a z-index value of -1000 caused some browsers to not display certain UI elements correctly. Setting this value to 0 instead seems to fix this.

This commit changes the default value in the templates generated by `capp gen`.

Fixes #2232, Refs #2194
