### PR TITLE
FIXED: combo box crash due to intercell spacing not being set

### DIFF
--- a/AppKit/CPComboBox.j
+++ b/AppKit/CPComboBox.j
@@ -470,7 +470,10 @@ var CPComboBoxTextSubview = @"text",
     [_listDelegate setFont:[self font]];
     [_listDelegate setAlignment:[self alignment]];
     [[_listDelegate scrollView] setHasVerticalScroller:_hasVerticalScroller];
-    [[_listDelegate tableView] setIntercellSpacing:_intercellSpacing];
+    
+    if(_intercellSpacing)
+        [[_listDelegate tableView] setIntercellSpacing:_intercellSpacing];
+    
     [[_listDelegate tableView] setRowHeight:_itemHeight];
 }
 


### PR DESCRIPTION
If a combo box is put using Interface Builder, with the current master, opening it result in a crash:

```
Uncaught TypeError: Cannot read property 'width' of null
VM22916:47 CGSizeEqualToSize
VM23138:278 $CPTableView__setIntercellSpacing_Objective-J.js:8944 
objj_msgSendFast1VM23148:269 $CPComboBox__setListDelegate_Objective-J.js:8944 
objj_msgSendFast1VM23148:310 $CPComboBox__popUpListObjective-J.js:8936 
objj_msgSendFast0VM23148:628 $CPComboBox___popUpButtonWasClickedObjective-J.js:8936 
objj_msgSendFast0VM23148:836 $_CPComboBoxPopUpButton__mouseDown_Objective-J.js:8944 
objj_msgSendFast1VM22920:97 $CPObject__performSelector_withObject_Objective-J.js:8952 
objj_msgSendFast2VM23044:944 $CPWindow__sendEvent_Objective-J.js:8944 
objj_msgSendFast1VM23081:316 $CPApplication__sendEvent_Objective-J.js:8944 
objj_msgSendFast1VM23056:741 $CPPlatformWindow__mouseEvent_VM23056:185 
mouseEventCallback
```

This patch solves this.

A reduction of the problem can be found here: https://www.dropbox.com/s/w361bjku3d6q24a/ComboCrash.zip?dl=0
