### PR TITLE
Fixed: button are always removed from the superview in layoutSubviews

### DIFF
--- a/AppKit/CPButtonBar.j
+++ b/AppKit/CPButtonBar.j
@@ -234,10 +234,11 @@
     {
         var button = buttonsNotHidden[count];
 
-        [button removeFromSuperview];
-
         if ([button isHidden])
+        {
+            [button removeFromSuperview];
             [buttonsNotHidden removeObject:button];
+        }
     }
 
     var currentButtonOffset = _resizeControlIsLeftAligned ? CGRectGetMaxX([self bounds]) + 1 : -1,


### PR DESCRIPTION
Previously, the button of a CPButtonBar were always removed and readded in the method layoutSubviews.
Now we only remove the hidden button.
