### PR TITLE
Fixed: wrong option for the observer in _CPPopoverWindow

### DIFF
--- a/AppKit/_CPPopoverWindow.j
+++ b/AppKit/_CPPopoverWindow.j
@@ -180,7 +180,7 @@ var _CPPopoverWindow_shouldClose_    = 1 << 4,
         return;
 
     _isObservingFrame = YES;
-    [_targetView addObserver:self forKeyPath:@"frame" options:CPKeyValueObservingOptionNew context:nil];
+    [_targetView addObserver:self forKeyPath:@"frame" options:0 context:nil];
 }
 
 /*!


### PR DESCRIPTION
Previously the option of the observer in _CPPopoverWindow were set to 0, now it's set to CPKeyValueObservingOptionNew.

This PR fix also another issue, the popoverWindow registered the observer in the wrong order. It firstly observed the frame of the sender and then removed it directly. Now it register when ordering front the popover and remove it when closing the popover
