### PR TITLE
Fix controls' heights that are displayed in CPPredicateEditor

### DIFF
--- a/AppKit/CPRuleEditor/_CPRuleEditorViewSliceRow.j
+++ b/AppKit/CPRuleEditor/_CPRuleEditorViewSliceRow.j
@@ -122,8 +122,8 @@
 {
     var title   = [[itemsArray objectAtIndex:index] title],
         font    = [_ruleEditor font],
-        width   = [title sizeWithFont:font].width + 20,
-        rect    = CGRectMake(0, 0, (width - width % 40) + 80, [_ruleEditor rowHeight]),
+        width   = [title sizeWithFont:font].width + 35, // 35 for right arrows + margins
+        rect    = CGRectMake(0, 0, width, [_ruleEditor rowHeight]),
         popup   = [[CPPopUpButton alloc] initWithFrame:rect];
 
     [popup setValue:font forThemeAttribute:@"font"];
@@ -315,8 +315,14 @@
         {
             [ruleView setControlSize:CPSmallControlSize];
 
+            var minSize = [ruleView currentValueForThemeAttribute:@"min-size"],
+                frame = [ruleView frame];
+
+            // Force controls to their minimum size
+            frame.size.height = minSize.height;
+            [ruleView setFrame:frame];
+
             [_ruleOptionViews addObject:ruleView];
-            var frame = [ruleView frame];
             [_ruleOptionInitialViewFrames addObject:frame];
             [_ruleOptionFrames addObject:frame];
 


### PR DESCRIPTION
Lastly, we removed the usage of max-size to enable some controls like CPTextField to have
a specific height. This may caused a CPTextField to have a wrong height.
As all controls in a CPPredicateEditor have a CPControlSize to small, we now force their height to the minimum size.
