### PR TITLE
Fixed: CPDatePicker takes key code CPReturnKeyCode all the time

### DIFF
--- a/AppKit/CPDatePicker/_CPDatePickerTextField.j
+++ b/AppKit/CPDatePicker/_CPDatePickerTextField.j
@@ -338,10 +338,11 @@ var CPZeroKeyCode = 48,
     if ([anEvent keyCode] == CPReturnKeyCode)
     {
         [_currentTextField _endEditing];
-        return YES;
+
+        return [super performKeyEquivalent:anEvent];
     }
 
-    return NO;
+    return [super performKeyEquivalent:anEvent];
 }
 
 /*! KeyDown event


### PR DESCRIPTION
Previously, the CPDatePicker took the key code CPReturnKeyCode all the time. It means, the key event wasn't redistributed to the other component, for example a defaultButton in a window.

Now instead of returning YES, it returns [super performKeyEquivalent:anEvent]
