### PR TITLE
Fixed: crash when dragging the first line of a RuleEditor above the field Any

### DIFF
--- a/AppKit/CPRuleEditor/CPRuleEditor.j
+++ b/AppKit/CPRuleEditor/CPRuleEditor.j
@@ -2207,7 +2207,7 @@ TODO: implement
         indexOfDropLine =  FLOOR(y / _sliceHeight),
         numberOfRows = [self numberOfRows];
 
-    if (indexOfDropLine < 0 || indexOfDropLine > numberOfRows || (indexOfDropLine >= [_draggingRows firstIndex] && indexOfDropLine <= [_draggingRows lastIndex] + 1))
+    if (indexOfDropLine <= 0 || indexOfDropLine > numberOfRows || (indexOfDropLine >= [_draggingRows firstIndex] && indexOfDropLine <= [_draggingRows lastIndex] + 1))
     {
         if (_subviewIndexOfDropLine !== CPNotFound && indexOfDropLine !== _subviewIndexOfDropLine)
             [self _clearDropLine];


### PR DESCRIPTION
Previously, cappuccino crashed when dragging the first line of a CPRuleEditor above the field any.
Now we make sure, we can not drag over this limit.
