### PR TITLE
Fixed: CPComboBox delegate methods

### DIFF
--- a/AppKit/CPComboBox.j
+++ b/AppKit/CPComboBox.j
@@ -241,25 +241,25 @@ var CPComboBoxTextSubview = @"text",
     if (aDelegate)
     {
         if ([aDelegate respondsToSelector:@selector(comboBoxSelectionIsChanging:)])
-            [defaultCenter addObserver:delegate
+            [defaultCenter addObserver:aDelegate
                               selector:@selector(comboBoxSelectionIsChanging:)
                                   name:CPComboBoxSelectionIsChangingNotification
                                 object:self];
 
         if ([aDelegate respondsToSelector:@selector(comboBoxSelectionDidChange:)])
-            [defaultCenter addObserver:delegate
+            [defaultCenter addObserver:aDelegate
                               selector:@selector(comboBoxSelectionDidChange:)
                                   name:CPComboBoxSelectionDidChangeNotification
                                 object:self];
 
         if ([aDelegate respondsToSelector:@selector(comboBoxWillPopUp:)])
-            [defaultCenter addObserver:delegate
+            [defaultCenter addObserver:aDelegate
                               selector:@selector(comboBoxWillPopUp:)
                                   name:CPComboBoxWillPopUpNotification
                                 object:self];
 
         if ([aDelegate respondsToSelector:@selector(comboBoxWillDismiss:)])
-            [defaultCenter addObserver:delegate
+            [defaultCenter addObserver:aDelegate
                               selector:@selector(comboBoxWillDismiss:)
                                   name:CPComboBoxWillDismissNotification
                                 object:self];


### PR DESCRIPTION
Previously, CPComboBox had a misspelled call to the delegate comboBoxWillDismiss method. This commit corrects the typo.

Fixes #2284.
