### PR TITLE
FIXED : a CPOperation marked as cancelled was never started 

### DIFF
--- a/Foundation/CPOperation.j
+++ b/Foundation/CPOperation.j
@@ -117,10 +117,11 @@ CPOperationQueuePriorityVeryHigh    = 8;
         [self willChangeValueForKey:@"isExecuting"];
         _executing = NO;
         [self didChangeValueForKey:@"isExecuting"];
-        [self willChangeValueForKey:@"isFinished"];
-        _finished = YES;
-        [self didChangeValueForKey:@"isFinished"];
     }
+
+    [self willChangeValueForKey:@"isFinished"];
+    _finished = YES;
+    [self didChangeValueForKey:@"isFinished"];
 }
 
 /*!

--- a/Foundation/CPOperationQueue.j
+++ b/Foundation/CPOperationQueue.j
@@ -70,7 +70,7 @@ var cpOperationMainQueue = nil;
         for (; i < count; i++)
         {
             var op = [_operations objectAtIndex:i];
-            if ([op isReady] && ![op isCancelled] && ![op isFinished] && ![op isExecuting])
+            if ([op isReady] && ![op isFinished] && ![op isExecuting])
             {
                 [op start];
             }
@@ -260,7 +260,7 @@ var cpOperationMainQueue = nil;
             for (; i < count; i++)
             {
                 var op = [ops objectAtIndex:i];
-                if ([op isReady] && ![op isCancelled] && ![op isFinished] && ![op isExecuting])
+                if ([op isReady] && ![op isFinished] && ![op isExecuting])
                 {
                     [op start];
                 }

--- a/Tests/Foundation/CPOperationQueueTest.j
+++ b/Tests/Foundation/CPOperationQueueTest.j
@@ -16,6 +16,33 @@ globalResults = [];
 
 @end
 
+@implementation TestOperation2 : CPOperation
+{
+    BOOL _started @accessors(getter=didStart);
+    BOOL _mained @accessors(getter=didMain);
+}
+
+- (id)init
+{
+    self = [super init];
+    _started = NO;
+    _mained = NO;
+    return self;
+}
+
+- (void)main
+{
+    _mained = YES;
+}
+
+- (void)start
+{
+    [super start];
+    _started = YES;
+}
+
+@end
+
 @implementation TestObserver : CPObject
 {
     CPArray changedKeyPaths @accessors;
@@ -165,6 +192,29 @@ globalResults = [];
 
     [oq setName:@"Soylent"];
     [self assert:@"name" equals:[[obs changedKeyPaths] objectAtIndex:4]];
+}
+
+- (void)testCancelledOperationDoesStart
+{
+    var op = [[TestOperation2 alloc] init],
+        queue = [[CPOperationQueue alloc] init];
+
+    [self assertFalse:[op isCancelled]];
+    [self assertFalse:[op isFinished]];
+    [self assertFalse:[op didMain]];
+    [self assertFalse:[op didStart]];
+
+    [op cancel];
+
+    [self assertTrue:[op isCancelled]];
+    [self assertFalse:[op isFinished]];
+
+    [queue addOperations:[op] waitUntilFinished:YES];
+
+    [self assertFalse:[op didMain]];
+    [self assertTrue:[op didStart]];
+    [self assertTrue:[op isCancelled]];
+    [self assertTrue:[op isFinished]];
 }
 
 @end

--- a/Tests/Foundation/CPOperationQueueTest.j
+++ b/Tests/Foundation/CPOperationQueueTest.j
@@ -16,7 +16,7 @@ globalResults = [];
 
 @end
 
-@implementation TestOperation2 : CPOperation
+@implementation TestCancelOperation : CPOperation
 {
     BOOL _started @accessors(getter=didStart);
     BOOL _mained @accessors(getter=didMain);
@@ -196,7 +196,7 @@ globalResults = [];
 
 - (void)testCancelledOperationDoesStart
 {
-    var op = [[TestOperation2 alloc] init],
+    var op = [[TestCancelOperation alloc] init],
         queue = [[CPOperationQueue alloc] init];
 
     [self assertFalse:[op isCancelled]];

--- a/Tests/Foundation/CPOperationTest.j
+++ b/Tests/Foundation/CPOperationTest.j
@@ -180,4 +180,21 @@
     [self assert:@"isCancelled" equals:[[obs changedKeyPaths] objectAtIndex:9]];
 }
 
+- (void)testCancelledOperationIsFinished
+{
+    var results = @[],
+        funcOp = [CPFunctionOperation functionOperationWithFunction:function() {[results addObject:"funcOp"];}];
+
+    [funcOp cancel];
+    [self assertTrue:[funcOp isCancelled]];
+    [self assertFalse:[funcOp isFinished]];
+
+    [funcOp start];
+
+    [self assertTrue:[funcOp isCancelled]];
+    [self assertTrue:[funcOp isFinished]];
+
+    [self assertTrue:([results count] == 0)];
+}
+
 @end


### PR DESCRIPTION
... (CPOperation -start not called), when managed in a queue.

FIXED : After an operation started, either from a queue or explicitely, its finished property was never set to true.

This was causing dependant operation to never be executed.
After this commit, cancelled operations are started (but not executed) and correctly marked as finished.

Tests: CPOperationQueueTest and CPOperationTest for an operation managed by a queue or run explicitely.