### PR TITLE
Fixed: -showRelativeToRect:ofView:preferredEdge is ignoring the positioning rectangle

### DIFF
--- a/AppKit/_CPPopoverWindow.j
+++ b/AppKit/_CPPopoverWindow.j
@@ -370,13 +370,6 @@ var _CPPopoverWindow_shouldClose_    = 1 << 4,
         _targetView = positioningView;
     }
 
-    if (positioningView !== _targetView)
-    {
-        [[_targetView window] removeChildWindow:self];
-        [self _removeFrameObserver];
-        _targetView = positioningView;
-    }
-
     [self makeKeyAndOrderFront:nil];
 
     /*

--- a/AppKit/_CPPopoverWindow.j
+++ b/AppKit/_CPPopoverWindow.j
@@ -370,6 +370,7 @@ var _CPPopoverWindow_shouldClose_    = 1 << 4,
         _targetView = positioningView;
     }
 
+    _targetRect = aRect;
     [self makeKeyAndOrderFront:nil];
 
     /*
@@ -383,7 +384,6 @@ var _CPPopoverWindow_shouldClose_    = 1 << 4,
         [[_targetView window] addChildWindow:self ordered:CPWindowAbove];
 
     _targetWindow = targetWindow;
-    _targetRect = aRect;
 
     if (!wasVisible)
         [self _trapNextMouseDown];

--- a/AppKit/_CPPopoverWindow.j
+++ b/AppKit/_CPPopoverWindow.j
@@ -64,6 +64,7 @@ var _CPPopoverWindow_shouldClose_    = 1 << 4,
     BOOL            _isObservingFrame;
     BOOL            _shouldPerformAnimation;
     CPInteger       _implementedDelegateMethods;
+    CGRect          _targetRect;
     CPWindow        _targetWindow;
     JSObject        _orderOutTransitionFunction;
     JSObject        _transitionCompleteFunction;
@@ -206,7 +207,7 @@ var _CPPopoverWindow_shouldClose_    = 1 << 4,
         if (![_targetView window])
             return;
 
-        var point = [self computeOriginFromRect:[_targetView bounds] ofView:_targetView preferredEdge:[_windowView preferredEdge]];
+        var point = [self computeOriginFromRect:_targetRect ofView:_targetView preferredEdge:[_windowView preferredEdge]];
         [self setFrameOrigin:point];
     }
 }
@@ -369,6 +370,13 @@ var _CPPopoverWindow_shouldClose_    = 1 << 4,
         _targetView = positioningView;
     }
 
+    if (positioningView !== _targetView)
+    {
+        [[_targetView window] removeChildWindow:self];
+        [self _removeFrameObserver];
+        _targetView = positioningView;
+    }
+
     [self makeKeyAndOrderFront:nil];
 
     /*
@@ -382,6 +390,7 @@ var _CPPopoverWindow_shouldClose_    = 1 << 4,
         [[_targetView window] addChildWindow:self ordered:CPWindowAbove];
 
     _targetWindow = targetWindow;
+    _targetRect = aRect;
 
     if (!wasVisible)
         [self _trapNextMouseDown];

--- a/AppKit/_CPPopoverWindow.j
+++ b/AppKit/_CPPopoverWindow.j
@@ -419,7 +419,7 @@ var _CPPopoverWindow_shouldClose_    = 1 << 4,
 
     if ([self isVisible])
     {
-        var point = [self computeOriginFromRect:[_targetView bounds] ofView:_targetView preferredEdge:[_windowView preferredEdge]];
+        var point = [self computeOriginFromRect:_targetRect ofView:_targetView preferredEdge:[_windowView preferredEdge]];
         [self setFrameOrigin:point];
     }
 }

--- a/AppKit/_CPPopoverWindow.j
+++ b/AppKit/_CPPopoverWindow.j
@@ -581,10 +581,12 @@ var _CPPopoverWindow_shouldClose_    = 1 << 4,
 
 - (void)_orderFront
 {
-    if (![self isVisible])
-        [self _addFrameObserver];
+    var wasVisible = [self isVisible];
 
     [super _orderFront];
+
+    if (!wasVisible)
+        [self _addFrameObserver];
 }
 
 - (void)_parentDidOrderInChild


### PR DESCRIPTION
previously, the popover was positioned centered to the positioning view regardless of the given positioning rectangle.

this bug had been introduced by commit 8b29369 and all credits for the fix go to @Dogild