### PR TITLE
Fixed: wrong default size of CPCheckBox when using constructor checkBoxWithTitle

### DIFF
--- a/AppKit/CPCheckBox.j
+++ b/AppKit/CPCheckBox.j
@@ -111,6 +111,30 @@ CPCheckBoxImageOffset = 4.0;
     return startedTracking;
 }
 
+
+#pragma mark -
+#pragma mark Override methods from CPButton
+
+- (CGSize)_minimumFrameSize
+{
+    var size = [super _minimumFrameSize],
+        contentView = [self ephemeralSubviewNamed:@"content-view"];
+
+    if (!contentView && [[self title] length])
+    {
+        var minSize = [self currentValueForThemeAttribute:@"min-size"],
+            maxSize = [self currentValueForThemeAttribute:@"max-size"];
+
+        // Here we always add the min size to the control which is the size of the view of the checkBox
+        size.width += minSize.width + CPCheckBoxImageOffset;
+
+        if (maxSize.width >= 0.0)
+            size.width = MIN(size.width, maxSize.width);
+    }
+
+    return size;
+}
+
 @end
 
 @implementation _CPCheckBoxValueBinder : CPBinder


### PR DESCRIPTION
Previously, the default size of a CPCheckBox created with the constructor method checkBoxWithTitle did not take in account the size of the checkBox view.
Now when calculating the size of the control, it will firstly calculate the size of the title and then add the size of the checkBox view and the offset.

Fixes #2281