### PR TITLE
Fixed: CPDatePicker does not grey out dates outside of minDate and maxDate

### DIFF
--- a/AppKit/CPDatePicker/_CPDatePickerCalendar.j
+++ b/AppKit/CPDatePicker/_CPDatePickerCalendar.j
@@ -737,7 +737,7 @@ var CPShortWeekDayNameArrayEn = [@"Mo", @"Tu", @"We", @"Th", @"Fr", @"Sa", @"Su"
 
         [dayTile setDate:[currentDate copy]];
         [dayTile setStringValue:currentDate.getDate()];
-        [dayTile setDisabled:![self isEnabled] || currentDate.getMonth() !== currentMonth.getMonth()];
+        [dayTile setDisabled:![self isEnabled] || currentDate.getMonth() !== currentMonth.getMonth() || currentDate < [_datePicker minDate] || currentDate > [_datePicker maxDate]];
         [dayTile setHighlighted:isPresentMonth && currentDate.getDate() == now.getDate()];
     }
 


### PR DESCRIPTION
Previously, CPDatePicker did not disable the dates outside of minDate and maxDate. This left the user wondering why some dates are not clickable for no apparent reason.
This PR sets the state to disabled if the tile not within minDate and maxDate.

Fixes #2262