### PR TITLE
Fixed: Wrong value parameter in CPObjectController>>setValue:forKey:

### DIFF
--- a/AppKit/CPObjectController.j
+++ b/AppKit/CPObjectController.j
@@ -749,7 +749,7 @@ var CPObjectControllerContentKey                        = @"CPObjectControllerCo
 
 - (void)setValue:(id)theValue forKey:(CPString)theKeyPath
 {
-    [self setValue:theKeyPath forKeyPath:theKeyPath];
+    [self setValue:theValue forKeyPath:theKeyPath];
 }
 
 - (unsigned)count


### PR DESCRIPTION
`CPObjectController>>setValue:forKey:` used the `theKeyPath` parameter as keypath **and** value.