### PR TITLE
FIXED: The text color of a checkbox inside a selected table row was black

### DIFF
--- a/AppKit/Themes/Aristo2/ThemeDescriptors.j
+++ b/AppKit/Themes/Aristo2/ThemeDescriptors.j
@@ -1482,6 +1482,8 @@ var themedButtonValues = nil,
 
         [@"font",                       [CPFont systemFontOfSize:CPFontCurrentSystemSize],  CPThemeStateNormal],
         [@"text-color",                 regularDisabledTextColor,                           CPThemeStateDisabled],
+        [@"text-color",         [CPColor colorWithCalibratedWhite:51.0 / 255.0 alpha:1.0],  CPThemeStateTableDataView],
+        [@"text-color",         [CPColor whiteColor],                                       [CPThemeStateTableDataView, CPThemeStateSelectedDataView, CPThemeStateFirstResponder, CPThemeStateKeyWindow]],
         [@"image-offset",               CPCheckBoxImageOffset],
 
         // CPThemeStateControlSizeRegular


### PR DESCRIPTION
Now it is white. The text-color values match the CPTextField values for the same theme states.

TEST: Tests/Manual/CPTableViewLion/