### PR TITLE
Fixed: Duplicate unit-tests

### DIFF
--- a/Tests/AppKit/CPStepperTest.j
+++ b/Tests/AppKit/CPStepperTest.j
@@ -32,14 +32,14 @@
     [self assert:1 equals:[stepper doubleValue]];
 }
 
-- (void)testPerformIncreaseWithIncrement
+- (void)testPerformClickUpIncreaseWithIncrement
 {
     [stepper setIncrement:10];
     [stepper performClickUp:nil];
     [self assert:10 equals:[stepper doubleValue]];
 }
 
-- (void)testPerformIncreaseWithIncrement
+- (void)testPerformClickDownIncreaseWithIncrement
 {
     [stepper setIncrement:10];
     [stepper performClickDown:nil];

--- a/Tests/Foundation/CPIndexSetTest.j
+++ b/Tests/Foundation/CPIndexSetTest.j
@@ -251,7 +251,13 @@ function descriptionWithoutEntity(aString)
 {
     var set1 = [CPIndexSet indexSetWithIndex:7],
         set2 = [CPIndexSet indexSetWithIndex:7],
-        set3 = [CPIndexSet indexSetWithIndexesInRange:CPMakeRange(7, 2)];
+        set3 = [CPIndexSet indexSetWithIndexesInRange:CPMakeRange(7, 2)],
+        differentSet = [CPIndexSet indexSetWithIndexesInRange:CPMakeRange(10, 11)],
+        equalSet = [CPIndexSet indexSetWithIndexesInRange:CPMakeRange(10, 10)];
+
+    [self assertFalse:[_set isEqualToIndexSet:differentSet]];
+    [self assertTrue:[_set isEqualToIndexSet:equalSet]];
+    [self assertTrue:[_set isEqualToIndexSet:_set]];
 
     [self assertFalse:[set1 isEqualToIndexSet:nil]];
     [self assertTrue:[set1 isEqualToIndexSet:set2]];
@@ -263,7 +269,14 @@ function descriptionWithoutEntity(aString)
 {
     var set1 = [CPIndexSet indexSetWithIndex:7],
         set2 = [CPIndexSet indexSetWithIndex:7],
-        set3 = [CPIndexSet indexSetWithIndexesInRange:CPMakeRange(7, 2)];
+        set3 = [CPIndexSet indexSetWithIndexesInRange:CPMakeRange(7, 2)],
+        differentSet = [CPIndexSet indexSetWithIndexesInRange:CPMakeRange(10, 11)],
+        equalSet = [CPIndexSet indexSetWithIndexesInRange:CPMakeRange(10, 10)];
+
+    [self assertFalse:[_set isEqual:nil]];
+    [self assertFalse:[_set isEqual:differentSet]];
+    [self assertTrue:[_set isEqual:equalSet]];
+    [self assertTrue:[_set isEqual:_set]];
 
     [self assertFalse:[set1 isEqual:nil]];
     [self assertFalse:[set1 isEqual:7]];
@@ -396,27 +409,6 @@ function descriptionWithoutEntity(aString)
     [_set shiftIndexesStartingAtIndex:0 by:-1];
     [self assert:[_set lastIndex] equals:CPNotFound];
     [self assert:[_set count] equals:0];
-}
-
-- (void)testIsEqual
-{
-    var differentSet = [CPIndexSet indexSetWithIndexesInRange:CPMakeRange(10, 11)],
-        equalSet = [CPIndexSet indexSetWithIndexesInRange:CPMakeRange(10, 10)];
-
-    [self assertFalse:[_set isEqual:nil]];
-    [self assertFalse:[_set isEqual:differentSet]];
-    [self assertTrue:[_set isEqual:equalSet]];
-    [self assertTrue:[_set isEqual:_set]];
-}
-
-- (void)testIsEqualToIndexSet
-{
-    var differentSet = [CPIndexSet indexSetWithIndexesInRange:CPMakeRange(10, 11)],
-        equalSet = [CPIndexSet indexSetWithIndexesInRange:CPMakeRange(10, 10)];
-
-    [self assertFalse:[_set isEqualToIndexSet:differentSet]];
-    [self assertTrue:[_set isEqualToIndexSet:equalSet]];
-    [self assertTrue:[_set isEqualToIndexSet:_set]];
 }
 
 - (void)testEnumerateIndexesUsingBlock_

--- a/Tests/Foundation/CPMutableArrayTest.j
+++ b/Tests/Foundation/CPMutableArrayTest.j
@@ -176,28 +176,6 @@
     [self assert:array equals:[arrayClass array]];
 }
 
-- (void)test_removeAllObjects
-{
-    var arrayClass = [[self class] arrayClass],
-        array = [arrayClass array];
-
-    [array removeAllObjects];
-    [self assert:0 same:[array count]];
-    [self assert:[arrayClass array] equals:array];
-
-    array = [arrayClass arrayWithObjects:0, 1, 2, 3, 4, 5, 6];
-
-    [array removeAllObjects];
-    [self assert:0 same:[array count]];
-    [self assert:[arrayClass array] equals:array];
-
-    array = [arrayClass arrayWithObjects:0, 1, 2, 3, 4, 5, 6, [arrayClass arrayWithObjects:0, 1, 2]];
-
-    [array removeAllObjects];
-    [self assert:0 same:[array count]];
-    [self assert:[arrayClass array] equals:array];
-}
-
 - (void)test_setArray_
 {
     var arrayClass = [[self class] arrayClass],

--- a/Tests/Foundation/CPTimeZoneTest.j
+++ b/Tests/Foundation/CPTimeZoneTest.j
@@ -83,7 +83,7 @@
     [self assert:timeZone equals:nil];
 }
 
-- (void)testexceptionTimeZoneWithNilNameWithData
+- (void)testexceptionTimeZoneWithNilName
 {
     try
     {


### PR DESCRIPTION
Previously, some unit-tests had the same name in a test file. Now they have unique name.