### PR TITLE
Fixed: compilation warning for NSTableHeaderView.j

### DIFF
--- a/AppKit/CPTableHeaderView.j
+++ b/AppKit/CPTableHeaderView.j
@@ -21,10 +21,11 @@
  */
 
 @import "CPTableColumn.j"
-@import "CPTableView.j"
 @import "CPView.j"
 @import "CPCursor.j"
 @import "_CPImageAndTextView.j"
+
+@class CPTableView
 
 @global CPApp
 

--- a/Tools/nib2cib/NSTableHeaderView.j
+++ b/Tools/nib2cib/NSTableHeaderView.j
@@ -43,8 +43,6 @@
             _bounds.size.height = height;
             _frame.size.height = height;
         }
-
-        _drawsColumnLines = YES;
     }
 
     return self;


### PR DESCRIPTION
Previously, there was a warning when compiling the file  NSTableHeaderView.j