### PR TITLE
Fixed: The CPDatePicker can take invalid date

### DIFF
--- a/AppKit/CPDatePicker/CPDatePicker.j
+++ b/AppKit/CPDatePicker/CPDatePicker.j
@@ -323,6 +323,15 @@ CPEraDatePickerElementFlag              = 0x0100;
 */
 - (void)_setDateValue:(CPDate)aDateValue timeInterval:(CPTimeInterval)aTimeInterval
 {
+    // Make sure to have a valid date and avoid NaN values
+    if (!isFinite(aDateValue))
+    {
+        [CPException raise:CPInvalidArgumentException
+                    reason:@"aDateValue is not valid"];
+        return;
+    }
+
+
     if (_minDate)
         aDateValue = new Date (MAX(aDateValue, _minDate));
 

--- a/AppKit/CPDatePicker/CPDatePicker.j
+++ b/AppKit/CPDatePicker/CPDatePicker.j
@@ -331,7 +331,6 @@ CPEraDatePickerElementFlag              = 0x0100;
         return;
     }
 
-
     if (_minDate)
         aDateValue = new Date (MAX(aDateValue, _minDate));
 


### PR DESCRIPTION
Previously, the CPDatePicker could get an invalid javascript date.
Now it will raise an exception when getting an invalidate date.