### PR TITLE
Fixed: CPSegmentedControl divider wrong color

### DIFF
--- a/AppKit/CPSegmentedControl.j
+++ b/AppKit/CPSegmentedControl.j
@@ -646,9 +646,8 @@ CPSegmentSwitchTrackingMomentary = 2;
         if (i == count - 1)
             continue;
 
-        var borderState = _themeStates[i].and(_themeStates[i + 1]);
 
-        borderState = (borderState.hasThemeState(CPThemeStateSelected) && !borderState.hasThemeState(CPThemeStateHighlighted)) ? CPThemeStateSelected : CPThemeStateNormal;
+        var borderState = _themeStates[i].and(_themeStates[i + 1]);
 
         borderState = isDisabled ? borderState.and(CPThemeStateDisabled) : borderState;
 


### PR DESCRIPTION
Previously, when clicking on segment, the divider did not have the expected color. Now they does.