### PR TITLE
Fixed: CPPopover position does not update each time

### DIFF
--- a/AppKit/_CPPopoverWindow.j
+++ b/AppKit/_CPPopoverWindow.j
@@ -181,7 +181,14 @@ var _CPPopoverWindow_shouldClose_    = 1 << 4,
         return;
 
     _isObservingFrame = YES;
-    [_targetView addObserver:self forKeyPath:@"frame" options:0 context:nil];
+
+    var view = _targetView;
+
+    while (view)
+    {
+        [view addObserver:self forKeyPath:@"frame" options:0 context:nil];
+        view = [view superview];
+    }
 }
 
 /*!
@@ -194,7 +201,14 @@ var _CPPopoverWindow_shouldClose_    = 1 << 4,
         return;
 
     _isObservingFrame = NO;
-    [_targetView removeObserver:self forKeyPath:@"frame"];
+
+    var view = _targetView;
+
+    while (view)
+    {
+        [view removeObserver:self forKeyPath:@"frame"];
+        view = [view superview];
+    }
 }
 
 /*!


### PR DESCRIPTION
Previously, when the frame of a superview of the targetedView would update, the popover did not update its position.
Now it does by observing each frame of each superviews of the targetedView.