### PR TITLE
New: added KVC operators unionOfObjects, distinctUnionOfObjects, unionOfArrays, distinctUnionOfArrays, distinctUnionOfSets

### DIFF
--- a/Foundation/_CPCollectionKVCOperators.j
+++ b/Foundation/_CPCollectionKVCOperators.j
@@ -22,7 +22,7 @@
 
 @import "CPObject.j"
 
-var _CPCollectionKVCOperatorSimpleRE = /^@(avg|count|m(ax|in)|sum)(\.|$)/;
+var _CPCollectionKVCOperatorSimpleRE = /^@(avg|count|m(ax|in)|sum|unionOfObjects|distinctUnionOfObjects|unionOfArrays|distinctUnionOfArrays|distinctUnionOfSets)(\.|$)/;
 
 
 @implementation _CPCollectionKVCOperator : CPObject
@@ -123,6 +123,91 @@ var _CPCollectionKVCOperatorSimpleRE = /^@(avg|count|m(ax|in)|sum)(\.|$)/;
 + (int)countForCollection:(id)aCollection propertyPath:(CPString)propertyPath
 {
     return [aCollection count];
+}
+
++ (CPArray)unionOfObjectsForCollection:(id)aCollection propertyPath:(CPString)propertyPath
+{
+    if (!propertyPath)
+        return [aCollection valueForUndefinedKey:@"@unionOfObjects"];
+
+    var objects = [aCollection valueForKeyPath:propertyPath];
+
+    if ([objects isKindOfClass:[CPSet class]])
+        return [objects allObjects];
+
+    return objects;
+}
+
++ (CPArray)distinctUnionOfObjectsForCollection:(id)aCollection propertyPath:(CPString)propertyPath
+{
+    if (!propertyPath)
+        return [aCollection valueForUndefinedKey:@"@distinctUnionOfObjects"];
+
+    var objects = [aCollection valueForKeyPath:propertyPath],
+        distinctObjects = [CPMutableArray new],
+        enumerator = [objects objectEnumerator],
+        object;
+
+    while ((object = [enumerator nextObject]) !== nil)
+    {
+        if ([distinctObjects indexOfObject:object] == CPNotFound)
+            [distinctObjects addObject:object];
+    }
+
+    return distinctObjects;
+}
+
++ (CPArray)unionOfArraysForCollection:(id)aCollection propertyPath:(CPString)propertyPath
+{
+    if (!propertyPath)
+        return [aCollection valueForUndefinedKey:@"@unionOfArrays"];
+
+    var objects = [],
+        number = [aCollection count];
+
+    for (var i = 0; i < number; i++)
+        [objects addObjectsFromArray:[aCollection[i] valueForKeyPath:propertyPath]];
+
+    return objects;
+}
+
++ (CPArray)distinctUnionOfArraysForCollection:(id)aCollection propertyPath:(CPString)propertyPath
+{
+    if (!propertyPath)
+        return [aCollection valueForUndefinedKey:@"@distinctUnionOfArrays"];
+
+    var objects = [],
+        number = [aCollection count];
+
+    for (var i = 0; i < number; i++)
+        [objects addObjectsFromArray:[aCollection[i] valueForKeyPath:propertyPath]];
+
+    var distinctObjects = [CPMutableArray new],
+        enumerator = [objects objectEnumerator],
+        object;
+
+    while ((object = [enumerator nextObject]) !== nil)
+    {
+        if ([distinctObjects indexOfObject:object] == CPNotFound)
+            [distinctObjects addObject:object];
+    }
+
+    return distinctObjects;
+}
+
++ (CPArray)distinctUnionOfSetsForCollection:(id)aCollection propertyPath:(CPString)propertyPath
+{
+    if (!propertyPath)
+        return [aCollection valueForUndefinedKey:@"@distinctUnionOfArrays"];
+
+    var objects = [CPMutableSet new],
+        number = [aCollection count],
+        sets = [aCollection allObjects];
+
+    for (var i = 0; i < number; i++)
+        [objects addObjectsFromArray:[[sets[i] valueForKeyPath:propertyPath] allObjects]];
+
+    return objects;
 }
 
 @end

--- a/Foundation/_CPCollectionKVCOperators.j
+++ b/Foundation/_CPCollectionKVCOperators.j
@@ -198,7 +198,7 @@ var _CPCollectionKVCOperatorSimpleRE = /^@(avg|count|m(ax|in)|sum|unionOfObjects
 + (CPArray)distinctUnionOfSetsForCollection:(id)aCollection propertyPath:(CPString)propertyPath
 {
     if (!propertyPath)
-        return [aCollection valueForUndefinedKey:@"@distinctUnionOfArrays"];
+        return [aCollection valueForUndefinedKey:@"@distinctUnionOfSets"];
 
     var objects = [CPMutableSet new],
         number = [aCollection count],

--- a/Tests/Foundation/CPKVCArrayTest.j
+++ b/Tests/Foundation/CPKVCArrayTest.j
@@ -331,20 +331,27 @@ var COUNTER;
          message:@"removeObjectFromValuesAtIndex: should have been called 10 times and insertObject:inValuesAtIndex: 2 times"];
 }
 
-- (void)testKVCArrayOperators
+- (void)testKVCCountArrayOperators
 {
     var one = [1, 1, 1, 1, 1, 1, 1, 1],
         two = [1, 2, 3, 4, 8, 0];
 
     [self assert:[one valueForKey:"@count"] equals:8];
-    [self assert:[one valueForKeyPath:"@sum.intValue"] equals:8];
-    [self assert:[two valueForKeyPath:"@avg.intValue"] equals:3];
-    [self assert:[two valueForKeyPath:"@max.intValue"] equals:8];
-    [self assert:[two valueForKeyPath:"@min.intValue"] equals:0];
 
     var a = [AA new];
     [a setValue:one forKey:"b"];
     [self assert:[a valueForKeyPath:"b.@count"] equals:8];
+}
+
+- (void)testKVCSumArrayOperators
+{
+    var one = [1, 1, 1, 1, 1, 1, 1, 1],
+        two = [1, 2, 3, 4, 8, 0];
+
+    [self assert:[one valueForKeyPath:"@sum.intValue"] equals:8];
+
+    var a = [AA new];
+    [a setValue:one forKey:"b"];
     [self assert:[a valueForKeyPath:"b.@sum.intValue"] equals:8];
 
     var b = [];
@@ -352,11 +359,120 @@ var COUNTER;
     [b addObject:[CPDictionary dictionaryWithObjects:[@"Dick", 31] forKeys:[@"name", @"age"]]];
     [b addObject:[CPDictionary dictionaryWithObjects:[@"Harry", 47] forKeys:[@"name", @"age"]]];
     [self assert:[b valueForKeyPath:@"@sum.age"] equals:105];
+}
+
+- (void)testKVCAvgArrayOperators
+{
+    var one = [1, 1, 1, 1, 1, 1, 1, 1],
+        two = [1, 2, 3, 4, 8, 0];
+
+    [self assert:[two valueForKeyPath:"@avg.intValue"] equals:3];
+
+    var b = [];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Tom", 27] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Dick", 31] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Harry", 47] forKeys:[@"name", @"age"]]];
     [self assert:[b valueForKeyPath:@"@avg.age"] equals:35];
+}
+
+- (void)testKVCMinArrayOperators
+{
+    var one = [1, 1, 1, 1, 1, 1, 1, 1],
+        two = [1, 2, 3, 4, 8, 0];
+
+    [self assert:[two valueForKeyPath:"@min.intValue"] equals:0];
+
+    var b = [];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Tom", 27] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Dick", 31] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Harry", 47] forKeys:[@"name", @"age"]]];
     [self assert:[b valueForKeyPath:@"@min.age"] equals:27];
-    [self assert:[b valueForKeyPath:@"@max.age"] equals:47];
     [self assert:[b valueForKeyPath:@"@min.name"] equals:@"Dick"];
+}
+
+- (void)testKVCMaxArrayOperators
+{
+    var one = [1, 1, 1, 1, 1, 1, 1, 1],
+        two = [1, 2, 3, 4, 8, 0];
+
+    [self assert:[two valueForKeyPath:"@max.intValue"] equals:8];
+
+    var b = [];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Tom", 27] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Dick", 31] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Harry", 47] forKeys:[@"name", @"age"]]];
+    [self assert:[b valueForKeyPath:@"@max.age"] equals:47];
     [self assert:[b valueForKeyPath:@"@max.name"] equals:@"Tom"];
+}
+
+- (void)testKVCDistinctUnionOfObjectsArrayOperators
+{
+    var b = [];
+
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Tom", 27] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Dick", 31] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Harry", 47] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Dick", 67] forKeys:[@"name", @"age"]]];
+
+    [self assert:[b valueForKeyPath:@"@distinctUnionOfObjects.name"] equals:[@"Tom", @"Dick", @"Harry"]];
+    [self assert:[b valueForKeyPath:@"@distinctUnionOfObjects.age"] equals:[27, 31, 47, 67]];
+}
+
+- (void)testKVCUnionOfObjectsArrayOperators
+{
+    var b = [];
+
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Tom", 27] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Dick", 31] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Harry", 47] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Dick", 67] forKeys:[@"name", @"age"]]];
+
+    [self assert:[b valueForKeyPath:@"@unionOfObjects.name"] equals:[@"Tom", @"Dick", @"Harry", @"Dick"]];
+    [self assert:[b valueForKeyPath:@"@unionOfObjects.age"] equals:[27, 31, 47, 67]];
+}
+
+- (void)testKVCDistinctUnionOfArraysArrayOperators
+{
+    var b = [];
+
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Tom", 27] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Dick", 31] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Harry", 47] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Dick", 67] forKeys:[@"name", @"age"]]];
+
+    var c = [];
+
+    [c addObject:[CPDictionary dictionaryWithObjects:[@"Jeff", 47] forKeys:[@"name", @"age"]]];
+    [c addObject:[CPDictionary dictionaryWithObjects:[@"Alex", 27] forKeys:[@"name", @"age"]]];
+    [c addObject:[CPDictionary dictionaryWithObjects:[@"Harry", 57] forKeys:[@"name", @"age"]]];
+    [c addObject:[CPDictionary dictionaryWithObjects:[@"Dick", 67] forKeys:[@"name", @"age"]]];
+
+    var all = [b, c];
+
+    [self assert:[all valueForKeyPath:@"@distinctUnionOfArrays.name"] equals:[@"Tom", @"Dick", @"Harry", @"Jeff", @"Alex"]];
+    [self assert:[all valueForKeyPath:@"@distinctUnionOfArrays.age"] equals:[27, 31, 47, 67, 57]];
+}
+
+- (void)testKVCUnionOfArraysArrayOperators
+{
+    var b = [];
+
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Tom", 27] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Dick", 31] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Harry", 47] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Dick", 67] forKeys:[@"name", @"age"]]];
+
+    var c = [];
+
+    [c addObject:[CPDictionary dictionaryWithObjects:[@"Jeff", 47] forKeys:[@"name", @"age"]]];
+    [c addObject:[CPDictionary dictionaryWithObjects:[@"Alex", 27] forKeys:[@"name", @"age"]]];
+    [c addObject:[CPDictionary dictionaryWithObjects:[@"Harry", 57] forKeys:[@"name", @"age"]]];
+    [c addObject:[CPDictionary dictionaryWithObjects:[@"Dick", 67] forKeys:[@"name", @"age"]]];
+
+    var all = [b, c];
+
+    [self assert:[all valueForKeyPath:@"@unionOfArrays.name"] equals:[@"Tom", @"Dick", @"Harry", @"Dick", @"Jeff", @"Alex", @"Harry", @"Dick"]];
+    [self assert:[all valueForKeyPath:@"@unionOfArrays.age"] equals:[27, 31, 47, 67, 47, 27, 57, 67]];
 }
 
 @end

--- a/Tests/Foundation/CPSetTest.j
+++ b/Tests/Foundation/CPSetTest.j
@@ -246,17 +246,64 @@
     [self assertSet:set onlyHasObjects:["horizon", "surfer", "7"]];
 }
 
-- (void)testKVCSetOperators
+- (void)testKVCCountSetOperators
 {
     var one = [CPSet setWithArray:[@"one", @"two", @"three"]],
         two = [CPSet setWithArray:[1, 2, 3, 4, 8, 0]];
 
     [self assert:[one valueForKey:"@count"] equals:3];
     [self assert:[two valueForKey:"@count"] equals:6];
+}
+
+- (void)testKVCSumSetOperators
+{
+    var one = [CPSet setWithArray:[@"one", @"two", @"three"]],
+        two = [CPSet setWithArray:[1, 2, 3, 4, 8, 0]];
+
     [self assert:[two valueForKeyPath:"@sum.intValue"] equals:18];
+
+    var b = [CPSet set];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Tom", 27] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Dick", 31] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Harry", 47] forKeys:[@"name", @"age"]]];
+    [self assert:[b valueForKeyPath:@"@sum.age"] equals:105];
+}
+
+- (void)testKVCAvgSetOperators
+{
+    var one = [CPSet setWithArray:[@"one", @"two", @"three"]],
+        two = [CPSet setWithArray:[1, 2, 3, 4, 8, 0]];
+
     [self assert:[two valueForKeyPath:"@avg.doubleValue"] equals:3.0];
+
+    var b = [CPSet set];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Tom", 27] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Dick", 31] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Harry", 47] forKeys:[@"name", @"age"]]];
+    [self assert:[b valueForKeyPath:@"@avg.age"] equals:35];
+}
+
+- (void)testKVCMaxSetOperators
+{
+    var one = [CPSet setWithArray:[@"one", @"two", @"three"]],
+        two = [CPSet setWithArray:[1, 2, 3, 4, 8, 0]];
+
     [self assert:[one valueForKeyPath:"@max.description"] equals:@"two"];
     [self assert:[two valueForKeyPath:"@max.intValue"] equals:8];
+
+    var b = [CPSet set];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Tom", 27] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Dick", 31] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Harry", 47] forKeys:[@"name", @"age"]]];
+    [self assert:[b valueForKeyPath:@"@max.age"] equals:47];
+    [self assert:[b valueForKeyPath:@"@max.name"] equals:@"Tom"];
+}
+
+- (void)testKVCMinSetOperators
+{
+    var one = [CPSet setWithArray:[@"one", @"two", @"three"]],
+        two = [CPSet setWithArray:[1, 2, 3, 4, 8, 0]];
+
     [self assert:[one valueForKeyPath:"@min.description"] equals:@"one"];
     [self assert:[two valueForKeyPath:"@min.intValue"] equals:0];
 
@@ -264,12 +311,51 @@
     [b addObject:[CPDictionary dictionaryWithObjects:[@"Tom", 27] forKeys:[@"name", @"age"]]];
     [b addObject:[CPDictionary dictionaryWithObjects:[@"Dick", 31] forKeys:[@"name", @"age"]]];
     [b addObject:[CPDictionary dictionaryWithObjects:[@"Harry", 47] forKeys:[@"name", @"age"]]];
-    [self assert:[b valueForKeyPath:@"@sum.age"] equals:105];
-    [self assert:[b valueForKeyPath:@"@avg.age"] equals:35];
-    [self assert:[b valueForKeyPath:@"@min.age"] equals:27];
-    [self assert:[b valueForKeyPath:@"@max.age"] equals:47];
     [self assert:[b valueForKeyPath:@"@min.name"] equals:@"Dick"];
-    [self assert:[b valueForKeyPath:@"@max.name"] equals:@"Tom"];
+}
+
+- (void)testKVCDistinctUnionOfObjectsSetOperators
+{
+    var b = [CPSet set];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Tom", 27] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Dick", 31] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Harry", 47] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Dick", 67] forKeys:[@"name", @"age"]]];
+
+    [self assert:[b valueForKeyPath:@"@distinctUnionOfObjects.name"] equals:[@"Tom", @"Dick", @"Harry"]];
+    [self assert:[b valueForKeyPath:@"@distinctUnionOfObjects.age"] equals:[27, 31, 47, 67]];
+}
+
+- (void)testKVCUnionOfObjectsSetOperators
+{
+    var b = [CPSet set];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Tom", 27] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Dick", 31] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Harry", 47] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Dick", 67] forKeys:[@"name", @"age"]]];
+
+    [self assert:[b valueForKeyPath:@"@unionOfObjects.name"] equals:[@"Tom", @"Dick", @"Harry"]];
+    [self assert:[b valueForKeyPath:@"@unionOfObjects.age"] equals:[27, 31, 47, 67]];
+}
+
+- (void)testKVCDistinctUnionOfSetsSetOperators
+{
+    var b = [CPSet set];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Tom", 27] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Dick", 31] forKeys:[@"name", @"age"]]];
+    [b addObject:[CPDictionary dictionaryWithObjects:[@"Harry", 47] forKeys:[@"name", @"age"]]];
+
+    var c = [CPSet set];
+    [c addObject:[CPDictionary dictionaryWithObjects:[@"Tom", 27] forKeys:[@"name", @"age"]]];
+    [c addObject:[CPDictionary dictionaryWithObjects:[@"Dick", 31] forKeys:[@"name", @"age"]]];
+    [c addObject:[CPDictionary dictionaryWithObjects:[@"Alex", 52] forKeys:[@"name", @"age"]]];
+
+    var all = [CPSet set];
+    [all addObject:b];
+    [all addObject:c];
+
+    [self assert:[all valueForKeyPath:@"@distinctUnionOfSets.name"] equals:[[CPSet alloc] initWithObjects:@"Tom", @"Dick", @"Harry", @"Alex"]];
+    [self assert:[all valueForKeyPath:@"@distinctUnionOfSets.age"] equals:[[CPSet alloc] initWithObjects:27, 31, 47, 52]];
 }
 
 - (void)testMember


### PR DESCRIPTION
This PR adds the KVC operators unionOfObjects, distinctUnionOfObjects, unionOfArrays, distinctUnionOfArrays, distinctUnionOfSets for array and set.

Unit-Tests Tests/Foundation/CPKVCArrayTest.j
Unit-Tests Tests/Foundation/CPSetTest.j