### PR TITLE
New: Added method viewAtColumn:row:makeIfNecessary: in CPTableView

### DIFF
--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -3403,7 +3403,6 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
 */
 - (void)load
 {
-    console.error(@"load");
     if (_reloadAllRows)
     {
         [self _unloadDataViewsInRows:_exposedRows columns:_exposedColumns];

--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -1622,7 +1622,7 @@ NOT YET IMPLEMENTED
 */
 - (int)numberOfRows
 {
-        return _numberOfRows;
+    return _numberOfRows;
 }
 
 - (int)_numberOfRows
@@ -3403,6 +3403,7 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
 */
 - (void)load
 {
+    console.error(@"load");
     if (_reloadAllRows)
     {
         [self _unloadDataViewsInRows:_exposedRows columns:_exposedColumns];
@@ -3701,6 +3702,64 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
     // Otherwise see if we have a view in the cib with this identifier
     else if (_isViewBased)
         view = [self _unarchiveViewWithIdentifier:anIdentifier owner:anOwner];
+
+    return view;
+}
+
+/*!
+    Returns an instance of CPView
+
+    @param column The index of the column in the tableColumn array
+    @param row The index of the row
+    @param makeIfNecessary YES if a view is required, NO if you want to update properties on a view, if one is available.
+
+    @discussion
+    This method first attempts to return an available view, which is generally in the visible area. If there is no available view, and makeIfNecessary is YES, a prepared temporary view is returned. If makeIfNecessary is NO, and the view is not available, nil will be returned.
+
+    An exception will be thrown if row is an invalid row index and if column is an invalid column index
+*/
+- (id)viewAtColumn:(CPInteger)column row:(CPInteger)row makeIfNecessary:(BOOL)makeIfNecessary
+{
+    if (row > (_numberOfRows - 1))
+        [CPException raise:CPInvalidArgumentException
+                    reason:@"Row " + row + " out of row range [0-" + (_numberOfRows - 1) + "] for rowViewAtRow:createIfNeeded:"];
+
+    if (column > (NUMBER_OF_COLUMNS() - 1))
+        [CPException raise:CPInvalidArgumentException
+                    reason:@"Column " + column + " out of row range [0-" + (NUMBER_OF_COLUMNS ()- 1) + "] for rowViewAtRow:createIfNeeded:"];
+
+    var dataViewsForRow = _dataViewsForRows[row],
+        tableColumn = _tableColumns[column],
+        tableColumnUID = [tableColumn UID],
+        view = dataViewsForRow ? dataViewsForRow[tableColumnUID] : nil;
+
+    if (!makeIfNecessary)
+        return view || nil;
+
+    if (!view)
+    {
+        if (!dataViewsForRow)
+        {
+            dataViewsForRow = {}
+            _dataViewsForRows[row] = dataViewsForRow;
+        }
+
+        // Here we will add this view to the tableView and add it to the exposedRows adn columns.
+        // The view will be deleted if necessary during the next run loop cycle of the table view
+        // This is how cocoa works
+        view = [self preparedViewAtColumn:column row:row];
+
+        if ([view superview] !== self)
+            [self addSubview:view];
+
+        dataViewsForRow[tableColumnUID] = view;
+
+        [_exposedRows addIndex:row];
+        [_exposedColumns addIndex:column];
+
+        // Make sure to layout the tableView again
+        [self setNeedsLayout];
+    }
 
     return view;
 }
@@ -4349,7 +4408,9 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
 - (void)viewWillMoveToSuperview:(CPView)aView
 {
     if ([aView isKindOfClass:[CPClipView class]])
+    {
         _observedClipView = aView;
+    }
     else
     {
         [self _stopObservingClipView];

--- a/Tests/AppKit/CPTableViewTest.j
+++ b/Tests/AppKit/CPTableViewTest.j
@@ -500,6 +500,95 @@
     }];
 }
 
+- (void)testMethodViewAtColumnWithMakeIfNecessarySetToNo
+{
+    var scrollView = [[CPScrollView alloc] initWithFrame:CGRectMake(0, 0, 100.0, 100.0)];
+    [scrollView setDocumentView:tableView];
+
+    var dataSource = [TestDataSource new];
+
+    [tableView setDelegate:[CustomeSizeTableDelegate new]];
+    [dataSource setTableEntries:["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]];
+    [tableView setDataSource:dataSource];
+
+    // Process all events immediately to make sure table data views are reloaded.
+    [[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
+
+    var view = [tableView viewAtColumn:0 row:0 makeIfNecessary:NO];
+    [self assert:[view objectValue] equals:@"A" message:@"View should be equal to A"];
+    [self assert:[view superview] equals:tableView message:@"Superview of view should be the tableview"];
+
+    view = [tableView viewAtColumn:0 row:25 makeIfNecessary:NO];
+    [self assert:view equals:nil message:@"View should be equal to nil"];
+}
+
+- (void)testMethodViewAtColumnWithMakeIfNecessarySetToYes
+{
+    var scrollView = [[CPScrollView alloc] initWithFrame:CGRectMake(0, 0, 100.0, 100.0)];
+    [scrollView setDocumentView:tableView];
+
+    var dataSource = [TestDataSource new];
+
+    [tableView setDelegate:[CustomeSizeTableDelegate new]];
+    [dataSource setTableEntries:["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]];
+    [tableView setDataSource:dataSource];
+
+    // Process all events immediately to make sure table data views are reloaded.
+    [[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
+
+    var view = [tableView viewAtColumn:0 row:0 makeIfNecessary:YES];
+    [self assert:[view objectValue] equals:@"A" message:@"View should be equal to A"];
+    [self assert:[view superview] equals:tableView message:@"Superview of view should be the tableview"];
+
+    view = [tableView viewAtColumn:0 row:25 makeIfNecessary:YES];
+    [self assert:[view objectValue] equals:@"Z" message:@"View should be equal to Z"];
+    [self assert:[view superview] equals:tableView message:@"Superview of view should be the tableview"];
+}
+
+- (void)testMethodViewAtColumnException
+{
+    var scrollView = [[CPScrollView alloc] initWithFrame:CGRectMake(0, 0, 100.0, 100.0)];
+    [scrollView setDocumentView:tableView];
+
+    var dataSource = [TestDataSource new];
+
+    [tableView setDelegate:[CustomeSizeTableDelegate new]];
+    [dataSource setTableEntries:["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]];
+    [tableView setDataSource:dataSource];
+
+    // Process all events immediately to make sure table data views are reloaded.
+    [[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
+
+    var expectedMessage = @"Row 26 out of row range [0-25] for rowViewAtRow:createIfNeeded:",
+        exceptionMessage = @"";
+
+    try
+    {
+        [tableView viewAtColumn:0 row:26 makeIfNecessary:YES];
+    }
+    catch (e)
+    {
+        exceptionMessage = e.message;
+    }
+
+    [self assert:expectedMessage equals:exceptionMessage];
+
+
+    expectedMessage = @"Column 2 out of row range [0-0] for rowViewAtRow:createIfNeeded:";
+
+    try
+    {
+        [tableView viewAtColumn:2 row:2 makeIfNecessary:YES];
+    }
+    catch (e)
+    {
+        exceptionMessage = e.message;
+    }
+
+    [self assert:expectedMessage equals:exceptionMessage];
+
+}
+
 @end
 
 @implementation FirstResponderConfigurableTableView : CPTableView
@@ -532,6 +621,23 @@
 - (void)tableView:(CPTableView)aTableView setObjectValue:(id)anObject forTableColumn:(CPTableColumn)aTableColumn row:(CPInteger)aRow
 {
     tableEntries[aRow] = anObject;
+}
+
+@end
+
+@implementation CustomeSizeTableDelegate : CPObject
+{
+
+}
+
+- (float)tableView:(CPTableView)aTableView heightOfRow:(CPInteger)aRowIndex
+{
+    return 200;
+}
+
+- (CPView)tableView:(CPTableView)aTableView viewForTableColumn:(CPTableColumn)aTableColumn row:(CPInteger)aRowIndex
+{
+    return [[CPTextField alloc] initWithFrame:CGRectMake(0,0, 100, 100)];
 }
 
 @end


### PR DESCRIPTION
This PR adds the method viewAtColumn:row:makeIfNecessary: in CPTableView.
This method first attempts to return an available view, which is generally in the visible area. If there is no available view, and makeIfNecessary is YES, a prepared temporary view is returned. If makeIfNecessary is NO, and the view is not available, nil will be returned.
An exception will be thrown if row is an invalid row index and if column is an invalid column index.
The returned result should generally not be held onto for longer than the current run loop cycle. Instead they should re-query the table view for the row view.

UnitTests in Tests/AppKit/CPTableViewTests.j