### PR TITLE
New: added the method setNeedsLayout:

### DIFF
--- a/AppKit/CPView.j
+++ b/AppKit/CPView.j
@@ -2624,6 +2624,11 @@ setBoundsOrigin:
     _CPDisplayServerAddLayoutObject(self);
 }
 
+- (BOOL)needsLayout
+{
+    return _needsLayout;
+}
+
 - (void)layoutIfNeeded
 {
     if (_needsLayout)

--- a/AppKit/CPView.j
+++ b/AppKit/CPView.j
@@ -2608,8 +2608,16 @@ setBoundsOrigin:
 
 - (void)setNeedsLayout
 {
-    if (!(_viewClassFlags & CPViewHasCustomLayoutSubviews))
+    [self setNeedsLayout:YES];
+}
+
+- (void)setNeedsLayout:(BOOL)needLayout
+{
+    if (!(_viewClassFlags & CPViewHasCustomLayoutSubviews) || !needLayout)
+    {
+        _needsLayout = NO;
         return;
+    }
 
     _needsLayout = YES;
 

--- a/Tests/AppKit/CPViewTest.j
+++ b/Tests/AppKit/CPViewTest.j
@@ -643,8 +643,78 @@ var methodCalled;
     [self assert:expectedRestult equals:methodCalled];
 }
 
+- (void)testLayoutSubviews
+{
+    var layoutView = [[CPLayoutView alloc] initWithFrame:CGRectMakeZero()];
+
+    [layoutView setIdentifier:@"layoutView"];
+
+    [[window contentView] addSubview:layoutView];
+    [layoutView setNeedsLayout]
+
+    methodCalled = [];
+    [[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
+
+    var expectedRestult = ["layoutSubivews_layoutView"];
+    [self assert:expectedRestult equals:methodCalled];
+
+
+    [layoutView setNeedsLayout]
+    [layoutView setNeedsLayout]
+
+    methodCalled = [];
+    [[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
+
+    expectedRestult = ["layoutSubivews_layoutView"];
+    [self assert:expectedRestult equals:methodCalled];
+
+
+    [layoutView setNeedsLayout:YES]
+
+    methodCalled = [];
+    [[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
+
+    expectedRestult = ["layoutSubivews_layoutView"];
+    [self assert:expectedRestult equals:methodCalled];
+
+
+    [layoutView setNeedsLayout:YES];
+    [layoutView setNeedsLayout:NO];
+
+    methodCalled = [];
+    [[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
+
+    expectedRestult = [];
+    [self assert:expectedRestult equals:methodCalled];
+
+
+    [layoutView setNeedsLayout:YES];
+    [layoutView setNeedsLayout:NO];
+    [layoutView setNeedsLayout:YES];
+
+    methodCalled = [];
+    [[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
+
+    expectedRestult = ["layoutSubivews_layoutView"];
+    [self assert:expectedRestult equals:methodCalled];
+}
+
 @end
 
+@implementation CPLayoutView : CPView
+{
+
+}
+
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+
+    var string = @"layoutSubivews_" + [self identifier];
+    [methodCalled addObject:string];
+}
+
+@end
 
 @implementation CPResponderView : CPView
 


### PR DESCRIPTION
This PR adds the possibility to layout or not a CPView.
Previously, once setNeedsLayout was called on a CPView, it wasn't possible to cancel the layout of the view.
Now we can as in cocoa. The method setNeedsLayout will still work (it calls the method setNeedsLayout: with YES).

UnitTests in Tests/AppKit/CPViewTest.j