### PR TITLE
Fixed: CPApplication dispatch the event when having the auto complete menu of a CPTokenField opened

### DIFF
--- a/AppKit/CPTokenField.j
+++ b/AppKit/CPTokenField.j
@@ -1033,6 +1033,21 @@ CPTokenFieldDeleteButtonType     = 1;
     [[[self window] platformWindow] _propagateCurrentDOMEvent:YES];
 }
 
+- (BOOL)performKeyEquivalent:(CPEvent)anEvent
+{
+    var characters = [anEvent characters];
+
+    // Here we handle the event when getting a CPNewlineCharacter or CPCarriageReturnCharacter when the menu is open
+    // We don't want that the application dispatches the event to the other controls
+    if ([self hasThemeState:CPThemeStateAutocompleting] && (characters === CPNewlineCharacter || characters === CPCarriageReturnCharacter))
+    {
+        [self keyDown:anEvent];
+        return YES;
+    }
+
+    return [super performKeyEquivalent:anEvent];
+}
+
 - (void)textDidChange:(CPNotification)aNotification
 {
     if ([aNotification object] !== self)


### PR DESCRIPTION
Previously, the CPApplication dispatched the current event when having the auto complete menu of a CPTokenField opened.
This occurs weird behavior. For instance when hitting enter on the menu and having a default button, the action of the button was triggered.
Now, the CPTokenField handles the key enter when the autocomplete menu is opened.