### PR TITLE
Duplicate ivar on superclass

### DIFF
--- a/AppKit/CPColorPanel.j
+++ b/AppKit/CPColorPanel.j
@@ -71,7 +71,6 @@ var SharedColorPanel = nil,
 */
 @implementation CPColorPanel : CPPanel
 {
-    _CPColorPanelToolbar    _toolbar;
     _CPColorPanelSwatches   _swatchView;
     _CPColorPanelPreview    _previewView;
 

--- a/AppKit/CPMenu/_CPMenuBarWindow.j
+++ b/AppKit/CPMenu/_CPMenuBarWindow.j
@@ -32,7 +32,6 @@
 
 @implementation _CPMenuBarWindow : CPPanel
 {
-    CPMenu      _menu;
     CPView      _highlightView;
     CPArray     _menuItemViews;
 

--- a/AppKit/CPRuleEditor/_CPRuleEditorViewSlice.j
+++ b/AppKit/CPRuleEditor/_CPRuleEditorViewSlice.j
@@ -29,7 +29,6 @@
     CGRect       _animationTargetRect   @accessors(property=_animationTargetRect);
     BOOL         _selected              @accessors(getter=_isSelected, setter=_setSelected:);
     BOOL         _lastSelected          @accessors(getter=_isLastSelected, setter=_setLastSelected:);
-    CPColor      _backgroundColor       @accessors(property=backgroundColor);
     BOOL         _editable              @accessors(getter=isEditable, setter=setEditable:);
 }
 

--- a/AppKit/CPWindow/_CPHUDWindowView.j
+++ b/AppKit/CPWindow/_CPHUDWindowView.j
@@ -27,7 +27,6 @@
 
 @implementation _CPHUDWindowView : _CPTitleableWindowView
 {
-    CPView              _toolbarView;
     CPButton            _closeButton;
 }
 

--- a/AppKit/CPWindow/_CPStandardWindowView.j
+++ b/AppKit/CPWindow/_CPStandardWindowView.j
@@ -94,7 +94,6 @@ var _CPStandardWindowViewDividerViewHeight = 1.0;
     _CPTexturedWindowHeadView   _headView;
     CPView                      _dividerView;
     CPView                      _bodyView;
-    CPView                      _toolbarView;
 
     CPButton                    _closeButton;
     CPButton                    _minimizeButton;

--- a/AppKit/Cib/CPCibHelpConnector.j
+++ b/AppKit/Cib/CPCibHelpConnector.j
@@ -24,7 +24,6 @@
 
 @implementation CPCibHelpConnector : CPCibConnector
 {
-    id _destination;
     id _file;
     id _marker;
 }

--- a/AppKit/_CPPopoverWindow.j
+++ b/AppKit/_CPPopoverWindow.j
@@ -63,7 +63,6 @@ var _CPPopoverWindow_shouldClose_    = 1 << 4,
     BOOL            _browserAnimates;
     BOOL            _isObservingFrame;
     BOOL            _shouldPerformAnimation;
-    CPInteger       _implementedDelegateMethods;
     CGRect          _targetRect;
     CPWindow        _targetWindow;
     JSObject        _orderOutTransitionFunction;

--- a/Objective-J/ObjJAcornCompiler.js
+++ b/Objective-J/ObjJAcornCompiler.js
@@ -1754,8 +1754,15 @@ ClassDeclarationStatement: function(node, st, c) {
                 ivar = {"type": ivarType, "name": ivarName},
                 accessors = ivarDecl.accessors;
 
-            if (ivars[ivarName])
-                throw compiler.error_message("Instance variable '" + ivarName + "' is already declared for class " + className, ivarDecl.id);
+            var checkIfIvarIsAlreadyDeclaredAndInSuperClass = function(aClassDef, recursiveFunction) {
+                if (aClassDef.ivars[ivarName])
+                    throw compiler.error_message("Instance variable '" + ivarName + "' is already declared for class " + className + (aClassDef.name !== className ? " in superclass " + aClassDef.name : ""), ivarDecl.id);
+                if (aClassDef.superClass)
+                    recursiveFunction(aClassDef.superClass, recursiveFunction);
+            }
+
+            // Check if ivar is already declared in this class or its super classes.
+            checkIfIvarIsAlreadyDeclaredAndInSuperClass(classDef, checkIfIvarIsAlreadyDeclaredAndInSuperClass);
 
             var isTypeDefined = !ivarTypeIsClass || typeof global[ivarType] !== "undefined" || typeof window[ivarType] !== "undefined"
                                 || compiler.getClassDef(ivarType) || compiler.getTypeDef(ivarType) || ivarType == classDef.name;

--- a/Tests/Manual/CompilationTests/TestCases/11.j
+++ b/Tests/Manual/CompilationTests/TestCases/11.j
@@ -1,0 +1,28 @@
+// Expected output: 256
+
+/*
+
+START_EXPECTED
+Error on line 10778 of file [unknown]
+SyntaxError:
+int myIvar;
+    ^
+ERROR line 12 in file:[__PATH__]: Instance variable 'myIvar' is already declared for class MySubclass in superclass MySuperclass
+END_EXPECTED
+*/
+
+@import <Foundation/Foundation.j>
+
+@implementation MySuperclass : CPObject
+{
+	int myIvar;
+}
+
+@end
+
+@implementation MySubclass : MySuperclass
+{
+	int myIvar;
+}
+
+@end

--- a/Tests/Manual/CompilationTests/TestCases/7.j
+++ b/Tests/Manual/CompilationTests/TestCases/7.j
@@ -7,7 +7,7 @@ Error on line 10001 of file [unknown]
 SyntaxError:
 @implementation MyType : CPObject
                 ^
-ERROR line 5 in file:[__PATH__]: MyType is already declared as type
+ERROR line 5 in file:[__PATH__]: MyType is already declared as a type
 END_EXPECTED
 
 */

--- a/Tests/Manual/CompilationTests/run.py
+++ b/Tests/Manual/CompilationTests/run.py
@@ -55,6 +55,7 @@ def cleanup_output(output):
     output = output.replace(" ", "")
     output = output.replace("\n", "")
     output = output.replace("[0m", "")
+    output = re.sub('\d*offile\[unknown\]', '', output)
     return re.sub('[^\s!-~]', '', output)
 
 

--- a/Tools/nib2cib/NSButton.j
+++ b/Tools/nib2cib/NSButton.j
@@ -409,7 +409,6 @@ var NSButtonIsBorderedMask = 0x00800000,
 
 @implementation NSButtonCell : NSActionCell
 {
-    BOOL        _isBordered         @accessors(readonly, getter=isBordered);
     int         _bezelStyle         @accessors(readonly, getter=bezelStyle);
 
     CPString    _title              @accessors(readonly, getter=title);

--- a/Tools/nib2cib/NSDatePicker.j
+++ b/Tools/nib2cib/NSDatePicker.j
@@ -177,7 +177,6 @@ var NSDatePickerDefaultSize = 22,
     BOOL            _drawsBackground    @accessors(getter=drawsBackground);
     CPDate          _minDate            @accessors(getter=minDate);
     CPDate          _maxDate            @accessors(getter=maxDate);
-    CPDateFormatter _formatter          @accessors(getter=formatter);
     CPInteger       _datePickerMode     @accessors(getter=datePickerMode);
     CPInteger       _datePickerElements @accessors(getter=datePickerElements);
     CPInteger       _datePickerType     @accessors(getter=datePickerType);


### PR DESCRIPTION
Today you can declare a duplicate ivar in a subclass. Now the compiler will generate an error.

This fixes #2271 and #362