### PR TITLE
Added documentation for CPArray's hash method

### DIFF
--- a/Foundation/CPArray/_CPArray.j
+++ b/Foundation/CPArray/_CPArray.j
@@ -209,7 +209,7 @@ var concat = Array.prototype.concat,
 }
 
 /*!
-    Returns a hash for the object. Other than in Cocoa, the hash value does not take the content into account. To distinct instances of CPArray with identical content (that are \c isEqual:) may return different \c -hash values.
+Returns a hash for the object. Unlike Cocoa, the hash value does not take content into account, so two arrays with the same content (\c isEqual: === YES) will not generate the same hash.
 */
 - (unsigned)hash
 {

--- a/Foundation/CPArray/_CPArray.j
+++ b/Foundation/CPArray/_CPArray.j
@@ -209,6 +209,14 @@ var concat = Array.prototype.concat,
 }
 
 /*!
+    Returns a hash for the object. Other than in Cocoa, the hash value does not take the content into account. To distinct instances of CPArray with identical content (that are \c isEqual:) may return different \c -hash values.
+*/
+- (unsigned)hash
+{
+    return [self UID];
+}
+
+/*!
     Returns the first object in the array. If the array is empty, returns \c nil
 */
 - (id)firstObject


### PR DESCRIPTION
The implementation of CPArray's hash method deliberately differs from cocoa.
This PR adds the appropriate documentation.

Fixes issue #10