### PR TITLE
Clarification for CPTableColumn's binding documentation

### DIFF
--- a/AppKit/CPTableColumn.j
+++ b/AppKit/CPTableColumn.j
@@ -601,7 +601,7 @@ CPTableColumnUserResizingMask   = 1 << 1;
 }
 
 /*!
-    Binds the receiver to an object. Note that other than in Cocoa, this will only work when the receiver has been added to a \c CPTableView.
+    Binds the receiver to an object. Note that unlike Cocoa, this works only *after* the receiver has been added to a \c CPTableView.
 
     @param CPString aBinding - The binding you wish to make. Typically CPValueBinding.
     @param id anObject - The object to bind the receiver to.

--- a/AppKit/CPTableColumn.j
+++ b/AppKit/CPTableColumn.j
@@ -601,7 +601,7 @@ CPTableColumnUserResizingMask   = 1 << 1;
 }
 
 /*!
-    Binds the receiver to an object.
+    Binds the receiver to an object. Note that other than in Cocoa, this will only work when the receiver has been added to a \c CPTableView.
 
     @param CPString aBinding - The binding you wish to make. Typically CPValueBinding.
     @param id anObject - The object to bind the receiver to.


### PR DESCRIPTION
This PR updates the documentation to clarify that bindings work only after a column has been added to a tableview.

fixes issue #1686 