### PR TITLE
Fixed: reloadData in CPTableView run the runLoop

### DIFF
--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -1145,6 +1145,7 @@ NOT YET IMPLEMENTED
         _dirtyTableColumnRangeIndex = MIN(index, _dirtyTableColumnRangeIndex);
 
     [self reloadData];
+    [[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
 }
 
 /*!
@@ -3833,6 +3834,9 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
 - (void)enumerateAvailableViewsUsingBlock:(Function/*CPView *dataView, CPInteger row, CPInteger column*, @ref stop*/)handler
 {
     [self reloadData];
+
+    [[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
+
     [self _enumerateViewsInRows:_exposedRows columns:_exposedColumns usingBlock:handler];
 }
 
@@ -3842,6 +3846,8 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
 
 - (void)_enumerateViewsInRows:(CPIndexSet)rowIndexes columns:(CPIndexSet)columnIndexes usingBlock:(Function/*CPView dataView, CPInteger row, CPInteger column, @ref stop*/)handler
 {
+    [[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
+
     [rowIndexes enumerateIndexesUsingBlock:function(rowIndex, stopRow)
     {
         var dataViewsForRow = _dataViewsForRows[rowIndex];
@@ -3867,6 +3873,8 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
 
 - (void)_enumerateViewsInRows:(CPIndexSet)rowIndexes tableColumns:(CPArray)tableColumns usingBlock:(Function/*CPView dataView, CPInteger row, CPtableColumn tableColumn, CPInteger column, @ref stop*/)handler
 {
+    [[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
+
     [rowIndexes enumerateIndexesUsingBlock:function(rowIndex, stopRow)
     {
         var dataViewsForRow = _dataViewsForRows[rowIndex];

--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -5308,6 +5308,9 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
 
     [self reloadData];
 
+    // Process all events immediately to make sure table data views are reloaded.
+    [[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
+
     [self scrollRowToVisible:rowIndex];
     [self scrollColumnToVisible:columnIndex];
 

--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -622,7 +622,6 @@ NOT YET IMPLEMENTED
 - (void)reloadData
 {
     [self _reloadDataViews];
-    [[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
 }
 
 /*!

--- a/Tests/AppKit/CPTableViewReloadDataTest.j
+++ b/Tests/AppKit/CPTableViewReloadDataTest.j
@@ -41,13 +41,18 @@
 
     [tableView reloadData];
 
+    var enumerateViewsInRowsCall = 0;
+
     [tableView _enumerateViewsInRows:[CPIndexSet indexSetWithIndexesInRange:CPMakeRange(0, 3)]  columns:[CPIndexSet indexSetWithIndexesInRange:CPMakeRange(0, 4)] usingBlock:function(view, row, column, stop)
     {
         var tableColumn = [[tableView tableColumns] objectAtIndex:column],
             expected = [tableColumn identifier] + "_" + [tableContent objectAtIndex:row];
 
         [self assertTrue:([view stringValue] == expected)];
+        enumerateViewsInRowsCall++;
     }];
+
+    [self assert:enumerateViewsInRowsCall equals:12];
 }
 
 - (int)numberOfRowsInTableView:(CPTableView)aTableView

--- a/Tests/AppKit/CPTableViewTableColumnTest.j
+++ b/Tests/AppKit/CPTableViewTableColumnTest.j
@@ -40,19 +40,21 @@
     [self assertTrue:([[tableView tableColumns] count] == 4)];
 
     [tableView removeTableColumn:[[tableView tableColumns] firstObject]];
-[[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
     [self assertTrue:([[tableView tableColumns] count] == 3)];
 
     [tableView removeTableColumn:[[tableView tableColumns] firstObject]];
-[[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
     [self assertTrue:([[tableView tableColumns] count] == 2)];
+
+    var enumerateViewsInRowsCall = 0;
 
     [tableView enumerateAvailableViewsUsingBlock:function(view, row, column, stop)
     {
         var tableColumn = [[tableView tableColumns] objectAtIndex:column];
         [self assert:("COLUMN_" + [tableColumn identifier] + "ROW_" + row) equals:[view objectValue]];
-
+        enumerateViewsInRowsCall++;
     }];
+
+    [self assert:enumerateViewsInRowsCall equals:30];
 }
 
 - (int)numberOfRowsInTableView:(CPTableView)aTableView


### PR DESCRIPTION
Previously, when reloading a CPTableView the run loop was explicitly call to layout the tableView. This is not the case in Cocoa.
You can call several times the method reloadData and this will only lay out the tableView one time.