### PR TITLE
Fixed: Encoding a [CPDecimalNumber zero] causes a corrupt CPDecimalNumbe...

### DIFF
--- a/Foundation/CPDecimalNumber.j
+++ b/Foundation/CPDecimalNumber.j
@@ -28,7 +28,7 @@
 // The default global behavior class, created lazily
 var CPDefaultDcmHandler = nil;
 
-var CPDecimalNumberUIDs	= new CFMutableDictionary();
+var CPDecimalNumberUIDs = new CFMutableDictionary();
 
 /*!
     @class CPDecimalNumberHandler

--- a/Foundation/CPDecimalNumber.j
+++ b/Foundation/CPDecimalNumber.j
@@ -28,6 +28,8 @@
 // The default global behavior class, created lazily
 var CPDefaultDcmHandler = nil;
 
+var CPDecimalNumberUIDs	= new CFMutableDictionary();
+
 /*!
     @class CPDecimalNumberHandler
     @ingroup foundation
@@ -531,6 +533,20 @@ var CPDecimalNumberHandlerRoundingModeKey       = @"CPDecimalNumberHandlerRoundi
 }
 
 // instance methods
+
+- (CPString)UID
+{
+    var UID = CPDecimalNumberUIDs.valueForKey(self);
+
+    if (!UID)
+    {
+        UID = objj_generateObjectUID();
+        CPDecimalNumberUIDs.setValueForKey(self, UID);
+    }
+
+    return UID + "";
+}
+
 /*!
     Returns a new CPDecimalNumber object with the result of the summation of
     the receiver object and \c decimalNumber. If overflow occurs then the

--- a/Tests/AppKit/CPTextFieldTest.j
+++ b/Tests/AppKit/CPTextFieldTest.j
@@ -29,6 +29,7 @@
 
     [numberFormatter setNumberStyle:CPNumberFormatterDecimalStyle];
     [numberFormatter setMaximumFractionDigits:3];
+	[numberFormatter setGeneratesDecimalNumbers:NO];
 
     [control setFormatter:numberFormatter];
     [control setStringValue:@"12.3456"];

--- a/Tests/AppKit/CPTextFieldTest.j
+++ b/Tests/AppKit/CPTextFieldTest.j
@@ -29,7 +29,7 @@
 
     [numberFormatter setNumberStyle:CPNumberFormatterDecimalStyle];
     [numberFormatter setMaximumFractionDigits:3];
-	[numberFormatter setGeneratesDecimalNumbers:NO];
+    [numberFormatter setGeneratesDecimalNumbers:NO];
 
     [control setFormatter:numberFormatter];
     [control setStringValue:@"12.3456"];

--- a/Tests/Foundation/CPNumberFormatterTest.j
+++ b/Tests/Foundation/CPNumberFormatterTest.j
@@ -62,6 +62,7 @@
 
     [numberFormatter setMinimum:10];
     [numberFormatter setMaximum:20];
+	[numberFormatter setGeneratesDecimalNumbers:NO];
 
     [self assertTrue:[numberFormatter getObjectValue:objectValueRef forString:@"10" errorDescription:nil]
              message:@"MinMax T1: Expected True."];

--- a/Tests/Foundation/CPNumberFormatterTest.j
+++ b/Tests/Foundation/CPNumberFormatterTest.j
@@ -62,7 +62,7 @@
 
     [numberFormatter setMinimum:10];
     [numberFormatter setMaximum:20];
-	[numberFormatter setGeneratesDecimalNumbers:NO];
+    [numberFormatter setGeneratesDecimalNumbers:NO];
 
     [self assertTrue:[numberFormatter getObjectValue:objectValueRef forString:@"10" errorDescription:nil]
              message:@"MinMax T1: Expected True."];


### PR DESCRIPTION
...r after decoding

Previously, CPNumber and CPDecimalNumber shared the same method UID and CPNumberUIDs-Dictionary.
This leads to some unexpected errors for example a [CPDecimalNumber zero] which refers to itself after
decoding. CPDecimalNumber now overwrites the method UID and has its own UID-Dictionary.

Fixes #2332