### PR TITLE
FIXED: CPSegmentedControl -setSelectedSegment:-1

### DIFF
--- a/AppKit/CPSegmentedControl.j
+++ b/AppKit/CPSegmentedControl.j
@@ -199,7 +199,20 @@ CPSegmentSwitchTrackingMomentary = 2;
 - (void)setSelectedSegment:(unsigned)aSegment
 {
     // setSelected:forSegment throws the exception for us (if necessary)
-    [self setSelected:YES forSegment:aSegment];
+    if (_selectedSegment == aSegment)
+        return;
+
+    if (aSegment == -1)
+    {
+        var count = [self segmentCount];
+
+        while (count--)
+            [self setSelected:NO forSegment:count];
+
+        _selectedSegment = -1;
+    }
+    else
+        [self setSelected:YES forSegment:aSegment];
 }
 
 /*!

--- a/Tests/AppKit/CPSegmentedControlTest.j
+++ b/Tests/AppKit/CPSegmentedControlTest.j
@@ -61,5 +61,36 @@
     [self assert:[_segmentedControl selectedSegment] equals:-1];
 }
 
+- (void)testDeselectAll
+{
+    [_segmentedControl setTrackingMode:CPSegmentSwitchTrackingSelectAny];
+    [_segmentedControl setSegmentCount:2];
+    [_segmentedControl setSelected:YES forSegment:0];
+    [_segmentedControl setSelected:YES forSegment:1];
+    [self assert:[_segmentedControl selectedSegment] equals:1];
+
+    [self assertNoThrow:function()
+    {
+        [_segmentedControl setSelectedSegment:-1];
+    }];
+
+    [self assert:[_segmentedControl selectedSegment] equals:-1];
+    [self assertFalse:[_segmentedControl isSelectedForSegment:0]];
+    [self assertFalse:[_segmentedControl isSelectedForSegment:1]];
+}
+
+- (void)testSetSelectedSegmentDoesNotDeselect
+{
+    [_segmentedControl setTrackingMode:CPSegmentSwitchTrackingSelectAny];
+    [_segmentedControl setSelected:YES forSegment:0];
+    [_segmentedControl setSelected:YES forSegment:1];
+    [self assert:[_segmentedControl selectedSegment] equals:1];
+
+    [_segmentedControl setSelectedSegment:1];
+
+    [self assertTrue:[_segmentedControl isSelectedForSegment:0]];
+    [self assertTrue:[_segmentedControl isSelectedForSegment:1]];
+}
+
 @end
 


### PR DESCRIPTION
previously, -setSelectedSegment:-1 was not visually deselecting the
segments and selectedSegment was not set to -1.

With tests.