### PR TITLE
New: compilation gives more informations when getting an error or warnin...

### DIFF
--- a/Objective-J/CFHTTPRequest.js
+++ b/Objective-J/CFHTTPRequest.js
@@ -277,12 +277,12 @@ CFHTTPRequest.prototype.removeEventListener = function(/*String*/ anEventName, /
     this._eventDispatcher.removeEventListener(anEventName, anEventListener);
 };
 
-CFHTTPRequest.prototype.setWithCredentials = function(/*Boolean*/ willSendWithCredentials) 
+CFHTTPRequest.prototype.setWithCredentials = function(/*Boolean*/ willSendWithCredentials)
 {
     this._nativeRequest.withCredentials = willSendWithCredentials;
 };
 
-CFHTTPRequest.prototype.withCredentials = function() 
+CFHTTPRequest.prototype.withCredentials = function()
 {
     return this._nativeRequest.withCredentials;
 };
@@ -325,7 +325,15 @@ function FileRequest(/*CFURL*/ aURL, onsuccess, onfailure, onprogress)
             gccFlags = require("objective-j").currentCompilerFlags(),
             gcc = OS.popen("gcc -E -x c -P " + (gccFlags ? gccFlags : "") + " " + OS.enquote(aFilePath), { charset:"UTF-8" }),
             chunk,
-            fileContents = "";
+            error,
+            fileContents = "",
+            fileErrors = "";
+
+        while (error = gcc.stderr.read())
+            fileErrors += error;
+
+        if (fileErrors.length > 0)
+            print("\nErrors/Warnings after gcc compilation :\n" + fileErrors);
 
         while (chunk = gcc.stdout.read())
             fileContents += chunk;

--- a/Objective-J/CFHTTPRequest.js
+++ b/Objective-J/CFHTTPRequest.js
@@ -333,7 +333,10 @@ function FileRequest(/*CFURL*/ aURL, onsuccess, onfailure, onprogress)
             fileErrors += error;
 
         if (fileErrors.length > 0)
-            print("\nErrors/Warnings after gcc compilation :\n" + fileErrors);
+        {
+            var TERM = require("narwhal/term");
+            TERM.stream.print("\0red(\nErrors/Warnings after gcc compilation :\n" + fileErrors + "\0)");
+        }
 
         while (chunk = gcc.stdout.read())
             fileContents += chunk;


### PR DESCRIPTION
...g

Previously, when the compilation of a project failed, we did not have so many informations about the cause of the problem.
Now, when gcc returns an error or a warning, we print in the console. This help to know what is the issue of the build we would like to have.