### PR TITLE
Fix ospopen

### DIFF
--- a/AppKit/Jakefile
+++ b/AppKit/Jakefile
@@ -1,8 +1,6 @@
 
 require("../common.jake");
 
-checkUlimit();
-
 var framework = require("objective-j/jake").framework,
     BundleTask = require("objective-j/jake").BundleTask;
 

--- a/CommonJS/bin/press
+++ b/CommonJS/bin/press
@@ -366,22 +366,31 @@ function pressEnvironment(rootPath, outputFiles, environment, options) {
     return {executable:includedBytes, data:dataBytes, mhtml:mhtmlBytes};
 }
 
-function pngcrushDirectory(directory) {
-    var directoryPath = FILE.path(directory);
-    var pngs = directoryPath.glob("**/*.png");
+function pngcrushDirectory(directory)
+{
+    var directoryPath = FILE.path(directory),
+        pngs = directoryPath.glob("**/*.png");
 
     system.stderr.print("Running pngcrush on " + pngs.length + " pngs:");
-    pngs.forEach(function(dstPath) {
-        var tmpPath = FILE.path(dstPath+".tmp");
+    pngs.forEach(function(dstPath)
+    {
+        var tmpPath = FILE.path(dstPath+".tmp"),
+            p = OS.popen(["pngcrush", "-rem", "alla", "-reduce", /*"-brute",*/ dstPath, tmpPath]);
 
-        var p = OS.popen(["pngcrush", "-rem", "alla", "-reduce", /*"-brute",*/ dstPath, tmpPath]);
-        if (p.wait()) {
+        if (p.wait())
+        {
             CPLog.warn("pngcrush failed. Ensure it's installed and on your PATH.");
         }
-        else {
+        else
+        {
             FILE.move(tmpPath, dstPath);
             system.stderr.write(".").flush();
         }
+
+        p.stdin.close();
+        p.stdout.close();
+        p.stderr.close();
+
     });
     system.stderr.print("");
 }

--- a/CommonJS/bin/press
+++ b/CommonJS/bin/press
@@ -374,24 +374,30 @@ function pngcrushDirectory(directory)
     system.stderr.print("Running pngcrush on " + pngs.length + " pngs:");
     pngs.forEach(function(dstPath)
     {
-        var tmpPath = FILE.path(dstPath+".tmp"),
-            p = OS.popen(["pngcrush", "-rem", "alla", "-reduce", /*"-brute",*/ dstPath, tmpPath]);
+        var tmpPath = FILE.path(dstPath+".tmp");
 
-        if (p.wait())
+        try
         {
-            CPLog.warn("pngcrush failed. Ensure it's installed and on your PATH.");
+            var p = OS.popen(["pngcrush", "-rem", "alla", "-reduce", /*"-brute",*/ dstPath, tmpPath]);
+
+            if (p.wait())
+            {
+                CPLog.warn("pngcrush failed. Ensure it's installed and on your PATH.");
+            }
+            else
+            {
+                FILE.move(tmpPath, dstPath);
+                system.stderr.write(".").flush();
+            }
         }
-        else
+        finally
         {
-            FILE.move(tmpPath, dstPath);
-            system.stderr.write(".").flush();
+            p.stdin.close();
+            p.stdout.close();
+            p.stderr.close();
         }
-
-        p.stdin.close();
-        p.stdout.close();
-        p.stderr.close();
-
     });
+
     system.stderr.print("");
 }
 

--- a/CommonJS/lib/cappuccino/fontinfo.j
+++ b/CommonJS/lib/cappuccino/fontinfo.j
@@ -3,18 +3,20 @@ var OS = require("os");
 
 exports.fontinfo = function(name, size)
 {
-    var p = OS.popen(["fontinfo", "-n", name, size || 12]),
-        result;
+    var result;
 
-    if (p.wait() === 0)
-        result = p.stdout.read();
+    try
+    {
+        var p = OS.popen(["fontinfo", "-n", name, size || 12]);
+        if (p.wait() === 0)
+            result = p.stdout.read();
+    }
+    finally
+    {
+        p.stdin.close();
+        p.stdout.close();
+        p.stderr.close();
+    }
 
-    p.stdin.close();
-    p.stdout.close();
-    p.stderr.close();
-
-    if (result)
-        return JSON.parse(result);
-    else
-        return null;
+    return result ? JSON.parse(result) : null;
 };

--- a/CommonJS/lib/cappuccino/fontinfo.j
+++ b/CommonJS/lib/cappuccino/fontinfo.j
@@ -3,10 +3,18 @@ var OS = require("os");
 
 exports.fontinfo = function(name, size)
 {
-    var p = OS.popen(["fontinfo", "-n", name, size || 12]);
+    var p = OS.popen(["fontinfo", "-n", name, size || 12]),
+        result;
 
     if (p.wait() === 0)
-        return JSON.parse(p.stdout.read());
+        result = p.stdout.read();
+
+    p.stdin.close();
+    p.stdout.close();
+    p.stderr.close();
+
+    if (result)
+        return JSON.parse(result);
     else
         return null;
 };

--- a/CommonJS/lib/cappuccino/imagesize.j
+++ b/CommonJS/lib/cappuccino/imagesize.j
@@ -3,18 +3,20 @@ var OS = require("os");
 
 exports.imagesize = function(path)
 {
-    var p = OS.popen(["imagesize", "-n", path]),
-        result;
+    var result;
 
-    if (p.wait() === 0)
-        result = p.stdout.read();
+    try
+    {
+        var p = OS.popen(["imagesize", "-n", path]);
+        if (p.wait() === 0)
+            result = p.stdout.read();
+    }
+    finally
+    {
+        p.stdin.close();
+        p.stdout.close();
+        p.stderr.close();
+    }
 
-    p.stdin.close();
-    p.stdout.close();
-    p.stderr.close();
-
-    if (result)
-        return JSON.parse(result);
-    else
-        return null;
+    return result ? JSON.parse(result) : null;
 };

--- a/CommonJS/lib/cappuccino/imagesize.j
+++ b/CommonJS/lib/cappuccino/imagesize.j
@@ -3,10 +3,18 @@ var OS = require("os");
 
 exports.imagesize = function(path)
 {
-    var p = OS.popen(["imagesize", "-n", path]);
+    var p = OS.popen(["imagesize", "-n", path]),
+        result;
 
     if (p.wait() === 0)
-        return JSON.parse(p.stdout.read());
+        result = p.stdout.read();
+
+    p.stdin.close();
+    p.stdout.close();
+    p.stderr.close();
+
+    if (result)
+        return JSON.parse(result);
     else
         return null;
 };

--- a/Jakefile
+++ b/Jakefile
@@ -135,6 +135,10 @@ function generateDocs(/* boolean */ noFrame)
             if (doxygenApps[0])
                 doxygen = FILE.join(doxygenApps[0], "Contents/Resources/doxygen");
         }
+
+        p.stdin.close();
+        p.stdout.close();
+        p.stderr.close();
     }
 
     if (!doxygen || !FILE.exists(doxygen))

--- a/Jakefile
+++ b/Jakefile
@@ -128,17 +128,22 @@ function generateDocs(/* boolean */ noFrame)
     // If the Doxygen application is installed on Mac OS X, use that
     if (!doxygen && executableExists("mdfind"))
     {
-        var p = OS.popen(["mdfind", "kMDItemContentType == 'com.apple.application-bundle' && kMDItemCFBundleIdentifier == 'org.doxygen'"]);
-        if (p.wait() === 0)
+        try
         {
-            var doxygenApps = p.stdout.read().split("\n");
-            if (doxygenApps[0])
-                doxygen = FILE.join(doxygenApps[0], "Contents/Resources/doxygen");
+            var p = OS.popen(["mdfind", "kMDItemContentType == 'com.apple.application-bundle' && kMDItemCFBundleIdentifier == 'org.doxygen'"]);
+            if (p.wait() === 0)
+            {
+                var doxygenApps = p.stdout.read().split("\n");
+                if (doxygenApps[0])
+                    doxygen = FILE.join(doxygenApps[0], "Contents/Resources/doxygen");
+            }
         }
-
-        p.stdin.close();
-        p.stdout.close();
-        p.stderr.close();
+        finally
+        {
+            p.stdin.close();
+            p.stdout.close();
+            p.stderr.close();
+        }
     }
 
     if (!doxygen || !FILE.exists(doxygen))

--- a/Objective-J/CFHTTPRequest.js
+++ b/Objective-J/CFHTTPRequest.js
@@ -277,12 +277,12 @@ CFHTTPRequest.prototype.removeEventListener = function(/*String*/ anEventName, /
     this._eventDispatcher.removeEventListener(anEventName, anEventListener);
 };
 
-CFHTTPRequest.prototype.setWithCredentials = function(/*Boolean*/ willSendWithCredentials) 
+CFHTTPRequest.prototype.setWithCredentials = function(/*Boolean*/ willSendWithCredentials)
 {
     this._nativeRequest.withCredentials = willSendWithCredentials;
 };
 
-CFHTTPRequest.prototype.withCredentials = function() 
+CFHTTPRequest.prototype.withCredentials = function()
 {
     return this._nativeRequest.withCredentials;
 };
@@ -329,6 +329,10 @@ function FileRequest(/*CFURL*/ aURL, onsuccess, onfailure, onprogress)
 
         while (chunk = gcc.stdout.read())
             fileContents += chunk;
+
+        gcc.stdin.close();
+        gcc.stdout.close();
+        gcc.stderr.close();
 
         if (fileContents.length > 0)
         {

--- a/Objective-J/CFHTTPRequest.js
+++ b/Objective-J/CFHTTPRequest.js
@@ -323,16 +323,21 @@ function FileRequest(/*CFURL*/ aURL, onsuccess, onfailure, onprogress)
         var aFilePath = aURL.toString().substring(5),
             OS = require("os"),
             gccFlags = require("objective-j").currentCompilerFlags(),
-            gcc = OS.popen("gcc -E -x c -P " + (gccFlags ? gccFlags : "") + " " + OS.enquote(aFilePath), { charset:"UTF-8" }),
             chunk,
             fileContents = "";
 
-        while (chunk = gcc.stdout.read())
-            fileContents += chunk;
-
-        gcc.stdin.close();
-        gcc.stdout.close();
-        gcc.stderr.close();
+        try
+        {
+            var gcc = OS.popen("gcc -E -x c -P " + (gccFlags ? gccFlags : "") + " " + OS.enquote(aFilePath), { charset:"UTF-8" });
+            while (chunk = gcc.stdout.read())
+                fileContents += chunk;
+        }
+        finally
+        {
+            gcc.stdin.close();
+            gcc.stdout.close();
+            gcc.stderr.close();
+        }
 
         if (fileContents.length > 0)
         {

--- a/Objective-J/CommonJS/lib/objective-j/compiler.js
+++ b/Objective-J/CommonJS/lib/objective-j/compiler.js
@@ -46,27 +46,39 @@ function compileWithResolvedFlags(aFilePath, objjcFlags, gccFlags, asPlainJavasc
 
     if (!shouldObjjPreprocess)
     {
-        var p = OS.popen("which gcc");
-        if (p.stdout.read().length === 0)
-            fileContents = FILE.read(aFilePath, { charset:"UTF-8" });
-        else
+        try
         {
-            // GCC preprocess the file.
-            var gcc = OS.popen("gcc -E -x c -P " + (gccFlags ? gccFlags.join(" ") : "") + " " + OS.enquote(aFilePath), { charset:"UTF-8" }),
-                chunk = "";
+            var p = OS.popen("which gcc");
 
-            while (chunk = gcc.stdout.read())
-                fileContents += chunk;
+            if (p.stdout.read().length === 0)
+            {
+                fileContents = FILE.read(aFilePath, { charset:"UTF-8" });
+            }
+            else
+            {
+                try
+                {
+                    var gcc = OS.popen("gcc -E -x c -P " + (gccFlags ? gccFlags.join(" ") : "") + " " + OS.enquote(aFilePath), { charset:"UTF-8" }),
+                        chunk = "";
 
-            gcc.stdin.close();
-            gcc.stdout.close();
-            gcc.stderr.close();
+                    while (chunk = gcc.stdout.read())
+                        fileContents += chunk;
+                }
+                finally
+                {
+                    gcc.stdin.close();
+                    gcc.stdout.close();
+                    gcc.stderr.close();
+                }
+            }
+        }
+        finally
+        {
+            p.stdin.close();
+            p.stdout.close();
+            p.stderr.close();
         }
 
-        p.stdin.close();
-        p.stdout.close();
-        p.stderr.close();
-        
         return fileContents;
     }
 

--- a/Objective-J/CommonJS/lib/objective-j/compiler.js
+++ b/Objective-J/CommonJS/lib/objective-j/compiler.js
@@ -46,7 +46,8 @@ function compileWithResolvedFlags(aFilePath, objjcFlags, gccFlags, asPlainJavasc
 
     if (!shouldObjjPreprocess)
     {
-        if (OS.popen("which gcc").stdout.read().length === 0)
+        var p = OS.popen("which gcc");
+        if (p.stdout.read().length === 0)
             fileContents = FILE.read(aFilePath, { charset:"UTF-8" });
         else
         {
@@ -57,7 +58,15 @@ function compileWithResolvedFlags(aFilePath, objjcFlags, gccFlags, asPlainJavasc
             while (chunk = gcc.stdout.read())
                 fileContents += chunk;
 
+            gcc.stdin.close();
+            gcc.stdout.close();
+            gcc.stderr.close();
         }
+
+        p.stdin.close();
+        p.stdout.close();
+        p.stderr.close();
+        
         return fileContents;
     }
 

--- a/Objective-J/CommonJS/lib/objective-j/jake.js
+++ b/Objective-J/CommonJS/lib/objective-j/jake.js
@@ -22,7 +22,6 @@
 
 var FILE = require("file");
 
-
 var BUNDLE_TASK = require("objective-j/jake/bundletask");
 
 exports.BundleTask = BUNDLE_TASK.BundleTask;

--- a/Objective-J/Jakefile
+++ b/Objective-J/Jakefile
@@ -40,8 +40,8 @@ $BROWSER_FILES      = new FileList($BROWSER_FILE).include($OBJECTIVEJ_FILES);
 
 filedir($BUILD_BROWSER_FILE, $BROWSER_FILES, function(aTask)
 {
-    gcc($BROWSER_FILE, 
-        $BUILD_BROWSER_FILE, 
+    gcc($BROWSER_FILE,
+        $BUILD_BROWSER_FILE,
         environmentFlags("Browser", "ObjJ").concat($INCLUDE_FLAGS, $DEBUG_FLAGS), $CONFIGURATION !== "Debug");
 });
 
@@ -119,11 +119,15 @@ function gcc(inputFilePath, outputFilePath, flags, compress)
     stream.print("Building... \0green(" + outputFilePath +"\0)");
 
     // GCC preprocess the file.
-    var cmd = ["gcc", "-E", "-x", "c", "-P"].concat(flags, inputFilePath).join(" ");
-    var gcc = OS.popen(cmd, { charset:"UTF-8" });
+    var cmd = ["gcc", "-E", "-x", "c", "-P"].concat(flags, inputFilePath).join(" "),
+        gcc = OS.popen(cmd, { charset:"UTF-8" }),
+        contents = FILE.read("header.txt", { charset : "UTF-8" });
 
-    var contents = FILE.read("header.txt", { charset : "UTF-8" });
     contents += gcc.stdout.read();
+
+    gcc.stdin.close();
+    gcc.stdout.close();
+    gcc.stderr.close();
 
     if (FILE.extension(inputFilePath) === ".js" && compress)
         contents = compressor(contents);

--- a/Objective-J/Jakefile
+++ b/Objective-J/Jakefile
@@ -120,14 +120,19 @@ function gcc(inputFilePath, outputFilePath, flags, compress)
 
     // GCC preprocess the file.
     var cmd = ["gcc", "-E", "-x", "c", "-P"].concat(flags, inputFilePath).join(" "),
-        gcc = OS.popen(cmd, { charset:"UTF-8" }),
         contents = FILE.read("header.txt", { charset : "UTF-8" });
 
-    contents += gcc.stdout.read();
-
-    gcc.stdin.close();
-    gcc.stdout.close();
-    gcc.stderr.close();
+    try
+    {
+        var gcc = OS.popen(cmd, { charset:"UTF-8" });
+        contents += gcc.stdout.read();
+    }
+    finally
+    {
+        gcc.stdin.close();
+        gcc.stdout.close();
+        gcc.stderr.close();
+    }
 
     if (FILE.extension(inputFilePath) === ".js" && compress)
         contents = compressor(contents);

--- a/Tools/XcodeCapp/Jakefile
+++ b/Tools/XcodeCapp/Jakefile
@@ -13,25 +13,34 @@ task ("build", function()
         OS.exit(0);
 
     // No building on 10.6
-    var p = OS.popen(["sw_vers", "-productVersion"]);
-
-    if (p.wait() === 0)
+    try
     {
-        var versions = p.stdout.read().split("."),
-            majorVersion = parseInt(versions[0], 10),
-            minorVersion = parseInt(versions[1], 10),
-            buildVersion = parseInt(versions[2], 10);
+        var p = OS.popen(["sw_vers", "-productVersion"]);
 
-        if (majorVersion < 10 || minorVersion < 7)
+        if (p.wait() === 0)
         {
-            colorPrint("XcodeCapp can only be built on Mac OS X 10.7+. You can download the binary here: https://www.dropbox.com/sh/gxdgm356gyb9tqc/rFNyl8hcVG", "red");
-            OS.exit(0);
+            var versions = p.stdout.read().split("."),
+                majorVersion = parseInt(versions[0], 10),
+                minorVersion = parseInt(versions[1], 10),
+                buildVersion = parseInt(versions[2], 10);
+
+            if (majorVersion < 10 || minorVersion < 7)
+            {
+                colorPrint("XcodeCapp can only be built on Mac OS X 10.7+. You can download the binary here: https://www.dropbox.com/sh/gxdgm356gyb9tqc/rFNyl8hcVG", "red");
+
+                p.stdin.close();
+                p.stdout.close();
+                p.stderr.close();
+                OS.exit(0);
+            }
         }
     }
-
-    p.stdin.close();
-    p.stdout.close();
-    p.stderr.close();
+    finally
+    {
+        p.stdin.close();
+        p.stdout.close();
+        p.stderr.close();
+    }
 
     if (executableExists("xcodebuild"))
     {

--- a/Tools/XcodeCapp/Jakefile
+++ b/Tools/XcodeCapp/Jakefile
@@ -25,10 +25,13 @@ task ("build", function()
         if (majorVersion < 10 || minorVersion < 7)
         {
             colorPrint("XcodeCapp can only be built on Mac OS X 10.7+. You can download the binary here: https://www.dropbox.com/sh/gxdgm356gyb9tqc/rFNyl8hcVG", "red");
-
             OS.exit(0);
         }
     }
+
+    p.stdin.close();
+    p.stdout.close();
+    p.stderr.close();
 
     if (executableExists("xcodebuild"))
     {

--- a/Tools/nib2cib/Converter.j
+++ b/Tools/nib2cib/Converter.j
@@ -119,8 +119,14 @@ ConverterConversionException = @"ConverterConversionException";
             // Compile xib or nib to make sure we have a non-new format nib.
             temporaryNibFilePath = FILE.join("/tmp", FILE.basename(aFilePath) + ".tmp.nib");
 
-            if (OS.popen(["/usr/bin/ibtool", aFilePath, "--compile", temporaryNibFilePath]).wait() === 1)
+            var p = OS.popen(["/usr/bin/ibtool", aFilePath, "--compile", temporaryNibFilePath]);
+
+            if (p.wait() === 1)
                 [CPException raise:ConverterConversionException reason:@"Could not compile file: " + aFilePath];
+
+            p.stdin.close();
+            p.stdout.close();
+            p.stderr.close();
         }
         else
         {
@@ -130,8 +136,14 @@ ConverterConversionException = @"ConverterConversionException";
         // Convert from binary plist to XML plist
         var temporaryPlistFilePath = FILE.join("/tmp", FILE.basename(aFilePath) + ".tmp.plist");
 
-        if (OS.popen(["/usr/bin/plutil", "-convert", "xml1", temporaryNibFilePath, "-o", temporaryPlistFilePath]).wait() === 1)
+        var p = OS.popen(["/usr/bin/plutil", "-convert", "xml1", temporaryNibFilePath, "-o", temporaryPlistFilePath]);
+
+        if (p.wait() === 1)
             [CPException raise:ConverterConversionException reason:@"Could not convert to xml plist for file: " + aFilePath];
+
+        p.stdin.close();
+        p.stdout.close();
+        p.stderr.close();
 
         if (!FILE.isReadable(temporaryPlistFilePath))
             [CPException raise:ConverterConversionException reason:@"Unable to convert nib file."];

--- a/Tools/nib2cib/Converter.j
+++ b/Tools/nib2cib/Converter.j
@@ -119,14 +119,19 @@ ConverterConversionException = @"ConverterConversionException";
             // Compile xib or nib to make sure we have a non-new format nib.
             temporaryNibFilePath = FILE.join("/tmp", FILE.basename(aFilePath) + ".tmp.nib");
 
-            var p = OS.popen(["/usr/bin/ibtool", aFilePath, "--compile", temporaryNibFilePath]);
+            try
+            {
+                var p = OS.popen(["/usr/bin/ibtool", aFilePath, "--compile", temporaryNibFilePath]);
+                if (p.wait() === 1)
+                    [CPException raise:ConverterConversionException reason:@"Could not compile file: " + aFilePath];
+            }
+            finally
+            {
+                p.stdin.close();
+                p.stdout.close();
+                p.stderr.close();
+            }
 
-            if (p.wait() === 1)
-                [CPException raise:ConverterConversionException reason:@"Could not compile file: " + aFilePath];
-
-            p.stdin.close();
-            p.stdout.close();
-            p.stderr.close();
         }
         else
         {
@@ -136,14 +141,18 @@ ConverterConversionException = @"ConverterConversionException";
         // Convert from binary plist to XML plist
         var temporaryPlistFilePath = FILE.join("/tmp", FILE.basename(aFilePath) + ".tmp.plist");
 
-        var p = OS.popen(["/usr/bin/plutil", "-convert", "xml1", temporaryNibFilePath, "-o", temporaryPlistFilePath]);
-
-        if (p.wait() === 1)
-            [CPException raise:ConverterConversionException reason:@"Could not convert to xml plist for file: " + aFilePath];
-
-        p.stdin.close();
-        p.stdout.close();
-        p.stderr.close();
+        try
+        {
+            var p = OS.popen(["/usr/bin/plutil", "-convert", "xml1", temporaryNibFilePath, "-o", temporaryPlistFilePath]);
+            if (p.wait() === 1)
+                [CPException raise:ConverterConversionException reason:@"Could not convert to xml plist for file: " + aFilePath];
+        }
+        finally
+        {
+            p.stdin.close();
+            p.stdout.close();
+            p.stderr.close();
+        }
 
         if (!FILE.isReadable(temporaryPlistFilePath))
             [CPException raise:ConverterConversionException reason:@"Unable to convert nib file."];

--- a/Tools/nib2cib/main.j
+++ b/Tools/nib2cib/main.j
@@ -28,27 +28,7 @@ var OS = require("os"),
 
 function main(args)
 {
-    checkUlimit();
-
     var nib2cib = [[Nib2Cib alloc] initWithArgs:args];
 
     [nib2cib run];
-}
-
-function checkUlimit()
-{
-    var minUlimit = 1024,
-        p = OS.popen(["ulimit", "-n"]);
-
-    if (p.wait() === 0)
-    {
-        var limit = p.stdout.read().split("\n")[0];
-
-        if (Number(limit) < minUlimit)
-        {
-            stream.print("\0red(\0bold(WARNING:\0)\0) nib2cib may need to open more files than this terminal session currently allows (" + limit + "). Add the following line to your login configuration file (.bash_profile, .bashrc, etc.), start a new terminal session, then try again:\n");
-            stream.print("ulimit -n " + minUlimit);
-            OS.exit(1);
-        }
-    }
 }

--- a/common.jake
+++ b/common.jake
@@ -385,6 +385,10 @@ global.setPackageMetadata = function(packagePath)
             pkg["cappuccino-revision"] = sha;
     }
 
+    p.stdin.close();
+    p.stdout.close();
+    p.stderr.close();
+
     pkg["cappuccino-timestamp"] = new Date().getTime();
     pkg["version"] = getCappuccinoVersion();
 
@@ -576,31 +580,6 @@ global.colorPrint = function(/* String */ message, /* String */ color)
 {
     stream.print(colorize(message, color));
 };
-
-var minUlimit = 1024;
-
-global.checkUlimit = function()
-{
-    var ulimitPath = executableExists("ulimit");
-
-    if (!ulimitPath)
-        return;
-
-    var p = OS.popen([ulimitPath, "-n"]);
-
-    if (p.wait() === 0)
-    {
-        var limit = p.stdout.read().split("\n")[0];
-
-        if (Number(limit) < minUlimit)
-        {
-            stream.print("\0red(\0bold(ERROR:\0)\0) Cappuccino may need to open more files than this terminal session currently allows (" + limit + "). Add the following line to your login configuration file (.bash_profile, .bashrc, etc.), start a new terminal session, then try again:\n");
-            stream.print("ulimit -n " + minUlimit);
-            OS.exit(1);
-        }
-    }
-}
-
 
 // built in tasks
 

--- a/common.jake
+++ b/common.jake
@@ -378,16 +378,21 @@ global.setPackageMetadata = function(packagePath)
 {
     var pkg = JSON.parse(FILE.read(packagePath, { charset : "UTF-8" }));
 
-    var p = OS.popen(["git", "rev-parse", "--verify", "HEAD"]);
-    if (p.wait() === 0) {
-        var sha = p.stdout.read().split("\n")[0];
-        if (sha.length === 40)
-            pkg["cappuccino-revision"] = sha;
+    try
+    {
+        var p = OS.popen(["git", "rev-parse", "--verify", "HEAD"]);
+        if (p.wait() === 0) {
+            var sha = p.stdout.read().split("\n")[0];
+            if (sha.length === 40)
+                pkg["cappuccino-revision"] = sha;
+        }
     }
-
-    p.stdin.close();
-    p.stdout.close();
-    p.stderr.close();
+    finally
+    {
+        p.stdin.close();
+        p.stdout.close();
+        p.stderr.close();
+    }
 
     pkg["cappuccino-timestamp"] = new Date().getTime();
     pkg["version"] = getCappuccinoVersion();


### PR DESCRIPTION
Previously, when popen was called, the 3 streams (stdin, stderr and stdourt) where never closed. This was the reason of the having an impossible number of open files.

This patch ensure all streams are closed after using them. This means that the ulimit trick is no more necessary

NOTE: weird error with Travis, trying new PR