### PR TITLE
FIXED: Fonts from IB not correctly interpreted in OSX El Capitain

### DIFF
--- a/Tools/nib2cib/NSFont.j
+++ b/Tools/nib2cib/NSFont.j
@@ -22,7 +22,8 @@
 
 @import <AppKit/CPFont.j>
 
-IBDefaultFontFace = @"Lucida Grande";
+IBDefaultFontFace = @".AppleSystemUIFont";
+IBDefaultFontFaceLegacy = @"Lucida Grande";
 IBDefaultFontSize = 13.0;
 
 var OS = require("os"),
@@ -59,7 +60,7 @@ var OS = require("os"),
 
 - (id)cibFontForNibFont
 {
-    if (_name === IBDefaultFontFace)
+    if (_name === IBDefaultFontFaceLegacy || _name == IBDefaultFontFace)
     {
         if (_size === IBDefaultFontSize && !_isBold && !_isItalic)
             return nil;
@@ -83,7 +84,7 @@ var OS = require("os"),
     if (self !== [NSFont class])
         return;
 
-    CPLog.debug("NSFont: default IB font: %s %f", IBDefaultFontFace, IBDefaultFontSize);
+    CPLog.debug("NSFont: default IB font: %s (legacy %s) %f", IBDefaultFontFace, IBDefaultFontFaceLegacy, IBDefaultFontSize);
 }
 
 + (CPString)descriptorForFont:(CPFont)aFont


### PR DESCRIPTION
This patch adds support for the new way of defining the default font from Xcode 7 beta. The patch also supports the old explicit 'Lucida Grande' of previous version.