### PR TITLE
New: added timeout and cache feature in CPURLRequest

### DIFF
--- a/Foundation/CPURLConnection.j
+++ b/Foundation/CPURLConnection.j
@@ -212,7 +212,7 @@ var CPURLConnectionDelegate = nil;
         _HTTPRequest.open([_request HTTPMethod], [[_request URL] absoluteString], YES);
 
         _HTTPRequest.onreadystatechange = function() { [self _readyStateDidChange]; };
-        _HTTPRequest.ontimeout = function() { [self _timeout]; };
+        _HTTPRequest.ontimeout = function() { [self _didTimeout]; };
 
         var fields = [_request allHTTPHeaderFields],
             key = nil,
@@ -260,11 +260,11 @@ var CPURLConnectionDelegate = nil;
 /*!
     @ignore
 */
-- (void)_timeout
+- (void)_didTimeout
 {
     var exception = [CPException exceptionWithName:@"Timeout exception"
-                            reason:"The request timed out."
-                          userInfo:@{}];
+                                            reason:"The request timed out."
+                                          userInfo:@{}];
 
     [self _sendDelegateDidFailWithError:exception];
 }
@@ -272,8 +272,6 @@ var CPURLConnectionDelegate = nil;
 /* @ignore */
 - (void)_readyStateDidChange
 {
-    var isTimeoutRequest = !_HTTPRequest.status() && !_HTTPRequest.responseText();
-
     if (_HTTPRequest.readyState() === CFHTTPRequest.CompleteState && !_HTTPRequest.isTimeoutRequest())
     {
         var statusCode = _HTTPRequest.status(),

--- a/Foundation/CPURLConnection.j
+++ b/Foundation/CPURLConnection.j
@@ -112,7 +112,6 @@ var CPURLConnectionDelegate = nil;
     try
     {
         var aCFHTTPRequest = new CFHTTPRequest();
-        aCFHTTPRequest.setTimeout([aRequest timeoutInterval] * 1000);
         aCFHTTPRequest.setWithCredentials([aRequest withCredentials]);
 
         aCFHTTPRequest.open([aRequest HTTPMethod], [[aRequest URL] absoluteString], NO);
@@ -126,7 +125,7 @@ var CPURLConnectionDelegate = nil;
 
         aCFHTTPRequest.send([aRequest HTTPBody]);
 
-        if (!aCFHTTPRequest.success() || aCFHTTPRequest.isTimeoutRequest())
+        if (!aCFHTTPRequest.success())
             return nil;
 
         return [CPData dataWithRawString:aCFHTTPRequest.responseText()];

--- a/Foundation/CPURLRequest.j
+++ b/Foundation/CPURLRequest.j
@@ -93,9 +93,7 @@ CPURLRequestReturnCacheDataDontLoad = 3;
 */
 - (id)initWithURL:(CPURL)anURL cachePolicy:(CPURLRequestCachePolicy)aCachePolicy timeoutInterval:(CPTimeInterval)aTimeoutInterval
 {
-    self = [self initWithURL:anURL];
-
-    if (self)
+    if (self = [self initWithURL:anURL])
     {
         _cachePolicy = aCachePolicy;
         _timeoutInterval = aTimeoutInterval;
@@ -112,9 +110,7 @@ CPURLRequestReturnCacheDataDontLoad = 3;
 */
 - (id)initWithURL:(CPURL)aURL
 {
-    self = [super init];
-
-    if (self)
+    if (self = [super init])
     {
         [self setURL:aURL];
 

--- a/Objective-J/CFHTTPRequest.js
+++ b/Objective-J/CFHTTPRequest.js
@@ -105,6 +105,7 @@ GLOBAL(CFHTTPRequest) = function()
 
     // by default, all requests will assume that credentials should not be sent.
     this._nativeRequest.withCredentials = false;
+    this._nativeRequest.timeout = 60000;
 
     var self = this;
     this._stateChangeHandler = function()
@@ -112,7 +113,13 @@ GLOBAL(CFHTTPRequest) = function()
         determineAndDispatchHTTPRequestEvents(self);
     };
 
+    this._timeoutHandler = function()
+    {
+        dispatchTimeoutHTTPRequestEvents(self);
+    };
+
     this._nativeRequest.onreadystatechange = this._stateChangeHandler;
+    this._nativeRequest.ontimeout = this._timeoutHandler;
 
     if (CFHTTPRequest.AuthenticationDelegate !== nil)
         this._eventDispatcher.addEventListener("HTTP403", function()
@@ -209,6 +216,16 @@ CFHTTPRequest.prototype.getResponseHeader = function(/*String*/ aHeader)
     return this._nativeRequest.getResponseHeader(aHeader);
 };
 
+CFHTTPRequest.prototype.setTimeout = function(/*int*/ aTimeout)
+{
+    this._nativeRequest.timeout = aTimeout;
+};
+
+CFHTTPRequest.prototype.getTimeout = function(/*int*/ aTimeout)
+{
+    return this._nativeRequest.timeout
+};
+
 CFHTTPRequest.prototype.getAllResponseHeaders = function()
 {
     return this._nativeRequest.getAllResponseHeaders();
@@ -235,7 +252,10 @@ CFHTTPRequest.prototype.send = function(/*Object*/ aBody)
     if (!this._isOpen)
     {
         delete this._nativeRequest.onreadystatechange;
+        delete this._nativeRequest.ontimeout;
+
         this._nativeRequest.open(this._method, this._URL, this._async, this._user, this._password);
+        this._nativeRequest.ontimeout = this._timeoutHandler;
         this._nativeRequest.onreadystatechange = this._stateChangeHandler;
     }
 
@@ -287,14 +307,24 @@ CFHTTPRequest.prototype.withCredentials = function()
     return this._nativeRequest.withCredentials;
 };
 
+CFHTTPRequest.prototype.isTimeoutRequest = function()
+{
+    // Can we consider that as a timeout ?
+    return !this.success() && !this._nativeRequest.response && !this._nativeRequest.responseText && !this._nativeRequest.responseType && !this._nativeRequest.responseURL && !this._nativeRequest.responseXML;
+};
+
+function dispatchTimeoutHTTPRequestEvents(/*CFHTTPRequest*/ aRequest)
+{
+    aRequest._eventDispatcher.dispatchEvent({ type:"timeout", request:aRequest});
+}
+
 function determineAndDispatchHTTPRequestEvents(/*CFHTTPRequest*/ aRequest)
 {
-    var eventDispatcher = aRequest._eventDispatcher;
+    var eventDispatcher = aRequest._eventDispatcher,
+        nativeRequest = aRequest._nativeRequest,
+        readyStates = ["uninitialized", "loading", "loaded", "interactive", "complete"];
 
     eventDispatcher.dispatchEvent({ type:"readystatechange", request:aRequest});
-
-    var nativeRequest = aRequest._nativeRequest,
-        readyStates = ["uninitialized", "loading", "loaded", "interactive", "complete"];
 
     if (readyStates[aRequest.readyState()] === "complete")
     {

--- a/Objective-J/CFHTTPRequest.js
+++ b/Objective-J/CFHTTPRequest.js
@@ -105,7 +105,6 @@ GLOBAL(CFHTTPRequest) = function()
 
     // by default, all requests will assume that credentials should not be sent.
     this._nativeRequest.withCredentials = false;
-    this._nativeRequest.timeout = 60000;
 
     var self = this;
     this._stateChangeHandler = function()

--- a/Objective-J/CFHTTPRequest.js
+++ b/Objective-J/CFHTTPRequest.js
@@ -223,7 +223,7 @@ CFHTTPRequest.prototype.setTimeout = function(/*int*/ aTimeout)
 
 CFHTTPRequest.prototype.getTimeout = function(/*int*/ aTimeout)
 {
-    return this._nativeRequest.timeout
+    return this._nativeRequest.timeout;
 };
 
 CFHTTPRequest.prototype.getAllResponseHeaders = function()


### PR DESCRIPTION
This PR adds the possibility to set the timeout and the cache policy of a CPURLRequest.
For that, there are new things in the framework :

- CFHTTPRequest has now the functions setTimeout(), getTimeout() and isTimeoutRequest
- CPURLRequest has now the methods +requestWithURL:cachePolicy:timeoutInterval: and -initWithURL:cachePolicy:timeoutInterval:
- CPURLConnection does not call the delegate didReceiveData: when a request has timed out. I will call the delegate didFailWithError:
- Cache is now possible for a CPURLRequest, only CPURLRequestReturnCacheDataElseLoad, CPURLRequestReturnCacheDataDontLoad and CPURLRequestReloadIgnoringLocalCacheData are supported. By default CPURLRequestReloadIgnoringLocalCacheData.
- Default timeout has been set to 60sec as in cocoa.
- A request is considered as timeout when there isn't any response (text/xml/type) and when the status of the response is 0.