### PR TITLE
New: default menu system is now disable for every right click except for the CPTextField

### DIFF
--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -1050,6 +1050,14 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
     }
 }
 
+- (void)rightMouseDown:(CPEvent)anEvent
+{
+    if ([self menuForEvent:anEvent] || [[self nextResponder] isKindOfClass:CPView])
+        [super rightMouseDown:anEvent];
+    else
+        [[[anEvent window] platformWindow] _propagateContextMenuDOMEvent:YES];
+}
+
 - (void)mouseDragged:(CPEvent)anEvent
 {
     if (![self isEnabled] || !([self isSelectable] || [self isEditable]))

--- a/AppKit/CPView.j
+++ b/AppKit/CPView.j
@@ -1831,7 +1831,7 @@ var CPViewHighDPIDrawingEnabled = YES;
     else if ([[self nextResponder] isKindOfClass:CPView])
         [super rightMouseDown:anEvent];
     else
-        [[[anEvent window] platformWindow] _propagateContextMenuDOMEvent:YES];
+        [[[anEvent window] platformWindow] _propagateContextMenuDOMEvent:NO];
 }
 
 - (CPMenu)menuForEvent:(CPEvent)anEvent


### PR DESCRIPTION
Previously, when making a right click and when a cappuccino menu was not displayed, the system menu was displayed. Now we don't display this menu anymore as in cocoa. We only display when making a right click on a CPTextField.