### PR TITLE
New: possibility to create a theme for every object of the Appkit

### DIFF
--- a/AppKit/AppKit.j
+++ b/AppKit/AppKit.j
@@ -20,6 +20,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+@import "_CPObject+Theme.j"
 @import "_CPToolTip.j"
 @import "CALayer.j"
 @import "CGGeometry.j"

--- a/AppKit/CPColor.j
+++ b/AppKit/CPColor.j
@@ -25,6 +25,7 @@
 
 @import "CGColor.j"
 
+@import "_CPObject+Theme.j"
 @import "CPCompatibility.j"
 @import "CPImage.j"
 
@@ -65,7 +66,8 @@ var cachedBlackColor,
     cachedOrangeColor,
     cachedPurpleColor,
     cachedShadowColor,
-    cachedClearColor;
+    cachedClearColor,
+    cachedThemeColor;
 
 /// @endcond
 
@@ -85,6 +87,27 @@ var cachedBlackColor,
     CPImage     _patternImage;
     CPString    _cssString;
 }
+
+
+#pragma mark -
+#pragma mark Theming
+
++ (CPString)defaultThemeClass
+{
+    return "color";
+}
+
++ (CPDictionary)themeAttributes
+{
+    return @{
+            @"alternate-selected-control-color": [CPNull null],
+            @"secondary-selected-control-color" : [CPNull null]
+        };
+}
+
+
+#pragma mark -
+#pragma mark Static methods
 
 /*!
     Creates a color in the RGB colorspace, with an alpha value.
@@ -436,14 +459,22 @@ var cachedBlackColor,
     return cachedClearColor;
 }
 
++ (CPColor)_cachedThemeColor
+{
+    if (!cachedThemeColor)
+        cachedThemeColor = [self colorWithCalibratedWhite:0.0 alpha:0.0];
+
+    return cachedThemeColor;
+}
+
 + (CPColor)alternateSelectedControlColor
 {
-    return [[CPColor alloc] _initWithRGBA:[0.22, 0.46, 0.84, 1.0]];
+    return [[self _cachedThemeColor] valueForThemeAttribute:@"alternate-selected-control-color"];
 }
 
 + (CPColor)secondarySelectedControlColor
 {
-    return [[CPColor alloc] _initWithRGBA:[0.83, 0.83, 0.83, 1.0]];
+    return [[self _cachedThemeColor] valueForThemeAttribute:@"secondary-selected-control-color"];
 }
 
 /*!
@@ -489,6 +520,10 @@ var cachedBlackColor,
     // use it (issue #1413.)
     [self _initCSSStringFromComponents];
 
+    _theme = [CPTheme defaultTheme];
+    _themeState = CPThemeStateNormal;
+    [self _loadThemeAttributes];
+
     return self;
 }
 
@@ -502,6 +537,10 @@ var cachedBlackColor,
         _components = components;
 
         [self _initCSSStringFromComponents];
+
+        _theme = [CPTheme defaultTheme];
+        _themeState = CPThemeStateNormal;
+        [self _loadThemeAttributes];
     }
 
     return self;
@@ -528,6 +567,10 @@ var cachedBlackColor,
         _patternImage = anImage;
         _cssString = "url(\"" + [_patternImage filename] + "\")";
         _components = [0.0, 0.0, 0.0, 1.0];
+
+        _theme = [CPTheme defaultTheme];
+        _themeState = CPThemeStateNormal;
+        [self _loadThemeAttributes];
     }
 
     return self;
@@ -835,9 +878,13 @@ var CPColorComponentsKey    = @"CPColorComponentsKey",
 - (id)initWithCoder:(CPCoder)aCoder
 {
     if ([aCoder containsValueForKey:CPColorPatternImageKey])
-        return [self _initWithPatternImage:[aCoder decodeObjectForKey:CPColorPatternImageKey]];
+        self = [self _initWithPatternImage:[aCoder decodeObjectForKey:CPColorPatternImageKey]];
+    else
+        self = [self _initWithRGBA:[aCoder decodeObjectForKey:CPColorComponentsKey]];
 
-    return [self _initWithRGBA:[aCoder decodeObjectForKey:CPColorComponentsKey]];
+    [self _decodeThemeObjectsWithCoder:aCoder];
+
+    return self;
 }
 
 /*!
@@ -850,6 +897,8 @@ var CPColorComponentsKey    = @"CPColorComponentsKey",
         [aCoder encodeObject:_patternImage forKey:CPColorPatternImageKey];
     else
         [aCoder encodeObject:_components forKey:CPColorComponentsKey];
+
+    [self _encodeThemeObjectsWithCoder:aCoder];
 }
 
 @end

--- a/AppKit/CPColor.j
+++ b/AppKit/CPColor.j
@@ -80,7 +80,7 @@ var cachedBlackColor,
     <p>It also provides some class helper methods that
     returns instances of commonly used colors.</p>
 */
-@implementation CPColor : CPObject
+@implementation CPColor : CPObject <CPTheme>
 {
     CPArray     _components;
 

--- a/AppKit/CPTheme.j
+++ b/AppKit/CPTheme.j
@@ -142,20 +142,19 @@ var CPThemesByName          = { },
 
     if (!className)
     {
-        if ([aClass isKindOfClass:[CPView class]])
+        if ([aClass respondsToSelector:@selector(defaultThemeClass)])
         {
-            if ([aClass respondsToSelector:@selector(defaultThemeClass)])
-                className = [aClass defaultThemeClass];
-            else if ([aClass respondsToSelector:@selector(themeClass)])
-            {
-                CPLog.warn(@"%@ themeClass is deprecated in favor of defaultThemeClass", CPStringFromClass(aClass));
-                className = [aClass themeClass];
-            }
-            else
-                return nil;
+            className = [aClass defaultThemeClass];
+        }
+        else if ([aClass respondsToSelector:@selector(themeClass)])
+        {
+            CPLog.warn(@"%@ themeClass is deprecated in favor of defaultThemeClass", CPStringFromClass(aClass));
+            className = [aClass themeClass];
         }
         else
-            [CPException raise:CPInvalidArgumentException reason:@"aClass must be a class object or a string."];
+        {
+            return nil;
+        }
     }
 
     return [_attributes objectForKey:className];

--- a/AppKit/CPView.j
+++ b/AppKit/CPView.j
@@ -24,6 +24,7 @@
 @import <Foundation/CPObjJRuntime.j>
 @import <Foundation/CPSet.j>
 
+@import "_CPObject+Theme.j"
 @import "CGAffineTransform.j"
 @import "CGGeometry.j"
 @import "CPAppearance.j"
@@ -113,8 +114,7 @@ CPViewMaxYMargin    = 32;
 CPViewBoundsDidChangeNotification   = @"CPViewBoundsDidChangeNotification";
 CPViewFrameDidChangeNotification    = @"CPViewFrameDidChangeNotification";
 
-var CachedNotificationCenter    = nil,
-    CachedThemeAttributes       = nil;
+var CachedNotificationCenter    = nil;
 
 #if PLATFORM(DOM)
 var DOMElementPrototype         = nil,
@@ -217,12 +217,6 @@ var CPViewHighDPIDrawingEnabled = YES;
     // Layout Support
     BOOL                _needsLayout;
     JSObject            _ephemeralSubviews;
-
-    // Theming Support
-    CPTheme             _theme;
-    CPString            _themeClass;
-    JSObject            _themeAttributes;
-    unsigned            _themeState;
 
     JSObject            _ephemeralSubviewsForNames;
     CPSet               _ephereralSubviews;
@@ -3101,33 +3095,19 @@ setBoundsOrigin:
 
 @end
 
+
 @implementation CPView (Theming)
-#pragma mark Theme States
 
-- (unsigned)themeState
-{
-    return _themeState;
-}
-
-- (BOOL)hasThemeState:(ThemeState)aState
-{
-    if (aState.isa && [aState isKindOfClass:CPArray])
-        return _themeState.hasThemeState.apply(_themeState, aState);
-
-    return _themeState.hasThemeState(aState);
-}
+#pragma mark Override
 
 - (BOOL)setThemeState:(ThemeState)aState
 {
-    if (aState && aState.isa && [aState isKindOfClass:CPArray])
-        aState = CPThemeState.apply(null, aState);
+    var shouldLayout = [super setThemeState:aState];
 
-    if (_themeState.hasThemeState(aState))
+    if (!shouldLayout)
         return NO;
 
-    _themeState = CPThemeState(_themeState, aState);
-
-    [self setNeedsLayout];
+    [self setNeedsLayout:YES];
     [self setNeedsDisplay:YES];
 
     return YES;
@@ -3135,26 +3115,35 @@ setBoundsOrigin:
 
 - (BOOL)unsetThemeState:(ThemeState)aState
 {
-    if (aState && aState.isa && [aState isKindOfClass:CPArray])
-        aState = CPThemeState.apply(null, aState);
+    var shouldLayout = [super unsetThemeState:aState];
 
-    var oldThemeState = _themeState;
-    _themeState = _themeState.without(aState);
-
-    if (oldThemeState === _themeState)
+    if (!shouldLayout)
         return NO;
 
-    [self setNeedsLayout];
+    [self setNeedsLayout:YES];
     [self setNeedsDisplay:YES];
 
     return YES;
 }
 
+- (void)setThemeClass:(CPString)theClass
+{
+    [super setThemeClass:theClass];
+
+    [self setNeedsLayout];
+    [self setNeedsDisplay:YES];
+}
+
+
+#pragma mark First responder
+
 - (BOOL)becomeFirstResponder
 {
     var r = [super becomeFirstResponder];
+
     if (r)
         [self _notifyViewDidBecomeFirstResponder];
+
     return r;
 }
 
@@ -3163,6 +3152,7 @@ setBoundsOrigin:
     [self setThemeState:CPThemeStateFirstResponder];
 
     var count = [_subviews count];
+
     while (count--)
         [_subviews[count] _notifyViewDidBecomeFirstResponder];
 }
@@ -3170,8 +3160,10 @@ setBoundsOrigin:
 - (BOOL)resignFirstResponder
 {
     var r = [super resignFirstResponder];
+
     if (r)
         [self _notifyViewDidResignFirstResponder];
+
     return r;
 }
 
@@ -3180,6 +3172,7 @@ setBoundsOrigin:
     [self unsetThemeState:CPThemeStateFirstResponder];
 
     var count = [_subviews count];
+
     while (count--)
         [_subviews[count] _notifyViewDidResignFirstResponder];
 }
@@ -3189,6 +3182,7 @@ setBoundsOrigin:
     [self setThemeState:CPThemeStateKeyWindow];
 
     var count = [_subviews count];
+
     while (count--)
         [_subviews[count] _notifyWindowDidBecomeKey];
 }
@@ -3198,117 +3192,12 @@ setBoundsOrigin:
     [self unsetThemeState:CPThemeStateKeyWindow];
 
     var count = [_subviews count];
+
     while (count--)
         [_subviews[count] _notifyWindowDidResignKey];
 }
 
 #pragma mark Theme Attributes
-
-+ (CPString)defaultThemeClass
-{
-    return nil;
-}
-
-- (CPString)themeClass
-{
-    if (_themeClass)
-        return _themeClass;
-
-    return [[self class] defaultThemeClass];
-}
-
-- (void)setThemeClass:(CPString)theClass
-{
-    _themeClass = theClass;
-
-    [self _loadThemeAttributes];
-
-    [self setNeedsLayout];
-    [self setNeedsDisplay:YES];
-}
-
-+ (CPDictionary)themeAttributes
-{
-    return nil;
-}
-
-+ (CPArray)_themeAttributes
-{
-    if (!CachedThemeAttributes)
-        CachedThemeAttributes = {};
-
-    var theClass = [self class],
-        CPViewClass = [CPView class],
-        attributes = [],
-        nullValue = [CPNull null];
-
-    for (; theClass && theClass !== CPViewClass; theClass = [theClass superclass])
-    {
-        var cachedAttributes = CachedThemeAttributes[class_getName(theClass)];
-
-        if (cachedAttributes)
-        {
-            attributes = attributes.length ? attributes.concat(cachedAttributes) : attributes;
-            CachedThemeAttributes[[self className]] = attributes;
-
-            break;
-        }
-
-        var attributeDictionary = [theClass themeAttributes];
-
-        if (!attributeDictionary)
-            continue;
-
-        var attributeKeys = [attributeDictionary allKeys],
-            attributeCount = attributeKeys.length;
-
-        while (attributeCount--)
-        {
-            var attributeName = attributeKeys[attributeCount],
-                attributeValue = [attributeDictionary objectForKey:attributeName];
-
-            attributes.push(attributeValue === nullValue ? nil : attributeValue);
-            attributes.push(attributeName);
-        }
-    }
-
-    return attributes;
-}
-
-- (void)_loadThemeAttributes
-{
-    var theClass = [self class],
-        attributes = [theClass _themeAttributes],
-        count = attributes.length;
-
-    if (!count)
-        return;
-
-    var theme = [self theme],
-        themeClass = [self themeClass];
-
-    _themeAttributes = {};
-
-    while (count--)
-    {
-        var attributeName = attributes[count--],
-            attribute = [[_CPThemeAttribute alloc] initWithName:attributeName defaultValue:attributes[count]];
-
-        [attribute setParentAttribute:[theme attributeWithName:attributeName forClass:themeClass]];
-
-        _themeAttributes[attributeName] = attribute;
-    }
-}
-
-- (void)setTheme:(CPTheme)aTheme
-{
-    if (_theme === aTheme)
-        return;
-
-    _theme = aTheme;
-
-    [self viewDidChangeTheme];
-}
 
 - (void)_setThemeIncludingDescendants:(CPTheme)aTheme
 {
@@ -3316,54 +3205,22 @@ setBoundsOrigin:
     [[self subviews] makeObjectsPerformSelector:@selector(_setThemeIncludingDescendants:) withObject:aTheme];
 }
 
-- (CPTheme)theme
-{
-    return _theme;
-}
-
-- (void)viewDidChangeTheme
+- (void)objectDidChangeTheme
 {
     if (!_themeAttributes)
         return;
 
-    var theme = [self theme],
-        themeClass = [self themeClass];
-
-    for (var attributeName in _themeAttributes)
-        if (_themeAttributes.hasOwnProperty(attributeName))
-            [_themeAttributes[attributeName] setParentAttribute:[theme attributeWithName:attributeName forClass:themeClass]];
+    [super objectDidChangeTheme];
 
     [self setNeedsLayout];
     [self setNeedsDisplay:YES];
 }
 
-- (CPDictionary)_themeAttributeDictionary
-{
-    var dictionary = @{};
-
-    if (_themeAttributes)
-    {
-        var theme = [self theme];
-
-        for (var attributeName in _themeAttributes)
-            if (_themeAttributes.hasOwnProperty(attributeName))
-                [dictionary setObject:_themeAttributes[attributeName] forKey:attributeName];
-    }
-
-    return dictionary;
-}
-
 - (void)setValue:(id)aValue forThemeAttribute:(CPString)aName inState:(ThemeState)aState
 {
-   if (aState.isa && [aState isKindOfClass:CPArray])
-        aState = CPThemeState.apply(null, aState);
-
-    if (!_themeAttributes || !_themeAttributes[aName])
-        [CPException raise:CPInvalidArgumentException reason:[self className] + " does not contain theme attribute '" + aName + "'"];
-
     var currentValue = [self currentValueForThemeAttribute:aName];
 
-    [_themeAttributes[aName] setValue:aValue forState:aState];
+    [super setValue:aValue forThemeAttribute:aName inState:aState];
 
     if ([self currentValueForThemeAttribute:aName] === currentValue)
         return;
@@ -3374,94 +3231,15 @@ setBoundsOrigin:
 
 - (void)setValue:(id)aValue forThemeAttribute:(CPString)aName
 {
-    if (!_themeAttributes || !_themeAttributes[aName])
-        [CPException raise:CPInvalidArgumentException reason:[self className] + " does not contain theme attribute '" + aName + "'"];
-
     var currentValue = [self currentValueForThemeAttribute:aName];
 
-    [_themeAttributes[aName] setValue:aValue];
+    [super setValue:aValue forThemeAttribute:aName ];
 
     if ([self currentValueForThemeAttribute:aName] === currentValue)
         return;
 
     [self setNeedsDisplay:YES];
     [self setNeedsLayout];
-}
-
-- (id)valueForThemeAttribute:(CPString)aName inState:(ThemeState)aState
-{
-   if (aState.isa && [aState isKindOfClass:CPArray])
-        aState = CPThemeState.apply(null, aState);
-
-    if (!_themeAttributes || !_themeAttributes[aName])
-        [CPException raise:CPInvalidArgumentException reason:[self className] + " does not contain theme attribute '" + aName + "'"];
-
-    return [_themeAttributes[aName] valueForState:aState];
-}
-
-- (id)valueForThemeAttribute:(CPString)aName
-{
-    if (!_themeAttributes || !_themeAttributes[aName])
-        [CPException raise:CPInvalidArgumentException reason:[self className] + " does not contain theme attribute '" + aName + "'"];
-
-    return [_themeAttributes[aName] value];
-}
-
-- (id)currentValueForThemeAttribute:(CPString)aName
-{
-    if (!_themeAttributes || !_themeAttributes[aName])
-        [CPException raise:CPInvalidArgumentException reason:[self className] + " does not contain theme attribute '" + aName + "'"];
-
-    return [_themeAttributes[aName] valueForState:_themeState];
-}
-
-- (BOOL)hasThemeAttribute:(CPString)aName
-{
-    return (_themeAttributes && _themeAttributes[aName] !== undefined);
-}
-
-/*!
-    Registers theme values encoded in an array at runtime. The format of the data in the array
-    is the same as that used by ThemeDescriptors.j, with the exception that you need to use
-    CPColorWithImages() in place of PatternColor(). For more information see the comments
-    at the top of ThemeDescriptors.j.
-
-    @param themeValues array of theme values
-*/
-- (void)registerThemeValues:(CPArray)themeValues
-{
-    for (var i = 0; i < themeValues.length; ++i)
-    {
-        var attributeValueState = themeValues[i],
-            attribute = attributeValueState[0],
-            value = attributeValueState[1],
-            state = attributeValueState[2];
-
-        if (state)
-            [self setValue:value forThemeAttribute:attribute inState:state];
-        else
-            [self setValue:value forThemeAttribute:attribute];
-    }
-}
-
-/*!
-    Registers theme values encoded in an array at runtime. The format of the data in the array
-    is the same as that used by ThemeDescriptors.j, with the exception that you need to use
-    CPColorWithImages() in place of PatternColor(). The values in \c inheritedValues are
-    registered first, then those in \c themeValues override/augment the inherited values.
-    For more information see the comments at the top of ThemeDescriptors.j.
-
-    @param themeValues array of base theme values
-    @param inheritedValues array of overridden/additional theme values
-*/
-- (void)registerThemeValues:(CPArray)themeValues inherit:(CPArray)inheritedValues
-{
-    // Register inherited values first, then override those with the subtheme values.
-    if (inheritedValues)
-        [self registerThemeValues:inheritedValues];
-
-    if (themeValues)
-        [self registerThemeValues:themeValues];
 }
 
 - (CPView)createEphemeralSubviewNamed:(CPString)aViewName
@@ -3613,8 +3391,6 @@ var CPViewAutoresizingMaskKey       = @"CPViewAutoresizingMask",
     CPViewSubviewsKey               = @"CPViewSubviewsKey",
     CPViewSuperviewKey              = @"CPViewSuperviewKey",
     CPViewTagKey                    = @"CPViewTagKey",
-    CPViewThemeClassKey             = @"CPViewThemeClassKey",
-    CPViewThemeStateKey             = @"CPViewThemeStateKey",
     CPViewWindowKey                 = @"CPViewWindowKey",
     CPViewNextKeyViewKey            = @"CPViewNextKeyViewKey",
     CPViewPreviousKeyViewKey        = @"CPViewPreviousKeyViewKey",
@@ -3719,23 +3495,7 @@ var CPViewAutoresizingMaskKey       = @"CPViewAutoresizingMask",
 
         [self setBackgroundColor:[aCoder decodeObjectForKey:CPViewBackgroundColorKey]];
         [self _setupViewFlags];
-
-        _theme = [CPTheme defaultTheme];
-        _themeClass = [aCoder decodeObjectForKey:CPViewThemeClassKey];
-        _themeState = CPThemeState([aCoder decodeObjectForKey:CPViewThemeStateKey]);
-        _themeAttributes = {};
-
-        var theClass = [self class],
-            themeClass = [self themeClass],
-            attributes = [theClass _themeAttributes],
-            count = attributes.length;
-
-        while (count--)
-        {
-            var attributeName = attributes[count--];
-
-            _themeAttributes[attributeName] = CPThemeAttributeDecode(aCoder, attributeName, attributes[count], _theme, themeClass);
-        }
+        [self _decodeThemeObjectsWithCoder:aCoder];
 
         [self setAppearance:[aCoder decodeObjectForKey:CPViewAppearanceKey]];
 
@@ -3814,12 +3574,7 @@ var CPViewAutoresizingMaskKey       = @"CPViewAutoresizingMask",
     if (previousKeyView !== nil && ![previousKeyView isEqual:self])
         [aCoder encodeConditionalObject:previousKeyView forKey:CPViewPreviousKeyViewKey];
 
-    [aCoder encodeObject:[self themeClass] forKey:CPViewThemeClassKey];
-    [aCoder encodeObject:String(_themeState) forKey:CPViewThemeStateKey];
-
-    for (var attributeName in _themeAttributes)
-        if (_themeAttributes.hasOwnProperty(attributeName))
-            CPThemeAttributeEncode(aCoder, _themeAttributes[attributeName]);
+    [self _encodeThemeObjectsWithCoder:aCoder];
 
     if (_identifier)
         [aCoder encodeObject:_identifier forKey:CPReuseIdentifierKey];

--- a/AppKit/CPView.j
+++ b/AppKit/CPView.j
@@ -149,7 +149,7 @@ var CPViewHighDPIDrawingEnabled = YES;
     appearance. Other methods of CPView and CPResponder can
     also be overridden to handle user generated events.
 */
-@implementation CPView : CPResponder
+@implementation CPView : CPResponder <CPTheme>
 {
     CPWindow            _window;
 

--- a/AppKit/Themes/Aristo/ThemeDescriptors.j
+++ b/AppKit/Themes/Aristo/ThemeDescriptors.j
@@ -384,6 +384,19 @@ var themedButtonValues = nil,
             "themedTokenFieldTokenCloseButton"];
 }
 
++ (CPColor)themedColor
+{
+    var color = [CPColor blackColor],
+        themedColorValues =
+    [
+        [@"alternate-selected-control-color", [[CPColor alloc] _initWithRGBA:[0.22, 0.46, 0.84, 1.0]]],
+        [@"secondary-selected-control-color", [[CPColor alloc] _initWithRGBA:[0.83, 0.83, 0.83, 1.0]]]
+    ];
+
+    [self registerThemeValues:themedColorValues forObject:color];
+
+    return color;
+}
 
 + (CPButton)makeButton
 {

--- a/AppKit/Themes/Aristo2/ThemeDescriptors.j
+++ b/AppKit/Themes/Aristo2/ThemeDescriptors.j
@@ -28,6 +28,7 @@
 @import <AppKit/CPButtonBar.j>
 @import <AppKit/CPCheckBox.j>
 @import <AppKit/CPComboBox.j>
+@import <AppKit/CPColor.j>
 @import <AppKit/CPColorWell.j>
 @import <AppKit/CPDatePicker.j>
 @import <AppKit/CPLevelIndicator.j>
@@ -96,7 +97,22 @@ var themedButtonValues = nil,
             "themedRuleEditor",
             "themedTableDataView",
             "themedCornerview",
-            "themedTokenFieldTokenCloseButton"];
+            "themedTokenFieldTokenCloseButton",
+            "themedColor"];
+}
+
++ (CPColor)themedColor
+{
+    var color = [CPColor redColor],
+        themedColorValues =
+    [
+        [@"alternate-selected-control-color", [[CPColor alloc] _initWithRGBA:[0.22, 0.46, 0.84, 1.0]]],
+        [@"secondary-selected-control-color", [[CPColor alloc] _initWithRGBA:[0.83, 0.83, 0.83, 1.0]]]
+    ];
+
+    [self registerThemeValues:themedColorValues forObject:color];
+
+    return color;
 }
 
 + (CPButton)makeButton

--- a/AppKit/Themes/BlendKit/BKThemeDescriptor.j
+++ b/AppKit/Themes/BlendKit/BKThemeDescriptor.j
@@ -217,6 +217,11 @@ var ItemSizes               = { },
     return [[self themeName] compare:[aThemeDescriptor themeName]];
 }
 
++ (void)registerThemeValues:(CPArray)themeValues forObject:(id)anObject
+{
+    [self registerThemeValues:themeValues forView:anObject];
+}
+
 + (void)registerThemeValues:(CPArray)themeValues forView:(CPView)aView
 {
     for (var i = 0; i < themeValues.length; ++i)
@@ -231,6 +236,11 @@ var ItemSizes               = { },
         else
             [aView setValue:value forThemeAttribute:attribute];
     }
+}
+
++ (void)registerThemeValues:(CPArray)themeValues forObject:(id)anObject inherit:(CPArray)inheritedValues
+{
+    [self registerThemeValues:themeValues forView:anObject inherit:inheritedValues];
 }
 
 + (void)registerThemeValues:(CPArray)themeValues forView:(CPView)aView inherit:(CPArray)inheritedValues

--- a/AppKit/Themes/CommonJS/blendtask.j
+++ b/AppKit/Themes/CommonJS/blendtask.j
@@ -172,17 +172,6 @@ function themeFromCibData(data)
     {
         var object = topLevelObjects[count];
 
-        if ([object._themedObject isKindOfClass:CPColor])
-        {
-            TERM.stream.print(object._themedObject);
-
-            for (var attributeName in object._themedObject._themeAttributes)
-            {
-                TERM.stream.print(attributeName);
-                TERM.stream.print([object._themedObject._themeAttributes[attributeName] value]);
-            }
-        }
-
         templates = templates.concat([object blendThemeObjectTemplates]);
 
         if ([object isKindOfClass:[BKThemeTemplate class]])

--- a/AppKit/Themes/CommonJS/blendtask.j
+++ b/AppKit/Themes/CommonJS/blendtask.j
@@ -172,6 +172,17 @@ function themeFromCibData(data)
     {
         var object = topLevelObjects[count];
 
+        if ([object._themedObject isKindOfClass:CPColor])
+        {
+            TERM.stream.print(object._themedObject);
+
+            for (var attributeName in object._themedObject._themeAttributes)
+            {
+                TERM.stream.print(attributeName);
+                TERM.stream.print([object._themedObject._themeAttributes[attributeName] value]);
+            }
+        }
+
         templates = templates.concat([object blendThemeObjectTemplates]);
 
         if ([object isKindOfClass:[BKThemeTemplate class]])

--- a/AppKit/_CPObject+Theme.j
+++ b/AppKit/_CPObject+Theme.j
@@ -28,7 +28,33 @@ var CachedThemeAttributes       = nil;
 var CPViewThemeClassKey             = @"CPViewThemeClassKey",
     CPViewThemeStateKey             = @"CPViewThemeStateKey";
 
-@implementation CPObject (ObjectTheming)
+@protocol CPTheme
+
+- (CPString)themeClass;
+- (void)setThemeClass:(CPString)theClass;
+
+- (CPTheme)theme;
+- (void)setTheme:(CPTheme)aTheme;
+
+- (unsigned)themeState;
+- (BOOL)hasThemeState:(ThemeState)aState;
+- (BOOL)setThemeState:(ThemeState)aState;
+- (BOOL)unsetThemeState:(ThemeState)aState;
+- (BOOL)hasThemeAttribute:(CPString)aName;
+
+- (void)objectDidChangeTheme;
+
+- (void)setValue:(id)aValue forThemeAttribute:(CPString)aName inState:(ThemeState)aState;
+- (void)setValue:(id)aValue forThemeAttribute:(CPString)aName;
+- (id)valueForThemeAttribute:(CPString)aName inState:(ThemeState)aState;
+- (id)valueForThemeAttribute:(CPString)aName;
+- (id)currentValueForThemeAttribute:(CPString)aName;
+- (void)registerThemeValues:(CPArray)themeValues;
+- (void)registerThemeValues:(CPArray)themeValues inherit:(CPArray)inheritedValues;
+
+@end
+
+@implementation CPObject (ObjectTheming) <CPTheme>
 {
     // Theming Support
     CPTheme             _theme;

--- a/AppKit/_CPObject+Theme.j
+++ b/AppKit/_CPObject+Theme.j
@@ -1,0 +1,355 @@
+/*
+ * AppKit.j
+ * AppKit
+ *
+ * Created by Alexandre Wilhelm.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+@import <Foundation/Foundation.j>
+
+@import "CPTheme.j"
+
+var CachedThemeAttributes       = nil;
+
+var CPViewThemeClassKey             = @"CPViewThemeClassKey",
+    CPViewThemeStateKey             = @"CPViewThemeStateKey";
+
+@implementation CPObject (ObjectTheming)
+{
+    // Theming Support
+    CPTheme             _theme;
+    CPString            _themeClass;
+    JSObject            _themeAttributes;
+    unsigned            _themeState;
+}
+
+
+#pragma mark -
+#pragma mark Theme State
+
+- (unsigned)themeState
+{
+    return _themeState;
+}
+
+- (BOOL)hasThemeState:(ThemeState)aState
+{
+    if (aState.isa && [aState isKindOfClass:CPArray])
+        return _themeState.hasThemeState.apply(_themeState, aState);
+
+    return _themeState.hasThemeState(aState);
+}
+
+- (BOOL)setThemeState:(ThemeState)aState
+{
+    if (aState && aState.isa && [aState isKindOfClass:CPArray])
+        aState = CPThemeState.apply(null, aState);
+
+    if (_themeState.hasThemeState(aState))
+        return NO;
+
+    _themeState = CPThemeState(_themeState, aState);
+
+    return YES;
+}
+
+- (BOOL)unsetThemeState:(ThemeState)aState
+{
+    if (aState && aState.isa && [aState isKindOfClass:CPArray])
+        aState = CPThemeState.apply(null, aState);
+
+    var oldThemeState = _themeState;
+    _themeState = _themeState.without(aState);
+
+    if (oldThemeState === _themeState)
+        return NO;
+
+    return YES;
+}
+
+#pragma mark Theme Attributes
+
++ (CPString)defaultThemeClass
+{
+    return nil;
+}
+
++ (CPDictionary)themeAttributes
+{
+    return nil;
+}
+
+- (CPString)themeClass
+{
+    if (_themeClass)
+        return _themeClass;
+
+    return [[self class] defaultThemeClass];
+}
+
+- (void)setThemeClass:(CPString)theClass
+{
+    _themeClass = theClass;
+
+    [self _loadThemeAttributes];
+}
+
++ (CPArray)_themeAttributes
+{
+    if (!CachedThemeAttributes)
+        CachedThemeAttributes = {};
+
+    var theClass = [self class],
+        CPObjectClass = [CPObject class],
+        attributes = [],
+        nullValue = [CPNull null];
+
+    for (; theClass && theClass !== CPObjectClass; theClass = [theClass superclass])
+    {
+        var cachedAttributes = CachedThemeAttributes[class_getName(theClass)];
+
+        if (cachedAttributes)
+        {
+            attributes = attributes.length ? attributes.concat(cachedAttributes) : attributes;
+            CachedThemeAttributes[[self className]] = attributes;
+
+            break;
+        }
+
+        var attributeDictionary = [theClass themeAttributes];
+
+        if (!attributeDictionary)
+            continue;
+
+        var attributeKeys = [attributeDictionary allKeys],
+            attributeCount = attributeKeys.length;
+
+        while (attributeCount--)
+        {
+            var attributeName = attributeKeys[attributeCount],
+                attributeValue = [attributeDictionary objectForKey:attributeName];
+
+            attributes.push(attributeValue === nullValue ? nil : attributeValue);
+            attributes.push(attributeName);
+        }
+    }
+
+    return attributes;
+}
+
+- (void)_loadThemeAttributes
+{
+    var theClass = [self class],
+        attributes = [theClass _themeAttributes],
+        count = attributes.length;
+
+    if (!count)
+        return;
+
+    var theme = [self theme],
+        themeClass = [self themeClass];
+
+    _themeAttributes = {};
+
+    while (count--)
+    {
+        var attributeName = attributes[count--],
+            attribute = [[_CPThemeAttribute alloc] initWithName:attributeName defaultValue:attributes[count]];
+
+        [attribute setParentAttribute:[theme attributeWithName:attributeName forClass:themeClass]];
+
+        _themeAttributes[attributeName] = attribute;
+    }
+}
+
+- (CPTheme)theme
+{
+    return _theme;
+}
+
+- (void)setTheme:(CPTheme)aTheme
+{
+    if (_theme === aTheme)
+        return;
+
+    _theme = aTheme;
+
+    [self objectDidChangeTheme];
+}
+
+- (void)objectDidChangeTheme
+{
+    if (!_themeAttributes)
+        return;
+
+    var theme = [self theme],
+        themeClass = [self themeClass];
+
+    for (var attributeName in _themeAttributes)
+    {
+        if (_themeAttributes.hasOwnProperty(attributeName))
+            [_themeAttributes[attributeName] setParentAttribute:[theme attributeWithName:attributeName forClass:themeClass]];
+    }
+
+}
+
+- (CPDictionary)_themeAttributeDictionary
+{
+    var dictionary = @{};
+
+    if (_themeAttributes)
+    {
+        var theme = [self theme];
+
+        for (var attributeName in _themeAttributes)
+        {
+            if (_themeAttributes.hasOwnProperty(attributeName))
+                [dictionary setObject:_themeAttributes[attributeName] forKey:attributeName];
+        }
+    }
+
+    return dictionary;
+}
+
+- (void)setValue:(id)aValue forThemeAttribute:(CPString)aName inState:(ThemeState)aState
+{
+   if (aState.isa && [aState isKindOfClass:CPArray])
+        aState = CPThemeState.apply(null, aState);
+
+    if (!_themeAttributes || !_themeAttributes[aName])
+        [CPException raise:CPInvalidArgumentException reason:[self className] + " does not contain theme attribute '" + aName + "'"];
+
+    [_themeAttributes[aName] setValue:aValue forState:aState];
+}
+
+- (void)setValue:(id)aValue forThemeAttribute:(CPString)aName
+{
+    if (!_themeAttributes || !_themeAttributes[aName])
+        [CPException raise:CPInvalidArgumentException reason:[self className] + " does not contain theme attribute '" + aName + "'"];
+
+    [_themeAttributes[aName] setValue:aValue];
+}
+
+- (id)valueForThemeAttribute:(CPString)aName inState:(ThemeState)aState
+{
+   if (aState.isa && [aState isKindOfClass:CPArray])
+        aState = CPThemeState.apply(null, aState);
+
+    if (!_themeAttributes || !_themeAttributes[aName])
+        [CPException raise:CPInvalidArgumentException reason:[self className] + " does not contain theme attribute '" + aName + "'"];
+
+    return [_themeAttributes[aName] valueForState:aState];
+}
+
+- (id)valueForThemeAttribute:(CPString)aName
+{
+    if (!_themeAttributes || !_themeAttributes[aName])
+        [CPException raise:CPInvalidArgumentException reason:[self className] + " does not contain theme attribute '" + aName + "'"];
+
+    return [_themeAttributes[aName] value];
+}
+
+- (id)currentValueForThemeAttribute:(CPString)aName
+{
+    if (!_themeAttributes || !_themeAttributes[aName])
+        [CPException raise:CPInvalidArgumentException reason:[self className] + " does not contain theme attribute '" + aName + "'"];
+
+    return [_themeAttributes[aName] valueForState:_themeState];
+}
+
+- (BOOL)hasThemeAttribute:(CPString)aName
+{
+    return (_themeAttributes && _themeAttributes[aName] !== undefined);
+}
+
+/*!
+    Registers theme values encoded in an array at runtime. The format of the data in the array
+    is the same as that used by ThemeDescriptors.j, with the exception that you need to use
+    CPColorWithImages() in place of PatternColor(). For more information see the comments
+    at the top of ThemeDescriptors.j.
+
+    @param themeValues array of theme values
+*/
+- (void)registerThemeValues:(CPArray)themeValues
+{
+    for (var i = 0; i < themeValues.length; ++i)
+    {
+        var attributeValueState = themeValues[i],
+            attribute = attributeValueState[0],
+            value = attributeValueState[1],
+            state = attributeValueState[2];
+
+        if (state)
+            [self setValue:value forThemeAttribute:attribute inState:state];
+        else
+            [self setValue:value forThemeAttribute:attribute];
+    }
+}
+
+/*!
+    Registers theme values encoded in an array at runtime. The format of the data in the array
+    is the same as that used by ThemeDescriptors.j, with the exception that you need to use
+    CPColorWithImages() in place of PatternColor(). The values in \c inheritedValues are
+    registered first, then those in \c themeValues override/augment the inherited values.
+    For more information see the comments at the top of ThemeDescriptors.j.
+
+    @param themeValues array of base theme values
+    @param inheritedValues array of overridden/additional theme values
+*/
+- (void)registerThemeValues:(CPArray)themeValues inherit:(CPArray)inheritedValues
+{
+    // Register inherited values first, then override those with the subtheme values.
+    if (inheritedValues)
+        [self registerThemeValues:inheritedValues];
+
+    if (themeValues)
+        [self registerThemeValues:themeValues];
+}
+
+- (void)_encodeThemeObjectsWithCoder:(CPCoder)aCoder
+{
+    [aCoder encodeObject:[self themeClass] forKey:CPViewThemeClassKey];
+    [aCoder encodeObject:String(_themeState) forKey:CPViewThemeStateKey];
+
+    for (var attributeName in _themeAttributes)
+    {
+        if (_themeAttributes.hasOwnProperty(attributeName))
+            CPThemeAttributeEncode(aCoder, _themeAttributes[attributeName]);
+    }
+}
+
+- (void)_decodeThemeObjectsWithCoder:(CPCoder)aCoder
+{
+    _theme = [CPTheme defaultTheme];
+    _themeClass = [aCoder decodeObjectForKey:CPViewThemeClassKey];
+    _themeState = CPThemeState([aCoder decodeObjectForKey:CPViewThemeStateKey]);
+    _themeAttributes = {};
+
+    var theClass = [self class],
+        themeClass = [self themeClass],
+        attributes = [theClass _themeAttributes],
+        count = attributes.length;
+
+    while (count--)
+    {
+        var attributeName = attributes[count--];
+
+        _themeAttributes[attributeName] = CPThemeAttributeDecode(aCoder, attributeName, attributes[count], _theme, themeClass);
+    }
+}
+
+@end

--- a/AppKit/_CPObject+Theme.j
+++ b/AppKit/_CPObject+Theme.j
@@ -54,7 +54,7 @@ var CPViewThemeClassKey             = @"CPViewThemeClassKey",
 
 @end
 
-@implementation CPObject (ObjectTheming) <CPTheme>
+@implementation CPObject (ObjectTheming)
 {
     // Theming Support
     CPTheme             _theme;


### PR DESCRIPTION
The purpose of this feature is to create theme for every object of the AppKit. Previously, we could not theme object like CPColor, however CPColor could be very interesting to theme, value like alternateSelectedControlColor were hard coded in the framework. With this PR, we can now theme a CPColor and take some values from the current theme of the application. Then, this PR offers the possibility to refactor the themeDescriptors, some classes contains theme attributes for other class (CPTabView and  CPTabViewItem for instance).

How doe it work ? A new category _CPObject+Theme.j has been added to the AppKit. This category contains every theme methods needed to theme an object (previously this category was in CPView). We add utils method like _encodeThemeObjectsWithCoder: and _decodeThemeObjectsWithCoder: in this category to be able to code and decode easily a coder for every object (this is generic).

This PR did not refactor the themeDescriptors, it only add this new mechanism for the methods alternateSelectedControlColor and secondarySelectedControlColor of CPColor. We will need to refactor that gradually