### PR TITLE
Fixed: crash when using a viewBased CPTableView with appearance

### DIFF
--- a/AppKit/CPView.j
+++ b/AppKit/CPView.j
@@ -3737,7 +3737,15 @@ var CPViewAutoresizingMaskKey       = @"CPViewAutoresizingMask",
             _themeAttributes[attributeName] = CPThemeAttributeDecode(aCoder, attributeName, attributes[count], _theme, themeClass);
         }
 
-        [self setAppearance:[aCoder decodeObjectForKey:CPViewAppearanceKey]];
+        var appearance = [aCoder decodeObjectForKey:CPViewAppearanceKey];
+
+        // TODO : find a way to fix this horrible things
+        // We only set the appearance here when everything and every subviews were unarchived.
+        // Otherwise this causes a crash with some subviews not unarchived but already created (how ? init is not called, neither initWithFrame or initWithCoder) in the coder (I have no idea why these views are present in _objects of the coder)
+        // To reproduce, uncomment the timeout and open the test Tests/Manual/TableTests/ViewBasedCib
+        window.setTimeout(function() {
+            [self setAppearance:appearance];
+        },0);
 
         [self setNeedsDisplay:YES];
         [self setNeedsLayout];

--- a/AppKit/CPVisualEffectView.j
+++ b/AppKit/CPVisualEffectView.j
@@ -89,7 +89,8 @@ CPVisualEffectStateInactive                 = 2;
         [CPException raise:CPInvalidArgumentException reason:"Appearance can only be CPAppearanceNameVibrantDark or CPAppearanceNameVibrantLight in CPVisualEffectView, but is " + anAppearance];
 
     [super setAppearance:anAppearance];
-    [self _applyVibrancyState];
+
+    [self setNeedsLayout:YES];
 }
 
 /*! Sets the received effect state.
@@ -109,7 +110,7 @@ CPVisualEffectStateInactive                 = 2;
     _state = aState;
     [self didChangeValueForKey:"state"];
 
-    [self _applyVibrancyState];
+    [self setNeedsLayout:YES];
 }
 
 
@@ -131,7 +132,7 @@ CPVisualEffectStateInactive                 = 2;
 
 }
 
-- (void)_applyVibrancyState
+- (void)layoutSubviews
 {
     switch (_state)
     {
@@ -152,52 +153,6 @@ CPVisualEffectStateInactive                 = 2;
 - (BOOL)_validAppearance:(CPAppearance)anAppearance
 {
     return [anAppearance isEqual:[CPAppearance appearanceNamed:CPAppearanceNameVibrantDark]] || [anAppearance isEqual:[CPAppearance appearanceNamed:CPAppearanceNameVibrantLight]];
-}
-
-
-#pragma mark -
-#pragma mark Overrides
-
-- (BOOL)setThemeState:(ThemeState)aState
-{
-    if (aState.isa && [aState isKindOfClass:CPArray])
-         aState = CPThemeState.apply(null, aState);
-
-    var r = [super setThemeState:aState];
-
-    if (r)
-        [self _applyVibrancyState];
-
-    return r;
-}
-
-- (BOOL)unsetThemeState:(ThemeState)aState
-{
-    if (aState.isa && [aState isKindOfClass:CPArray])
-         aState = CPThemeState.apply(null, aState);
-
-    var r = [super unsetThemeState:aState];
-
-    if (r)
-        [self _applyVibrancyState];
-
-    return r;
-}
-
-- (void)viewDidMoveToSuperview
-{
-    [super viewDidMoveToSuperview];
-
-    if (_superview)
-        [self _applyVibrancyState];
-}
-
-- (void)viewDidMoveToWindow
-{
-    [super viewDidMoveToWindow];
-
-    if (_window)
-        [self _applyVibrancyState];
 }
 
 

--- a/Tests/AppKit/CPViewTest.j
+++ b/Tests/AppKit/CPViewTest.j
@@ -773,6 +773,8 @@ var methodCalled;
 
 - (void)testAppearanceDefaultvalue
 {
+    [[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
+
     [self assert:nil equals:[view appearance]];
     [self assertFalse:[view hasThemeState:CPThemeStateAppearanceVibrantDark]];
     [self assertFalse:[view hasThemeState:CPThemeStateAppearanceVibrantLight]];
@@ -782,9 +784,10 @@ var methodCalled;
 - (void)testAppearanceWithVibrantDark
 {
     [view setAppearance:[CPAppearance appearanceNamed:CPAppearanceNameVibrantDark]];
-
     [self assert:[CPAppearance appearanceNamed:CPAppearanceNameVibrantDark] equals:[view appearance]];
     [self assert:[CPAppearance appearanceNamed:CPAppearanceNameVibrantDark] equals:[view effectiveAppearance]];
+
+    [[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
     [self assertTrue:[view hasThemeState:CPThemeStateAppearanceVibrantDark]];
     [self assertFalse:[view hasThemeState:CPThemeStateAppearanceVibrantLight]];
 }
@@ -795,6 +798,8 @@ var methodCalled;
 
     [self assert:[CPAppearance appearanceNamed:CPAppearanceNameVibrantLight] equals:[view appearance]];
     [self assert:[CPAppearance appearanceNamed:CPAppearanceNameVibrantLight] equals:[view effectiveAppearance]];
+
+    [[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
     [self assertTrue:[view hasThemeState:CPThemeStateAppearanceVibrantLight]];
     [self assertFalse:[view hasThemeState:CPThemeStateAppearanceVibrantDark]];
 }
@@ -806,6 +811,8 @@ var methodCalled;
 
     [self assert:nil equals:[view appearance]];
     [self assert:nil equals:[view effectiveAppearance]];
+
+    [[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
     [self assertFalse:[view hasThemeState:CPThemeStateAppearanceVibrantLight]];
     [self assertFalse:[view hasThemeState:CPThemeStateAppearanceVibrantDark]];
 }
@@ -833,12 +840,14 @@ var methodCalled;
 
     [viewA addSubview:view];
 
+    [[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
     [self assert:[CPAppearance appearanceNamed:CPAppearanceNameVibrantLight] equals:[view effectiveAppearance]];
     [self assertTrue:[view hasThemeState:CPThemeStateAppearanceVibrantLight]];
     [self assertFalse:[view hasThemeState:CPThemeStateAppearanceVibrantDark]];
 
     [viewB addSubview:view];
 
+    [[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
     [self assert:[CPAppearance appearanceNamed:CPAppearanceNameVibrantDark] equals:[view effectiveAppearance]];
     [self assertFalse:[view hasThemeState:CPThemeStateAppearanceVibrantLight]];
     [self assertTrue:[view hasThemeState:CPThemeStateAppearanceVibrantDark]];


### PR DESCRIPTION
Previously, when using a viewBased CPTableView Cappuccino just crashed.
This was due to the new appearance feature. Indeed, at the end of the method initWithCoder: of CPView, we set the appearance of the current view and the themeStates of the view and its subviews. For an unknown reason some of these subviews were not completely initialized (see comment line 3742), this made crashed cappuccino because _themeState was null.

To fix this issue, we send the method setAppearance when the current stack was performed. (Magic setTimeout...).

This is for sure not the ultimate best fix, but it's prevent to have a broken master. We will need in the future to fix this issue in a better way.