### PR TITLE
Fixed: The init method ’initWithObjects:count:’ for CPArray did not work

### DIFF
--- a/Foundation/CPArray/_CPJavaScriptArray.j
+++ b/Foundation/CPArray/_CPJavaScriptArray.j
@@ -91,7 +91,7 @@ var concat = Array.prototype.concat,
 - (id)initWithObjects:(CPArray)objects count:(CPUInteger)aCount
 {
     if ([objects isKindOfClass:_CPJavaScriptArray])
-        return slice.call(objects, 0);
+        return slice.call(objects, 0, aCount);
 
     var array = [],
         index = 0;

--- a/Tests/Foundation/CPArrayTest.j
+++ b/Tests/Foundation/CPArrayTest.j
@@ -11,6 +11,16 @@
     return ConcreteArray;
 }
 
+- (void)test_initWithObjects_count_
+{
+    var arrayClass = [[self class] arrayClass],
+        array = [[arrayClass alloc] initWithObjects:[@"hello", @"bye", @"goodnight", @"seeya"] count:2];
+
+    [self assert:[array count] equals:2];
+    [self assert:[array objectAtIndex:0] equals:@"hello"];
+    [self assert:[array objectAtIndex:1] equals:@"bye"];
+}
+
 - (void)test_containsObject_
 {
     var arrayClass = [[self class] arrayClass],
@@ -759,6 +769,21 @@
 
     if (self)
         array = [anArray copy];
+
+    return self;
+}
+
+- (id)initWithObjects:(CPArray)objects count:(CPUInteger)aCount
+{
+    self = [super init];
+
+    if (self)
+    {
+      array = [];
+
+      for (var index = 0; index < aCount; ++index)
+          array.push([objects objectAtIndex:index]);
+    }
 
     return self;
 }

--- a/Tests/Foundation/CPMutableArrayTest.j
+++ b/Tests/Foundation/CPMutableArrayTest.j
@@ -555,6 +555,21 @@
     return self;
 }
 
+- (id)initWithObjects:(CPArray)objects count:(CPUInteger)aCount
+{
+    self = [super init];
+
+    if (self)
+    {
+      array = [];
+
+      for (var index = 0; index < aCount; ++index)
+          array.push([objects objectAtIndex:index]);
+    }
+
+    return self;
+}
+
 - (CPUInteger)count
 {
     return array.length;


### PR DESCRIPTION
The init method ’initWithObjects:count:’ for CPArray did not work on native CPJavaScriptArray when ’count’ is not the same as the length on the provided array.

A test case for this is also added in the test class CPArrayTest