### PR TITLE
Use the faster objj_msgSend instead of the old slower objj_msgSend

### DIFF
--- a/AppKit/CPAlert.j
+++ b/AppKit/CPAlert.j
@@ -821,12 +821,12 @@ var bottomHeight = 71;
     else if (_modalDelegate)
     {
         if (_didEndSelector)
-            objj_msgSend(_modalDelegate, _didEndSelector, self, returnCode, contextInfo);
+            _modalDelegate.isa.objj_msgSend3(_modalDelegate, _didEndSelector, self, returnCode, contextInfo);
     }
     else if (_delegate)
     {
         if (_didEndSelector)
-            objj_msgSend(_delegate, _didEndSelector, self, returnCode);
+            _delegate.isa.objj_msgSend2(_delegate, _didEndSelector, self, returnCode);
         else
             [self _sendDelegateAlertDidEndReturnCode:returnCode];
     }

--- a/AppKit/CPApplication.j
+++ b/AppKit/CPApplication.j
@@ -984,7 +984,7 @@ var CPApplicationDelegate_applicationShouldTerminate_           = 1 << 0,
 */
 - (void)setTarget:(id)aTarget selector:(SEL)aSelector forNextEventMatchingMask:(unsigned int)aMask untilDate:(CPDate)anExpiration inMode:(CPString)aMode dequeue:(BOOL)shouldDequeue
 {
-    _eventListeners.splice(_eventListenerInsertionIndex++, 0, _CPEventListenerMake(aMask, function (anEvent) { objj_msgSend(aTarget, aSelector, anEvent); }, shouldDequeue));
+    _eventListeners.splice(_eventListenerInsertionIndex++, 0, _CPEventListenerMake(aMask, function (anEvent) { if (aTarget != null) aTarget.isa.objj_msgSend1(aTarget, aSelector, anEvent); }, shouldDequeue));
 }
 
 /*!
@@ -1358,7 +1358,7 @@ var _CPAppBootstrapperActions = nil;
     {
         var action = _CPAppBootstrapperActions.shift();
 
-        if (objj_msgSend(self, action))
+        if (self.isa.objj_msgSend0(self, action))
             return;
     }
 

--- a/AppKit/CPDocument.j
+++ b/AppKit/CPDocument.j
@@ -515,7 +515,9 @@ var CPDocumentUntitledCount = 0;
 
         alert("There was an error retrieving the document.");
 
-        objj_msgSend(session.delegate, session.didReadSelector, self, NO, session.contextInfo);
+        var theDelegate = session.delegate;
+
+        theDelegate.isa.objj_msgSend3(theDelegate, session.didReadSelector, self, NO, session.contextInfo);
     }
     else
     {
@@ -540,7 +542,9 @@ var CPDocumentUntitledCount = 0;
 
                 _writeRequest = nil;
 
-                objj_msgSend(session.delegate, session.didSaveSelector, self, NO, session.contextInfo);
+                var theDelegate = session.delegate;
+
+                theDelegate.isa.objj_msgSend3(theDelegate, session.didSaveSelector, self, NO, session.contextInfo);
                 [self _sendDocumentSavedNotification:NO];
             }
         }
@@ -553,14 +557,15 @@ var CPDocumentUntitledCount = 0;
 */
 - (void)connection:(CPURLConnection)aConnection didReceiveData:(CPString)aData
 {
-    var session = aConnection.session;
+    var session = aConnection.session,
+        theDelegate = session.delegate;
 
     // READ
     if (aConnection == _readConnection)
     {
         [self readFromData:[CPData dataWithRawString:aData] ofType:session.fileType error:nil];
 
-        objj_msgSend(session.delegate, session.didReadSelector, self, YES, session.contextInfo);
+        theDelegate.isa.objj_msgSend3(theDelegate, session.didReadSelector, self, YES, session.contextInfo);
     }
     else
     {
@@ -569,7 +574,7 @@ var CPDocumentUntitledCount = 0;
 
         _writeRequest = nil;
 
-        objj_msgSend(session.delegate, session.didSaveSelector, self, YES, session.contextInfo);
+        theDelegate.isa.objj_msgSend3(theDelegate, session.didSaveSelector, self, YES, session.contextInfo);
         [self _sendDocumentSavedNotification:YES];
     }
 }
@@ -580,10 +585,11 @@ var CPDocumentUntitledCount = 0;
 */
 - (void)connection:(CPURLConnection)aConnection didFailWithError:(CPError)anError
 {
-    var session = aConnection.session;
+    var session = aConnection.session,
+        theDelegate = session.delegate;
 
     if (_readConnection == aConnection)
-        objj_msgSend(session.delegate, session.didReadSelector, self, NO, session.contextInfo);
+        theDelegate.isa.objj_msgSend3(theDelegate, session.didReadSelector, self, NO, session.contextInfo);
 
     else
     {
@@ -597,7 +603,7 @@ var CPDocumentUntitledCount = 0;
 
         alert("There was an error saving the document.");
 
-        objj_msgSend(session.delegate, session.didSaveSelector, self, NO, session.contextInfo);
+        theDelegate.isa.objj_msgSend3(theDelegate, session.didSaveSelector, self, NO, session.contextInfo);
         [self _sendDocumentSavedNotification:NO];
     }
 }
@@ -858,21 +864,24 @@ var CPDocumentUntitledCount = 0;
         [self canCloseDocumentWithDelegate:self shouldCloseSelector:@selector(_document:shouldClose:context:) contextInfo:{delegate:delegate, selector:selector, context:info}];
 
     else if ([delegate respondsToSelector:selector])
-        objj_msgSend(delegate, selector, self, YES, info);
+        delegate.isa.objj_msgSend3(delegate, selector, self, YES, info);
 }
 
 - (void)_document:(CPDocument)aDocument shouldClose:(BOOL)shouldClose context:(Object)context
 {
+    var theDelegate = context.delegate;
+
     if (aDocument === self && shouldClose)
         [self close];
 
-    objj_msgSend(context.delegate, context.selector, aDocument, shouldClose, context.context);
+    if (theDelegate != null)
+        theDelegate.isa.objj_msgSend3(theDelegate, context.selector, aDocument, shouldClose, context.context);
 }
 
 - (void)canCloseDocumentWithDelegate:(id)aDelegate shouldCloseSelector:(SEL)aSelector contextInfo:(Object)context
 {
     if (![self isDocumentEdited])
-        return [aDelegate respondsToSelector:aSelector] && objj_msgSend(aDelegate, aSelector, self, YES, context);
+        return [aDelegate respondsToSelector:aSelector] && aDelegate.isa.objj_msgSend3(aDelegate, aSelector, self, YES, context);
 
     _canCloseAlert = [[CPAlert alloc] init];
 
@@ -901,8 +910,8 @@ var CPDocumentUntitledCount = 0;
 
     if (returnCode === 0)
         [self saveDocumentWithDelegate:delegate didSaveSelector:selector contextInfo:context];
-    else
-        objj_msgSend(delegate, selector, self, returnCode === 2, context);
+    else if (delegate != null)
+        delegate.isa.objj_msgSend3(delegate, selector, self, returnCode === 2, context);
 
     _canCloseAlert = nil;
 }

--- a/AppKit/CPDocumentController.j
+++ b/AppKit/CPDocumentController.j
@@ -402,8 +402,10 @@ var CPSharedDocumentController = nil;
         }
     }
 
-    if ([context.delegate respondsToSelector:context.selector])
-        objj_msgSend(context.delegate, context.selector, self, [[self documents] count] === 0, context.context);
+    var theDelegate = context.delegate;
+
+    if ([theDelegate respondsToSelector:context.selector])
+        theDelegate.isa.objj_msgSend3(theDelegate, context.selector, self, [[self documents] count] === 0, context.context);
 }
 
 @end

--- a/AppKit/CPOutlineView.j
+++ b/AppKit/CPOutlineView.j
@@ -1417,7 +1417,7 @@ var CPOutlineViewCoalesceSelectionNotificationStateOff  = 0,
             if (_dropItem)
             {
                 [_dropOperationFeedbackView blink];
-                [CPTimer scheduledTimerWithTimeInterval:.3 callback:objj_msgSend(self, "expandItem:", _dropItem) repeats:NO];
+                [CPTimer scheduledTimerWithTimeInterval:.3 callback:[self expandItem:_dropItem] repeats:NO];
             }
         };
 

--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -3649,7 +3649,7 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
     var view = nil;
 
     if (_viewForTableColumnRowSelector)
-        view = objj_msgSend(self, _viewForTableColumnRowSelector, aTableColumn, aRow);
+        view = self.isa.objj_msgSend2(self, _viewForTableColumnRowSelector, aTableColumn, aRow);
 
     if (!view)
     {
@@ -4211,7 +4211,7 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
     while (count--)
     {
         var currentIndex = indexes[count],
-            rowRect = CGRectIntersection(objj_msgSend(self, rectSelector, currentIndex), aRect);
+            rowRect = CGRectIntersection(self.isa.objj_msgSend1(self, rectSelector, currentIndex), aRect);
 
         // group rows get the same highlight style as other rows if they're source list...
         if (!drawGradient)
@@ -4285,7 +4285,7 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
 
     for (var i = 0; i < count2; i++)
     {
-         var rect = objj_msgSend(self, rectSelector, indexes[i]),
+         var rect = self.isa.objj_msgSend1(self, rectSelector, indexes[i]),
              minX = CGRectGetMinX(rect) - 0.5,
              maxX = CGRectGetMaxX(rect) - 0.5,
              minY = CGRectGetMinY(rect) - 0.5,
@@ -6304,17 +6304,17 @@ var CPTableViewDataSourceKey                = @"CPTableViewDataSourceKey",
 
     var showCallback = function()
     {
-        objj_msgSend(self, "setHidden:", NO)
+        [self setHidden: NO];
         isBlinking = NO;
     };
 
     var hideCallback = function()
     {
-        objj_msgSend(self, "setHidden:", YES)
+        [self setHidden: YES];
         isBlinking = YES;
     };
 
-    objj_msgSend(self, "setHidden:", YES);
+    [self setHidden: YES];
     [CPTimer scheduledTimerWithTimeInterval:0.1 callback:showCallback repeats:NO];
     [CPTimer scheduledTimerWithTimeInterval:0.19 callback:hideCallback repeats:NO];
     [CPTimer scheduledTimerWithTimeInterval:0.27 callback:showCallback repeats:NO];

--- a/AppKit/CPWindow/CPWindow.j
+++ b/AppKit/CPWindow/CPWindow.j
@@ -2856,7 +2856,7 @@ CPTexturedBackgroundWindowMask
     if (delegate && endSelector)
     {
         if (_sheetContext["isAttached"])
-            objj_msgSend(delegate, endSelector, _sheetContext["sheet"], _sheetContext["returnCode"],
+            delegate.isa.objj_msgSend3(delegate, endSelector, _sheetContext["sheet"], _sheetContext["returnCode"],
                 _sheetContext["contextInfo"]);
         else
             _sheetContext["deferDidEndSelector"] = YES;
@@ -2920,7 +2920,8 @@ CPTexturedBackgroundWindowMask
         _sheetContext = nil;
         sheet._parentView = nil;
 
-        objj_msgSend(delegate, selector, sheet, returnCode, contextInfo);
+        if (delegate != null)
+            delegate.isa.objj_msgSend3(delegate, selector, sheet, returnCode, contextInfo);
     }
     else
     {

--- a/Foundation/CPKeyValueObserving.j
+++ b/Foundation/CPKeyValueObserving.j
@@ -164,10 +164,11 @@
 + (BOOL)automaticallyNotifiesObserversForKey:(CPString)aKey
 {
     var capitalizedKey = aKey.charAt(0).toUpperCase() + aKey.substring(1),
-        selector = "automaticallyNotifiesObserversOf" + capitalizedKey;
+        selector = "automaticallyNotifiesObserversOf" + capitalizedKey,
+        aClass = [self class];
 
-    if ([[self class] respondsToSelector:selector])
-        return objj_msgSend([self class], selector);
+    if ([aClass respondsToSelector:selector])
+        return aClass.isa.objj_msgSend0(aClass, selector);
 
     return YES;
 }
@@ -175,10 +176,11 @@
 + (CPSet)keyPathsForValuesAffectingValueForKey:(CPString)aKey
 {
     var capitalizedKey = aKey.charAt(0).toUpperCase() + aKey.substring(1),
-        selector = "keyPathsForValuesAffecting" + capitalizedKey;
+        selector = "keyPathsForValuesAffecting" + capitalizedKey,
+        aClass = [self class];
 
-    if ([[self class] respondsToSelector:selector])
-        return objj_msgSend([self class], selector);
+    if ([aClass respondsToSelector:selector])
+        return aClass.isa.objj_msgSend0(aClass, selector);
 
     return [CPSet set];
 }

--- a/Tools/nib2cib/NSClassSwapper.j
+++ b/Tools/nib2cib/NSClassSwapper.j
@@ -72,7 +72,7 @@ var _CPCibClassSwapperClassNameKey          = @"_CPCibClassSwapperClassNameKey",
             {
                 // Switch to userland temporarily
                 self.isa = nsClass;
-                self = objj_msgSend(self, _cmd, aCoder);
+                self = nsClass.objj_msgSend1(self, _cmd, aCoder);
                 self.isa = swapperClass;
             }
             else
@@ -100,7 +100,7 @@ var _CPCibClassSwapperClassNameKey          = @"_CPCibClassSwapperClassNameKey",
             {
                 // Switch to userland temporarily
                 self.isa = nsClass;
-                objj_msgSend(self, _cmd, aCoder);
+                nsClass.objj_msgSend1(self, _cmd, aCoder);
                 self.isa = swapperClass;
             }
             else
@@ -110,7 +110,7 @@ var _CPCibClassSwapperClassNameKey          = @"_CPCibClassSwapperClassNameKey",
             // the correct class is swapped during unarchiving.
             if (nsClass)
             {
-                var classForArchiver = objj_msgSend(nsClass, "classForKeyedArchiver");
+                var classForArchiver = [nsClass classForKeyedArchiver];
 
                 if (classForArchiver)
                     aClassName = [classForArchiver className];


### PR DESCRIPTION
In some places the objj_msgSend function is called directly. Most of the times the old slower version is called. This commit will use the never faster version instead.