### PR TITLE
Faster theme state handling

### DIFF
--- a/AppKit/CPButton.j
+++ b/AppKit/CPButton.j
@@ -280,7 +280,7 @@ CPButtonImageOffset   = 3.0;
             break;
 
         case CPOffState:
-            [self unsetThemeState:[CPThemeStateSelected, CPButtonStateMixed, CPThemeStateHighlighted]];
+            [self unsetThemeStates:[CPThemeStateSelected, CPButtonStateMixed, CPThemeStateHighlighted]];
     }
 }
 

--- a/AppKit/CPTableHeaderView.j
+++ b/AppKit/CPTableHeaderView.j
@@ -622,7 +622,7 @@ var CPTableHeaderViewResizeZone = 3.0,
     [[headerView subviews] makeObjectsPerformSelector:@selector(setHidden:) withObject:YES];
 
     // The underlying column header shows normal state
-    [headerView unsetThemeState:CPThemeStateHighlighted | CPThemeStateSelected];
+    [headerView unsetThemeStates:[CPThemeStateHighlighted, CPThemeStateSelected]];
 
     // Keep track of the location within the column header where the original mousedown occurred
     _columnDragHeaderView = [_columnDragView viewWithTag:CPTableHeaderViewDragColumnHeaderTag];

--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -6400,18 +6400,12 @@ var CPTableViewDataSourceKey                = @"CPTableViewDataSourceKey",
 
 - (BOOL)setThemeState:(ThemeState)aState
 {
-    if (aState.isa && [aState isKindOfClass:CPArray])
-        aState = CPThemeState.apply(null, aState);
-
     [super setThemeState:aState];
     [self recursivelyPerformSelector:@selector(setThemeState:) withObject:aState startingFrom:self];
 }
 
 - (BOOL)unsetThemeState:(ThemeState)aState
 {
-    if (aState.isa && [aState isKindOfClass:CPArray])
-        aState = CPThemeState.apply(null, aState);
-
     [super unsetThemeState:aState];
     [self recursivelyPerformSelector:@selector(unsetThemeState:) withObject:aState startingFrom:self];
 }

--- a/AppKit/CPTheme.j
+++ b/AppKit/CPTheme.j
@@ -389,6 +389,9 @@ ThemeState.prototype.isSubsetOf = function(aState)
 
 ThemeState.prototype.without = function(aState)
 {
+    if (!aState || aState === [CPNull null])
+        return this;
+
     var firstTransform = CPThemeWithoutTransform[this._stateNameString],
         result;
 
@@ -398,22 +401,18 @@ ThemeState.prototype.without = function(aState)
             return result;
     }
 
-    if (!aState || aState === [CPNull null])
-        result = this;
-    else
+    var newStates = {};
+
+    for (var stateName in this._stateNames)
     {
-        var newStates = {};
-        for (var stateName in this._stateNames)
-        {
-            if (!this._stateNames.hasOwnProperty(stateName))
-                continue;
+        if (!this._stateNames.hasOwnProperty(stateName))
+            continue;
 
-            if (!aState._stateNames[stateName])
-                newStates[stateName] = true;
-        }
-
-        result = ThemeState._cacheThemeState(new ThemeState(newStates));
+        if (!aState._stateNames[stateName])
+            newStates[stateName] = true;
     }
+
+    result = ThemeState._cacheThemeState(new ThemeState(newStates));
 
     if (!firstTransform)
         firstTransform = CPThemeWithoutTransform[this._stateNameString] = {};

--- a/AppKit/CPTheme.j
+++ b/AppKit/CPTheme.j
@@ -389,28 +389,64 @@ ThemeState.prototype.isSubsetOf = function(aState)
 
 ThemeState.prototype.without = function(aState)
 {
-    if (!aState || aState === [CPNull null])
-        return this;
+    var firstTransform = CPThemeWithoutTransform[this._stateNameString],
+        result;
 
-    var newStates = {};
-    for (var stateName in this._stateNames)
-    {
-        if (!this._stateNames.hasOwnProperty(stateName))
-            continue;
-
-        if (!aState._stateNames[stateName])
-            newStates[stateName] = true;
+    if (firstTransform) {
+        result = firstTransform[aState._stateNameString];
+        if (result)
+            return result;
     }
 
-    return ThemeState._cacheThemeState(new ThemeState(newStates));
+    if (!aState || aState === [CPNull null])
+        result = this;
+    else
+    {
+        var newStates = {};
+        for (var stateName in this._stateNames)
+        {
+            if (!this._stateNames.hasOwnProperty(stateName))
+                continue;
+
+            if (!aState._stateNames[stateName])
+                newStates[stateName] = true;
+        }
+
+        result = ThemeState._cacheThemeState(new ThemeState(newStates));
+    }
+
+    if (!firstTransform)
+        firstTransform = CPThemeWithoutTransform[this._stateNameString] = {};
+
+    firstTransform[aState._stateNameString] = result;
+
+    return result;
 }
 
 ThemeState.prototype.and  = function(aState)
 {
-    return CPThemeState(this, aState);
+    var firstTransform = CPThemeAndTransform[this._stateNameString],
+        result;
+
+    if (firstTransform) {
+        result = firstTransform[aState._stateNameString];
+        if (result)
+            return result;
+    }
+
+    result = CPThemeState(this, aState);
+
+    if (!firstTransform)
+        firstTransform = CPThemeAndTransform[this._stateNameString] = {};
+
+    firstTransform[aState._stateNameString] = result;
+
+    return result;
 }
 
 var CPThemeStates = {};
+var CPThemeWithoutTransform = {};
+var CPThemeAndTransform = {};
 
 ThemeState._cacheThemeState = function(aState)
 {

--- a/AppKit/CPTokenField.j
+++ b/AppKit/CPTokenField.j
@@ -1475,9 +1475,6 @@ CPTokenFieldDeleteButtonType     = 1;
 
 - (BOOL)setThemeState:(ThemeState)aState
 {
-   if (aState.isa && [aState isKindOfClass:CPArray])
-        aState = CPThemeState.apply(null, aState);
-
     var r = [super setThemeState:aState];
 
     // Share hover state with the disclosure and delete buttons.
@@ -1492,9 +1489,6 @@ CPTokenFieldDeleteButtonType     = 1;
 
 - (BOOL)unsetThemeState:(ThemeState)aState
 {
-   if (aState.isa && [aState isKindOfClass:CPArray])
-        aState = CPThemeState.apply(null, aState);
-
     var r = [super unsetThemeState:aState];
 
     // Share hover state with the disclosure and delete button.

--- a/AppKit/Themes/Aristo2/ThemeDescriptors.j
+++ b/AppKit/Themes/Aristo2/ThemeDescriptors.j
@@ -326,7 +326,7 @@ var themedButtonValues = nil,
     var button = [self button];
 
     [button setTitle:@"OK"];
-    [button setThemeState:[CPButtonStateBezelStyleRounded, CPThemeStateDefault]];
+    [button setThemeStates:[CPButtonStateBezelStyleRounded, CPThemeStateDefault]];
 
     return button;
 }

--- a/AppKit/_CPObject+Theme.j
+++ b/AppKit/_CPObject+Theme.j
@@ -38,8 +38,11 @@ var CPViewThemeClassKey             = @"CPViewThemeClassKey",
 
 - (unsigned)themeState;
 - (BOOL)hasThemeState:(ThemeState)aState;
+- (BOOL)hasThemeStates:(CPArray)states;
 - (BOOL)setThemeState:(ThemeState)aState;
+- (BOOL)setThemeStates:(CPArray)aState;
 - (BOOL)unsetThemeState:(ThemeState)aState;
+- (BOOL)unsetThemeStates:(CPArray)aState;
 - (BOOL)hasThemeAttribute:(CPString)aName;
 
 - (void)objectDidChangeTheme;
@@ -74,29 +77,47 @@ var CPViewThemeClassKey             = @"CPViewThemeClassKey",
 
 - (BOOL)hasThemeState:(ThemeState)aState
 {
-    if (aState.isa && [aState isKindOfClass:CPArray])
-        return _themeState.hasThemeState.apply(_themeState, aState);
+#if DEBUG
+    if (aState && aState.isa && [aState isKindOfClass:CPArray])
+        [CPException raise:CPInvalidArgumentException reason:@"aState can't be an array. Please use 'hasThemeStates: instead: " + aState];
+#endif
 
+    return _themeState.hasThemeState(aState);
+}
+
+- (BOOL)hasThemeStates:(CPArray)states
+{
+    var i = [states count],
+        aState = [states objectAtIndex:--i];
+
+    while (i > 0)
+    {
+        aState = aState.and([states objectAtIndex:--i]);
+    }
     return _themeState.hasThemeState(aState);
 }
 
 - (BOOL)setThemeState:(ThemeState)aState
 {
+#if DEBUG
     if (aState && aState.isa && [aState isKindOfClass:CPArray])
-        aState = CPThemeState.apply(null, aState);
+        [CPException raise:CPInvalidArgumentException reason:@"aState can't be an array. Please use 'setThemeStates: instead: " + aState];
+#endif
 
     if (_themeState.hasThemeState(aState))
         return NO;
 
-    _themeState = CPThemeState(_themeState, aState);
+    _themeState = _themeState.and(aState);
 
     return YES;
 }
 
 - (BOOL)unsetThemeState:(ThemeState)aState
 {
+#if DEBUG
     if (aState && aState.isa && [aState isKindOfClass:CPArray])
-        aState = CPThemeState.apply(null, aState);
+        [CPException raise:CPInvalidArgumentException reason:@"aState can't be an array. Please use 'unsetThemeStates: instead: " + aState];
+#endif
 
     var oldThemeState = _themeState;
     _themeState = _themeState.without(aState);
@@ -105,6 +126,30 @@ var CPViewThemeClassKey             = @"CPViewThemeClassKey",
         return NO;
 
     return YES;
+}
+
+- (BOOL)setThemeStates:(CPArray)states
+{
+    var i = [states count],
+        aState = [states objectAtIndex:--i];
+
+    while (i > 0)
+    {
+        aState = aState.and([states objectAtIndex:--i]);
+    }
+    return [self setThemeState:aState];
+}
+
+- (BOOL)unsetThemeStates:(CPArray)states
+{
+    var i = [states count],
+        aState = [states objectAtIndex:--i];
+
+    while (i > 0)
+    {
+        aState = aState.and([states objectAtIndex:--i]);
+    }
+    return [self unsetThemeState:aState];
 }
 
 #pragma mark Theme Attributes

--- a/AppKit/_CPObject+Theme.j
+++ b/AppKit/_CPObject+Theme.j
@@ -186,8 +186,13 @@ var CPViewThemeClassKey             = @"CPViewThemeClassKey",
 
     var theClass = [self class],
         CPObjectClass = [CPObject class],
-        attributes = [],
+        attributes = CachedThemeAttributes[class_getName(theClass)],
         nullValue = [CPNull null];
+
+    if (attributes)
+        return attributes;
+    else
+        attributes = [];
 
     for (; theClass && theClass !== CPObjectClass; theClass = [theClass superclass])
     {
@@ -196,8 +201,6 @@ var CPViewThemeClassKey             = @"CPViewThemeClassKey",
         if (cachedAttributes)
         {
             attributes = attributes.length ? attributes.concat(cachedAttributes) : attributes;
-            CachedThemeAttributes[[self className]] = attributes;
-
             break;
         }
 
@@ -218,6 +221,8 @@ var CPViewThemeClassKey             = @"CPViewThemeClassKey",
             attributes.push(attributeName);
         }
     }
+
+    CachedThemeAttributes[[self className]] = attributes;
 
     return attributes;
 }

--- a/Tests/AppKit/CPViewTest.j
+++ b/Tests/AppKit/CPViewTest.j
@@ -94,7 +94,7 @@ var methodCalled;
     [self assert:String(CPThemeState(CPThemeStateDisabled, CPThemeStateHighlighted)) equals:String([view themeState]) message:@"The view should be in the combined state of CPThemeStateDisabled and CPThemeStateHighlighted"];
 
     [view unsetThemeState:[view themeState]];
-    [view setThemeState:[CPThemeStateSelected, CPThemeStateDisabled]];
+    [view setThemeStates:[CPThemeStateSelected, CPThemeStateDisabled]];
     [self assert:String(CPThemeState(CPThemeStateDisabled, CPThemeStateSelected)) equals:String([view themeState]) message:@"setThemeState works with array argument"];
 }
 
@@ -117,20 +117,20 @@ var methodCalled;
     [self assert:String(CPThemeStateNormal) equals:String([view themeState]) message:@"CPView should be able to unset a combined theme state"];
 
     [view setThemeState:CPThemeState(CPThemeStateDisabled, CPThemeStateHighlighted, CPThemeStateBordered)];
-    [view unsetThemeState:[CPThemeStateBordered, CPThemeStateHighlighted]];
+    [view unsetThemeStates:[CPThemeStateBordered, CPThemeStateHighlighted]];
     [self assert:String(CPThemeStateDisabled) equals:String([view themeState]) message:@"unsetThemeState works with array argument"];
 
     [view setThemeState:CPThemeStateDisabled];
-    [view unsetThemeState:[CPThemeStateDisabled, CPThemeStateHighlighted]];
+    [view unsetThemeStates:[CPThemeStateDisabled, CPThemeStateHighlighted]];
     [self assert:String(CPThemeStateNormal) equals:String([view themeState]) message:@"CPView should be able to unset a combined theme state that has more theme states than the view currently has"];
 
     [view setThemeState:CPThemeState(CPThemeStateDisabled, CPThemeStateBordered)];
-    var returnValue = [view unsetThemeState:[CPThemeStateDisabled, CPThemeStateHighlighted]];
+    var returnValue = [view unsetThemeStates:[CPThemeStateDisabled, CPThemeStateHighlighted]];
     [self assert:String(CPThemeStateBordered) equals:String([view themeState]) message:@"CPView should be able to unset a combined theme state that has not entirely overlapping themestates"];
     [self assertTrue:returnValue message:@"When unsetThemeState successfully unsets anything, it return YES"];
 
     [view setThemeState:CPThemeState(CPThemeStateDisabled, CPThemeStateBordered)];
-    var returnValue = [view unsetThemeState:[CPThemeStateSelected, CPThemeStateHighlighted]];
+    var returnValue = [view unsetThemeStates:[CPThemeStateSelected, CPThemeStateHighlighted]];
     [self assert:String(CPThemeState(CPThemeStateDisabled, CPThemeStateBordered)) equals:String([view themeState]) message:@"CPView not unset any theme states it does not have"];
     [self assertFalse:returnValue message:@"When unsetThemeState doesn't unset anything, it returns NO"];
 

--- a/Tests/AppKit/CPViewTest.j
+++ b/Tests/AppKit/CPViewTest.j
@@ -69,7 +69,7 @@ var methodCalled;
     [self assertTrue:[view hasThemeState:CPThemeStateDisabled] message:@"CPView should be in state CPThemeStateDisabled"];
     [self assertTrue:[view hasThemeState:CPThemeStateBordered] message:@"CPView should be in state CPThemeStateBordered"];
     [self assertTrue:[view hasThemeState:CPThemeState(CPThemeStateBordered, CPThemeStateDisabled)] message:@"CPView should be in the combined state of CPThemeStateDisabled and CPThemeStateBordered"];
-    [self assertTrue:[view hasThemeState:[CPThemeStateBordered, CPThemeStateDisabled]] message:@"hasThemeState works with an array argument"];
+    [self assertTrue:[view hasThemeStates:[CPThemeStateBordered, CPThemeStateDisabled]] message:@"hasThemeState works with an array argument"];
     [self assertFalse:[view hasThemeState:CPThemeState(CPThemeStateNormal)] message:@"CPView should not be in CPThemeStateNormal"];
 }
 


### PR DESCRIPTION
ThemeState was changed from a bit mask to a Javascript object last year. This was done to handle more states as a bit mask is limited to 32 bits.
The performance impact of this was not good and made theme handling slower.
This pull request adds a cache mechanism to get back some of the lost performance.
Also fixed some other small performance improvements.

I tested to load a large cib file in Safari 9.0 and it took 1.80 seconds. With this change it will load in 1.60 seconds. Similar speed gains in Chrome too.