### PR TITLE
Fixed: default selection of a CPTabView item

### DIFF
--- a/AppKit/CPTabView.j
+++ b/AppKit/CPTabView.j
@@ -789,7 +789,13 @@ var CPTabViewItemsKey               = "CPTabViewItemsKey",
         var idx = [self indexOfTabViewItem:_selectedTabViewItem];
 
         if (idx !== CPNotFound)
+        {
+            // Temporarily set the selected item to not selected.
+            // It allows the initial selection to be made correctly.
+            _selectedTabViewItem = nil;
+
             [self selectTabViewItemAtIndex:idx];
+        }
     }
 
     var type = _type;


### PR DESCRIPTION
With the lately merged PR #2339 it breaks the default CPTabView item selection. The item is correctly selected inside the internal state of the object but the tab view is not loaded at all.

This is due to the fact that the _selectedTabViewItem contains the selected item from the init call and the selectTabViewItemAtIndex: method is called within the awakeFromCib method to load the selected tab, which fails as this happens to be already selected.

This PR fixes that.