### PR TITLE
New: added the method performBlock in CPRunLoop

### DIFF
--- a/AppKit/CPComboBox.j
+++ b/AppKit/CPComboBox.j
@@ -843,8 +843,9 @@ var CPComboBoxTextSubview = @"text",
         // In FireFox this needs to be done in setTimeout, otherwise there is no caret
         // We have to save the input element now, when we lose focus it will change.
         var element = [self _inputElement];
-        window.setTimeout(function() {
 
+        [[CPRunLoop mainRunLoop] performBlock:function()
+        {
             // This will prevent to jump to the focused element
             var previousScrollingOrigin = [self _scrollToVisibleRectAndReturnPreviousOrigin];
 
@@ -852,7 +853,7 @@ var CPComboBoxTextSubview = @"text",
 
             [self _restorePreviousScrollingOrigin:previousScrollingOrigin];
 
-        }, 0);
+        } argument:nil order:0 modes:[CPDefaultRunLoopMode]];
 #endif
 
         return NO;

--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -70,7 +70,6 @@ var CPTextFieldDOMCurrentElement = nil,
 
 var CPSecureTextFieldCharacter = "\u2022";
 
-
 function CPTextFieldBlurFunction(anEvent, owner, domElement, inputElement, resigning, didBlurRef)
 {
     if (owner && domElement != inputElement.parentNode)
@@ -87,7 +86,7 @@ function CPTextFieldBlurFunction(anEvent, owner, domElement, inputElement, resig
         */
         if ([owner _isWithinUsablePlatformRect])
         {
-            window.setTimeout(function()
+            [[CPRunLoop mainRunLoop] performBlock:function()
             {
                 // This will prevent to jump to the focused element
                 var previousScrollingOrigin = [owner _scrollToVisibleRectAndReturnPreviousOrigin];
@@ -95,7 +94,7 @@ function CPTextFieldBlurFunction(anEvent, owner, domElement, inputElement, resig
                 inputElement.focus();
 
                 [owner _restorePreviousScrollingOrigin:previousScrollingOrigin];
-            }, 0.0);
+            } argument:nil order:0 modes:[CPDefaultRunLoopMode]];
         }
     }
 
@@ -671,11 +670,8 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
 
     CPTextFieldInputOwner = self;
 
-    window.setTimeout(function()
+    [[CPRunLoop mainRunLoop] performBlock:function()
     {
-        /*
-            setTimeout handlers are not guaranteed to fire in the order they were initiated. This can cause a race condition when several windows with text fields are opened quickly, resulting in several instances of this timeout function being fired, perhaps out of order. So we have to check that by the time this function is fired, CPTextFieldInputOwner has not been changed to another text field in the meantime.
-        */
         if (CPTextFieldInputOwner !== self)
             return;
 
@@ -693,7 +689,7 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
         _willBecomeFirstResponderByClick = NO;
 
         [self textDidFocus:[CPNotification notificationWithName:CPTextFieldDidFocusNotification object:self userInfo:nil]];
-    }, 0.0);
+    } argument:nil order:0 modes:[CPDefaultRunLoopMode]];
 
 #endif
 
@@ -1510,7 +1506,7 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
                 if (immediately)
                     element.select();
                 else
-                    window.setTimeout(function() { element.select(); }, 0);
+                    [[CPRunLoop mainRunLoop] performBlock:function(){ element.select(); } argument:nil order:0 modes:[CPDefaultRunLoopMode]];
             }
             else if (wind !== nil && [wind makeFirstResponder:self])
                 [self _selectText:sender immediately:immediately];

--- a/AppKit/CPTokenField.j
+++ b/AppKit/CPTokenField.j
@@ -448,14 +448,14 @@ CPTokenFieldDeleteButtonType     = 1;
     element.style.width = CGRectGetWidth(contentRect) + "px";
     element.style.height = [font defaultLineHeightForFont] + "px";
 
-    window.setTimeout(function()
+    [[CPRunLoop mainRunLoop] performBlock:function()
     {
         [_tokenScrollView documentView]._DOMElement.appendChild(element);
 
         //post CPControlTextDidBeginEditingNotification
         [self textDidBeginEditing:[CPNotification notificationWithName:CPControlTextDidBeginEditingNotification object:self userInfo:nil]];
 
-        window.setTimeout(function()
+        [[CPRunLoop mainRunLoop] performBlock:function()
         {
             // This will prevent to jump to the focused element
             var previousScrollingOrigin = [self _scrollToVisibleRectAndReturnPreviousOrigin];
@@ -465,10 +465,10 @@ CPTokenFieldDeleteButtonType     = 1;
             [self _restorePreviousScrollingOrigin:previousScrollingOrigin];
 
             CPTokenFieldInputOwner = self;
-        }, 0.0);
+        } argument:nil order:0 modes:[CPDefaultRunLoopMode]];
 
         [self textDidFocus:[CPNotification notificationWithName:CPTextFieldDidFocusNotification object:self userInfo:nil]];
-    }, 0.0);
+    } argument:nil order:0 modes:[CPDefaultRunLoopMode]];
 
     [[[self window] platformWindow] _propagateCurrentDOMEvent:YES];
 

--- a/Tests/Foundation/CPRunLoopTest.j
+++ b/Tests/Foundation/CPRunLoopTest.j
@@ -34,6 +34,18 @@
     [self assert:[10] equals:performer2.callArgs];
 }
 
+- (void)testPerformBlock
+{
+    var i = 0;
+
+    [[CPRunLoop mainRunLoop] performBlock:function()
+    {i++} argument:nil order:0 modes:[CPDefaultRunLoopMode]];
+
+    [[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
+
+    [self assert:i equals:1];
+}
+
 @end
 
 @implementation Performer : CPObject


### PR DESCRIPTION
Previously, we could only give a selector and a target for perform in the runLoop. Now we can give a block.
This feature is used in the CPTextField class. Previously, when we wanted to call a function at the end of the stack we used window.setTimeout, however due to HTML5 specifications this wasn't called just at the end of the stack but at least 4ms (more information here https://developer.mozilla.org/en-US/docs/Web/API/WindowTimers/setTimeout#Minimum_delay_and_timeout_nesting). Now we give a block to perform, and this block will be performed in the next runloop.

Unittest has been added in Tests/Foundation/CPRunLoopTest.j