### PR TITLE
mouseEntered and mouseExited propagation fix proposal

### DIFF
--- a/AppKit/CPControl.j
+++ b/AppKit/CPControl.j
@@ -511,6 +511,8 @@ var CPControlBlackColor = [CPColor blackColor];
 
 - (void)mouseEntered:(CPEvent)anEvent
 {
+    [super mouseEntered:anEvent];
+
     if (![self isEnabled])
         return;
 
@@ -519,6 +521,8 @@ var CPControlBlackColor = [CPColor blackColor];
 
 - (void)mouseExited:(CPEvent)anEvent
 {
+    [super mouseExited:anEvent];
+
     var currentLocation = [self convertPoint:[anEvent locationInWindow] fromView:nil],
         isWithinFrame = [self tracksMouseOutsideOfFrame] || CGRectContainsPoint([self bounds], currentLocation);
 

--- a/AppKit/CPResponder.j
+++ b/AppKit/CPResponder.j
@@ -188,7 +188,9 @@ CPDeleteForwardKeyCode  = 46;
 
 - (void)mouseEntered:(CPEvent)anEvent
 {
-    [_nextResponder performSelector:_cmd withObject:anEvent];
+    if ([[anEvent window] shouldPropagateMouseEnteredEventToView:_nextResponder])
+        
+        [_nextResponder performSelector:_cmd withObject:anEvent];
 }
 
 /*!
@@ -197,7 +199,9 @@ CPDeleteForwardKeyCode  = 46;
 */
 - (void)mouseExited:(CPEvent)anEvent
 {
-    [_nextResponder performSelector:_cmd withObject:anEvent];
+    if ([[anEvent window] shouldPropagateMouseExitedEventToView:_nextResponder])
+        
+        [_nextResponder performSelector:_cmd withObject:anEvent];
 }
 
 /*!

--- a/AppKit/CPResponder.j
+++ b/AppKit/CPResponder.j
@@ -189,7 +189,6 @@ CPDeleteForwardKeyCode  = 46;
 - (void)mouseEntered:(CPEvent)anEvent
 {
     if ([[anEvent window] shouldPropagateMouseEnteredEventToView:_nextResponder])
-        
         [_nextResponder performSelector:_cmd withObject:anEvent];
 }
 
@@ -200,7 +199,6 @@ CPDeleteForwardKeyCode  = 46;
 - (void)mouseExited:(CPEvent)anEvent
 {
     if ([[anEvent window] shouldPropagateMouseExitedEventToView:_nextResponder])
-        
         [_nextResponder performSelector:_cmd withObject:anEvent];
 }
 

--- a/AppKit/CPWindow/CPWindow.j
+++ b/AppKit/CPWindow/CPWindow.j
@@ -198,6 +198,7 @@ var CPWindowActionMessageKeys = [
     CPView                              _toolbarView;
 
     CPArray                             _mouseEnteredStack;
+    CPArray                             mouseEnteredStack;
     CPView                              _leftMouseDownView;
     CPView                              _rightMouseDownView;
 
@@ -1985,13 +1986,16 @@ CPTexturedBackgroundWindowMask
             if (!_mouseEnteredStack)
                 _mouseEnteredStack = [];
 
+            if (!mouseEnteredStack)
+                mouseEnteredStack = [];
+            
             var hitTestView = [_windowView hitTest:point];
 
             if ([_mouseEnteredStack count] && [_mouseEnteredStack lastObject] === hitTestView)
                 return [hitTestView mouseMoved:anEvent];
 
-            var view = hitTestView,
-                mouseEnteredStack = [];
+            var view = hitTestView;
+            mouseEnteredStack = [];
 
             while (view)
             {
@@ -2013,8 +2017,7 @@ CPTexturedBackgroundWindowMask
             {
                 var event = [CPEvent mouseEventWithType:CPMouseExited location:point modifierFlags:[anEvent modifierFlags] timestamp:[anEvent timestamp] windowNumber:_windowNumber context:nil eventNumber:-1 clickCount:1 pressure:0];
 
-                for (; index < count; ++index)
-                    [_mouseEnteredStack[index] mouseExited:event];
+                [_mouseEnteredStack[count-1] mouseExited:event];
             }
 
             index = deviation + 1;
@@ -2024,14 +2027,25 @@ CPTexturedBackgroundWindowMask
             {
                 var event = [CPEvent mouseEventWithType:CPMouseEntered location:point modifierFlags:[anEvent modifierFlags] timestamp:[anEvent timestamp] windowNumber:_windowNumber context:nil eventNumber:-1 clickCount:1 pressure:0];
 
-                for (; index < count; ++index)
-                    [mouseEnteredStack[index] mouseEntered:event];
+                [mouseEnteredStack[count-1] mouseEntered:event];
             }
 
             _mouseEnteredStack = mouseEnteredStack;
 
             [hitTestView mouseMoved:anEvent];
     }
+}
+
+// The two following methods tell the sender (CPResponder) if it can or not propagate the current event deeper in the view hierarchy
+
+- (BOOL)shouldPropagateMouseEnteredEventToView:(CPView)aView
+{
+    return (![_mouseEnteredStack containsObject:aView]);
+}
+
+- (BOOL)shouldPropagateMouseExitedEventToView:(CPView)aView
+{
+    return (![mouseEnteredStack containsObject:aView]);
 }
 
 /*!


### PR DESCRIPTION
In a hierarchy of views, mouseEntered and mouseExited events are propagated via two mechanisms : the CPWindow sendEvent and the CPResponder mouseEntered / mouseExited methods.

In the CPWindow sendEvent, the event was sent to all views concerned by mouse event, from the bottommost to the topmost.

We take the following example : view 1 is a subclass of CPView implementing a mouseEntered event and containing view 2, a standard CPView (thus not implementing a specific mouseEntered method), that exactly fills the same space than view 1.

In the CPWindow sendEvent, a mouseEntered event was sent to view 1 (thus catched by the view 1 mouseEntered method), then sent to view 2. As view 2 doesn't deal with this event, the standard CPResponder mouseEntered method was called, passing the event to the next responder of view 2, aka view 1, which then catched it again.

The proposed fix modifies this process : 

In the CPWindow sendEvent, instead of sending the event to all entered/exited views, it now only send it to the topmost view. Then, if the view doesn't cope with this event, the CPResponder sends it to the next responder (going down the hierarchy) but only if the event has to be sent, that is if the next responder didn't yet received the event in the past.

If a view deals with the event, it can, if needed, call the super method to try to propagate the event down the hierarchy.


If you try the following sample app without the fix, you can observe : 

> Left sample : 

- entering the red square (which implements the mouseEntered/Exited methods) fires a mouseEntered
- then entering the green square (standard CPView) also fires a mouseEntered by the red square
- leaving the green square fires a mouseExited by the red square (which is bad)
- leaving the red square fires a mouseExited (which is normal)

> Middle sample : 

Everything works as expected as the red square is above the green one

> Right sample : 

A little more complex as the blue rectangle covers half the red square.


If you try this with the proposed fix, everything should be fine.

```
@class SomeViewSubclass;

@implementation AppController : CPObject
{
    @outlet CPWindow    theWindow;
}

- (void)applicationDidFinishLaunching:(CPNotification)aNotification
{
    // This is called when the application is done loading.
}

- (void)awakeFromCib
{
    // This is called when the cib is done loading.
    // You can implement this method on any object instantiated from a Cib.
    // It's a useful hook for setting up current UI values, and other things.
    
    // In this case, we want the window from Cib to become our full browser window
    [theWindow setFullPlatformWindow:NO];
    
    
    // Simple test
    
    var aView = [[SomeViewSubclass alloc] initWithFrame:CGRectMake(10, 10, 50, 50)];
    
    [aView setBackgroundColor:[CPColor redColor]];
    
    [[theWindow contentView] addSubview:aView];
    
    var anotherView = [[CPView alloc] initWithFrame:CGRectMake(10, 10, 30, 30)];
    
    [anotherView setBackgroundColor:[CPColor greenColor]];
    
    [aView addSubview:anotherView];
    
    
    
    // Second simple (opposite)
    
    
    
    var aView = [[CPView alloc] initWithFrame:CGRectMake(100, 10, 50, 50)];
    
    [aView setBackgroundColor:[CPColor greenColor]];
    
    [[theWindow contentView] addSubview:aView];
    
    var anotherView = [[SomeViewSubclass alloc] initWithFrame:CGRectMake(10, 10, 30, 30)];
    
    [anotherView setBackgroundColor:[CPColor redColor]];
    
    [aView addSubview:anotherView];

    
    // Third
    
    
    var aView = [[SomeViewSubclass alloc] initWithFrame:CGRectMake(200, 10, 50, 50)];
    
    [aView setBackgroundColor:[CPColor redColor]];
    
    [[theWindow contentView] addSubview:aView];
    
    var halfView = [[CPView alloc] initWithFrame:CGRectMake(0, 0, 25, 50)];
    
    [halfView setBackgroundColor:[CPColor blueColor]];
    
    [aView addSubview:halfView];
    
    var anotherView = [[CPView alloc] initWithFrame:CGRectMake(10, 10, 30, 30)];
    
    [anotherView setBackgroundColor:[CPColor greenColor]];
    
    [aView addSubview:anotherView];
}

@end

@implementation SomeViewSubclass : CPView
{
}

- (void)mouseEntered:(CPEvent)anEvent
{
    CPLog.trace("######### mouseEntered in "+self);
}

- (void)mouseExited:(CPEvent)anEvent
{
    CPLog.trace("######### mouseExited from "+self);
}

@end
```
