### PR TITLE
Objective-J runtime method type accessor functions

### DIFF
--- a/Objective-J/Debug.js
+++ b/Objective-J/Debug.js
@@ -185,7 +185,7 @@ GLOBAL(objj_typecheck_decorator) = function(msgSend)
         if (!aReceiver)
             return msgSend.apply(this, arguments);
 
-        var types = aReceiver.isa.method_dtable[aSelector].types;
+        var types = aReceiver.isa.method_dtable[aSelector].method_types;
         for (var i = 2; i < arguments.length; i++)
         {
             try

--- a/Objective-J/Runtime.js
+++ b/Objective-J/Runtime.js
@@ -1020,6 +1020,7 @@ GLOBAL(method_getName) = function(/*Method*/ aMethod)
     return aMethod.method_name;
 }
 
+// This will not return correct values if the compiler does not have the option 'IncludeTypeSignatures'
 GLOBAL(method_copyReturnType) = function(/*Method*/ aMethod)
 {
     var types = aMethod.method_types;
@@ -1034,25 +1035,37 @@ GLOBAL(method_copyReturnType) = function(/*Method*/ aMethod)
         return NULL;
 }
 
+// This will not return correct values for index > 1 if the compiler does not have the option 'IncludeTypeSignatures'
 GLOBAL(method_copyArgumentType) = function(/*Method*/ aMethod, /*unsigned int*/ index)
 {
-    var types = aMethod.method_types;
+    switch (index) {
+        case 0:
+            return "id";
 
-    if (types)
-    {
-        var argType = types[index + 1];
+        case 1:
+            return "SEL";
 
-        return argType != NULL ? argType : NULL;
+        default:
+            var types = aMethod.method_types;
+
+            if (types)
+            {
+                var argType = types[index - 1];
+
+                return argType != NULL ? argType : NULL;
+            }
+            else
+                return NULL;
     }
-    else
-        return NULL;
 }
 
+// Returns number of arguments for a method. The first argument is 'self' and the second is the selector.
+// Those are followed by the method arguments. So for example it will return 2 for a method with no arguments.
 GLOBAL(method_getNumberOfArguments) = function(/*Method*/ aMethod)
 {
     var types = aMethod.method_types;
 
-    return types ? types.length - 1 : ((aMethod.method_name.match(/:/g) || []).length);
+    return types ? types.length + 1 : ((aMethod.method_name.match(/:/g) || []).length + 2);
 }
 
 GLOBAL(method_getImplementation) = function(/*Method*/ aMethod)

--- a/Objective-J/Runtime.js
+++ b/Objective-J/Runtime.js
@@ -1020,14 +1020,6 @@ GLOBAL(method_getName) = function(/*Method*/ aMethod)
     return aMethod.method_name;
 }
 
-// FIXME: This function is deprecated and should be removed in a future release
-// Please use 'method_copyReturnType' or 'method_copyArgumentType'
-GLOBAL(method_getTypes) = function(/*Method*/ aMethod)
-{
-    console.warn("Runtime function 'method_getTypes' is deprecated. Please use function 'method_copyReturnType' or 'method_copyArgumentType'");
-    return aMethod.method_types;
-}
-
 GLOBAL(method_copyReturnType) = function(/*Method*/ aMethod)
 {
     var types = aMethod.method_types;

--- a/Objective-J/Runtime.js
+++ b/Objective-J/Runtime.js
@@ -1031,13 +1031,29 @@ GLOBAL(method_getTypes) = function(/*Method*/ aMethod)
 GLOBAL(method_copyReturnType) = function(/*Method*/ aMethod)
 {
     var types = aMethod.method_types;
-    return types ? types[0] : NULL;
+
+    if (types)
+    {
+        var argType = types[0];
+
+        return argType != NULL ? argType : NULL;
+    }
+    else
+        return NULL;
 }
 
 GLOBAL(method_copyArgumentType) = function(/*Method*/ aMethod, /*unsigned int*/ index)
 {
     var types = aMethod.method_types;
-    return types ? types[index + 1] : NULL;
+
+    if (types)
+    {
+        var argType = types[index + 1];
+
+        return argType != NULL ? argType : NULL;
+    }
+    else
+        return NULL;
 }
 
 GLOBAL(method_getImplementation) = function(/*Method*/ aMethod)

--- a/Objective-J/Runtime.js
+++ b/Objective-J/Runtime.js
@@ -1056,6 +1056,13 @@ GLOBAL(method_copyArgumentType) = function(/*Method*/ aMethod, /*unsigned int*/ 
         return NULL;
 }
 
+GLOBAL(method_getNumberOfArguments) = function(/*Method*/ aMethod)
+{
+    var types = aMethod.method_types;
+
+    return types ? types.length - 1 : ((aMethod.method_name.match(/:/g) || []).length);
+}
+
 GLOBAL(method_getImplementation) = function(/*Method*/ aMethod)
 {
     return aMethod.method_imp;

--- a/Objective-J/Runtime.js
+++ b/Objective-J/Runtime.js
@@ -1020,8 +1020,11 @@ GLOBAL(method_getName) = function(/*Method*/ aMethod)
     return aMethod.method_name;
 }
 
+// FIXME: This function is deprecated and should be removed in a future release
+// Please use 'method_copyReturnType' or 'method_copyArgumentType'
 GLOBAL(method_getTypes) = function(/*Method*/ aMethod)
 {
+    console.warn("Runtime function 'method_getTypes' is deprecated. Please use function 'method_copyReturnType' or 'method_copyArgumentType'");
     return aMethod.method_types;
 }
 

--- a/Objective-J/Runtime.js
+++ b/Objective-J/Runtime.js
@@ -1025,6 +1025,18 @@ GLOBAL(method_getTypes) = function(/*Method*/ aMethod)
     return aMethod.method_types;
 }
 
+GLOBAL(method_copyReturnType) = function(/*Method*/ aMethod)
+{
+    var types = aMethod.method_types;
+    return types ? types[0] : NULL;
+}
+
+GLOBAL(method_copyArgumentType) = function(/*Method*/ aMethod, /*unsigned int*/ index)
+{
+    var types = aMethod.method_types;
+    return types ? types[index + 1] : NULL;
+}
+
 GLOBAL(method_getImplementation) = function(/*Method*/ aMethod)
 {
     return aMethod.method_imp;

--- a/Tests/Objective-J/Preprocessor/BehaviorTests/MethodTest.j
+++ b/Tests/Objective-J/Preprocessor/BehaviorTests/MethodTest.j
@@ -87,17 +87,17 @@
     [self assert:method_getName(method) equals:@"sqrt:"];
 }
 
-- (void)testMethodNoArguments
+- (void)testMethodNoOfArguments
 {
     var method = class_getInstanceMethod(MathClass, @selector(five));
 
-    [self assert:method_getNumberOfArguments(method) equals:0];
+    [self assert:method_getNumberOfArguments(method) equals:2];
 
     method = class_getInstanceMethod(MathClass, @selector(multiply:));
-    [self assert:method_getNumberOfArguments(method) equals:1];
+    [self assert:method_getNumberOfArguments(method) equals:3];
 
     method = class_getInstanceMethod(MathClass, @selector(multiply:with:));
-    [self assert:method_getNumberOfArguments(method) equals:2];
+    [self assert:method_getNumberOfArguments(method) equals:4];
 }
 
 - (void)testMethodTypes
@@ -113,20 +113,26 @@
     var method = class_getInstanceMethod(theClass, @selector(myMethod:));
 
     [self assert:method_copyReturnType(method) equals:@"void" message:@"Return type of method 'myMethod:'"];
-    [self assert:method_copyArgumentType(method, 0) equals:@"CPNumber"];
-    [self assertTrue:method_copyArgumentType(method, 1) === nil];
-    [self assert:method_getNumberOfArguments(method) equals:1];
+    [self assert:method_copyArgumentType(method, 0) equals:@"id"];
+    [self assert:method_copyArgumentType(method, 1) equals:@"SEL"];
+    [self assert:method_copyArgumentType(method, 2) equals:@"CPNumber"];
+    [self assertTrue:method_copyArgumentType(method, 3) === nil];
+    [self assert:method_getNumberOfArguments(method) equals:3];
 
     method = class_getInstanceMethod(theClass, @selector(myMethod2:));
     [self assert:method_copyReturnType(method) equals:@"int" message:@"Return type of method 'myMethod2:'"];
-    [self assert:method_copyArgumentType(method, 0) equals:@"float"];
-    [self assertTrue:method_copyArgumentType(method, 1) === nil];
-    [self assert:method_getNumberOfArguments(method) equals:1];
+    [self assert:method_copyArgumentType(method, 0) equals:@"id"];
+    [self assert:method_copyArgumentType(method, 1) equals:@"SEL"];
+    [self assert:method_copyArgumentType(method, 2) equals:@"float"];
+    [self assertTrue:method_copyArgumentType(method, 3) === nil];
+    [self assert:method_getNumberOfArguments(method) equals:3];
 
     method = class_getInstanceMethod(theClass, @selector(myMethod3:));
     [self assertTrue:method_copyReturnType(method) == nil];
-    [self assertTrue:method_copyArgumentType(method, 0) === nil];
-    [self assert:method_getNumberOfArguments(method) equals:1];
+    [self assert:method_copyArgumentType(method, 0) equals:@"id"];
+    [self assert:method_copyArgumentType(method, 1) equals:@"SEL"];
+    [self assertTrue:method_copyArgumentType(method, 2) === nil];
+    [self assert:method_getNumberOfArguments(method) equals:3];
 }
 
 @end

--- a/Tests/Objective-J/Preprocessor/BehaviorTests/MethodTest.j
+++ b/Tests/Objective-J/Preprocessor/BehaviorTests/MethodTest.j
@@ -80,4 +80,53 @@
     [self assert:-6 equals:[testClass void:10 in:4]];
 }
 
+- (void)testMethodName
+{
+    var method = class_getInstanceMethod(MathClass, @selector(sqrt:));
+
+    [self assert:method_getName(method) equals:@"sqrt:"];
+}
+
+- (void)testMethodNoArguments
+{
+    var method = class_getInstanceMethod(MathClass, @selector(five));
+
+    [self assert:method_getNumberOfArguments(method) equals:0];
+
+    method = class_getInstanceMethod(MathClass, @selector(multiply:));
+    [self assert:method_getNumberOfArguments(method) equals:1];
+
+    method = class_getInstanceMethod(MathClass, @selector(multiply:with:));
+    [self assert:method_getNumberOfArguments(method) equals:2];
+}
+
+- (void)testMethodTypes
+{
+    var theClass = objj_allocateClassPair(CPObject, RAND() + "");
+
+    objj_registerClassPair(theClass);
+    class_addMethod(theClass, @"myMethod:", function() { }, ["void", "CPNumber"]);
+    class_addMethod(theClass, @"myMethod2:", function() { }, ["int", "float"]);
+    class_addMethod(theClass, @"myMethod3:", function() { });
+    [theClass new];
+
+    var method = class_getInstanceMethod(theClass, @selector(myMethod:));
+
+    [self assert:method_copyReturnType(method) equals:@"void" message:@"Return type of method 'myMethod:'"];
+    [self assert:method_copyArgumentType(method, 0) equals:@"CPNumber"];
+    [self assertTrue:method_copyArgumentType(method, 1) === nil];
+    [self assert:method_getNumberOfArguments(method) equals:1];
+
+    method = class_getInstanceMethod(theClass, @selector(myMethod2:));
+    [self assert:method_copyReturnType(method) equals:@"int" message:@"Return type of method 'myMethod2:'"];
+    [self assert:method_copyArgumentType(method, 0) equals:@"float"];
+    [self assertTrue:method_copyArgumentType(method, 1) === nil];
+    [self assert:method_getNumberOfArguments(method) equals:1];
+
+    method = class_getInstanceMethod(theClass, @selector(myMethod3:));
+    [self assertTrue:method_copyReturnType(method) == nil];
+    [self assertTrue:method_copyArgumentType(method, 0) === nil];
+    [self assert:method_getNumberOfArguments(method) equals:1];
+}
+
 @end


### PR DESCRIPTION
Added runtime functions to get return type and parameter types on methods.

The old function ```method_getTypes```was not compliant to how Objective-C runtime works. This function is now deprecated.