### PR TITLE
Default include type signatures for all kind of builds

### DIFF
--- a/Foundation/CPKeyValueObserving.j
+++ b/Foundation/CPKeyValueObserving.j
@@ -423,7 +423,7 @@ var kvoNewAndOld        = CPKeyValueObservingOptionNew | CPKeyValueObservingOpti
             setKey_method_imp(self, _cmd, anObject);
 
             [self didChangeValueForKey:aKey];
-        }, "");
+        }, setKey_method.method_types);
     }
 
     // FIXME: Deprecated.
@@ -441,7 +441,7 @@ var kvoNewAndOld        = CPKeyValueObservingOptionNew | CPKeyValueObservingOpti
             _setKey_method_imp(self, _cmd, anObject);
 
             [self didChangeValueForKey:aKey];
-        }, "");
+        }, _setKey_method.method_types);
     }
 
     // Ordered To-Many Relationships
@@ -478,7 +478,7 @@ var kvoNewAndOld        = CPKeyValueObservingOptionNew | CPKeyValueObservingOpti
                 [self didChange:CPKeyValueChangeInsertion
                 valuesAtIndexes:[CPIndexSet indexSetWithIndex:anIndex]
                          forKey:aKey];
-            }, "");
+            }, insertObject_inKeyAtIndex_method.method_types);
         }
 
         if (insertKey_atIndexes_method)
@@ -496,7 +496,7 @@ var kvoNewAndOld        = CPKeyValueObservingOptionNew | CPKeyValueObservingOpti
                 [self didChange:CPKeyValueChangeInsertion
                 valuesAtIndexes:[indexes copy]
                          forKey:aKey];
-            }, "");
+            }, insertKey_atIndexes_method.method_types);
         }
 
         if (removeObjectFromKeyAtIndex_method)
@@ -514,7 +514,7 @@ var kvoNewAndOld        = CPKeyValueObservingOptionNew | CPKeyValueObservingOpti
                 [self didChange:CPKeyValueChangeRemoval
                 valuesAtIndexes:[CPIndexSet indexSetWithIndex:anIndex]
                          forKey:aKey];
-            }, "");
+            }, removeObjectFromKeyAtIndex_method.method_types);
         }
 
         if (removeKeyAtIndexes_method)
@@ -532,7 +532,7 @@ var kvoNewAndOld        = CPKeyValueObservingOptionNew | CPKeyValueObservingOpti
                 [self didChange:CPKeyValueChangeRemoval
                 valuesAtIndexes:[indexes copy]
                          forKey:aKey];
-            }, "");
+            }, removeKeyAtIndexes_method.method_types);
         }
 
         // These are optional.
@@ -558,7 +558,7 @@ var kvoNewAndOld        = CPKeyValueObservingOptionNew | CPKeyValueObservingOpti
                 [self didChange:CPKeyValueChangeReplacement
                 valuesAtIndexes:[CPIndexSet indexSetWithIndex:anIndex]
                          forKey:aKey];
-            }, "");
+            }, replaceObjectInKeyAtIndex_withObject_method.method_types);
         }
 
         var replaceKeyAtIndexes_withKey_selector =
@@ -581,7 +581,7 @@ var kvoNewAndOld        = CPKeyValueObservingOptionNew | CPKeyValueObservingOpti
                 [self didChange:CPKeyValueChangeReplacement
                 valuesAtIndexes:[indexes copy]
                          forKey:aKey];
-            }, "");
+            }, replaceKeyAtIndexes_withKey_method.method_types);
         }
     }
 
@@ -615,7 +615,7 @@ var kvoNewAndOld        = CPKeyValueObservingOptionNew | CPKeyValueObservingOpti
                 [self didChangeValueForKey:aKey
                            withSetMutation:CPKeyValueUnionSetMutation
                               usingObjects:[CPSet setWithObject:anObject]];
-            }, "");
+            }, addKeyObject_method.method_types);
         }
 
         if (addKey_method)
@@ -633,7 +633,7 @@ var kvoNewAndOld        = CPKeyValueObservingOptionNew | CPKeyValueObservingOpti
                 [self didChangeValueForKey:aKey
                            withSetMutation:CPKeyValueUnionSetMutation
                               usingObjects:[objects copy]];
-            }, "");
+            }, addKey_method.method_types);
         }
 
         if (removeKeyObject_method)
@@ -651,7 +651,7 @@ var kvoNewAndOld        = CPKeyValueObservingOptionNew | CPKeyValueObservingOpti
                 [self didChangeValueForKey:aKey
                            withSetMutation:CPKeyValueMinusSetMutation
                               usingObjects:[CPSet setWithObject:anObject]];
-            }, "");
+            }, removeKeyObject_method.method_types);
         }
 
         if (removeKey_method)
@@ -669,7 +669,7 @@ var kvoNewAndOld        = CPKeyValueObservingOptionNew | CPKeyValueObservingOpti
                 [self didChangeValueForKey:aKey
                            withSetMutation:CPKeyValueMinusSetMutation
                               usingObjects:[objects copy]];
-            }, "");
+            }, removeKey_method.method_types);
         }
 
         // intersect<Key>: is optional.
@@ -691,7 +691,7 @@ var kvoNewAndOld        = CPKeyValueObservingOptionNew | CPKeyValueObservingOpti
                 [self didChangeValueForKey:aKey
                            withSetMutation:CPKeyValueIntersectSetMutation
                               usingObjects:[aSet copy]];
-            }, "");
+            }, intersectKey_method.method_types);
         }
     }
 

--- a/Objective-J/CommonJS/lib/objective-j.js
+++ b/Objective-J/CommonJS/lib/objective-j.js
@@ -90,11 +90,14 @@ exports.run = function(args)
         if (argv[0] === "--help" || argv[0] === "-h")
         {
             print("Usage (objj): " + args[0] + " [options] [--] files...");
-            print("  -v, --version                  print the current version of objj");
-            print("  -I, --objj-include-paths       include a specific framework paths")
-            print("  -h, --help                     print this help");
-            print("  -m, --multifiles               launch objj on several files")
-            print("  -x, --xml                      specify the output format in xml.")
+            print("  -v, --version                       print the current version of objj");
+            print("  -I, --objj-include-paths            include a specific framework paths")
+            print("  -h, --help                          print this help");
+            print("  -m, --multifiles                    launch objj on several files")
+            print("  -x, --xml                           specify the output format in xml.")
+            print("  -g, --include-debug-symbols         Include debug symbols when compiling.")
+            print("  -T, --dont-include-type-signatures  Do not include type signatures when compiling.")
+            print("  -O2, --inline-msg-send              Inline objj_msgSend function when compiling.")
             return;
         }
 
@@ -118,6 +121,24 @@ exports.run = function(args)
                 case "--xml":
                     argv.shift();
                     exports.outputFormatInXML = true;
+                    break;
+
+                case "-g":
+                case "--include-debug-symbols":
+                    argv.shift();
+                    (OBJJ_COMPILER_FLAGS || (OBJJ_COMPILER_FLAGS = [])).push("IncludeDebugSymbols");
+                    break;
+
+                case "-T":
+                case "--dont-include-type-signatures":
+                    argv.shift();
+                    (OBJJ_COMPILER_FLAGS || (OBJJ_COMPILER_FLAGS = [])).push("IncludeTypeSignatures");
+                    break;
+
+                case "-O2":
+                case "--inline-msg-send":
+                    argv.shift();
+                    (OBJJ_COMPILER_FLAGS || (OBJJ_COMPILER_FLAGS = [])).push("InlineMsgSend");
                     break;
             }
         }

--- a/Objective-J/CommonJS/lib/objective-j/compiler.js
+++ b/Objective-J/CommonJS/lib/objective-j/compiler.js
@@ -187,7 +187,7 @@ function resolveFlags(args)
             objjcFlags &= ~ObjectiveJ.ObjJAcornCompiler.Flags.CheckSyntax;
 
         else if (argument.indexOf("-T") === 0)
-            objjcFlags |= ObjectiveJ.ObjJAcornCompiler.Flags.IncludeTypeSignatures;
+            objjcFlags &= ~ObjectiveJ.ObjJAcornCompiler.Flags.IncludeTypeSignatures;
 
         else if (argument.indexOf("-g") === 0)
             objjcFlags |= ObjectiveJ.ObjJAcornCompiler.Flags.IncludeDebugSymbols;
@@ -259,12 +259,16 @@ exports.main = function(args)
         if (argv[0] === "--help" || argv[0].substr(0, 1) == '-')
         {
             print("Usage (objjc 2.0): " + args[0] + " [options] [--] file...");
-            print("  -p, --print                    print the output directly to stdout");
-            print("  --unmarked                     don't tag the output with @STATIC header");
+            print("  -p, --print                         print the output directly to stdout");
+            print("  --unmarked                          don't tag the output with @STATIC header");
             print("");
-            print("  -T, --includeTypeSignatures    include type signatures in the compiled output");
+            print("  -T, --dont-include-type-signatures  include type signatures in the compiled output");
+            print("  -g, --include-debug-symbols         include debug symbols in the compiled output");
+            print("  -T, --include-type-signatures       include type signatures in the compiled output");
+            print("  -O, --compress                      compress the compiled output");
+            print("  -O2, --inline-msg-send              inline objj_msgSend function in the compiled output");
             print("");
-            print("  --help                         print this help");
+            print("  --help                              print this help");
             return;
         }
 

--- a/Tests/Foundation/CPKeyValueObservingTest.j
+++ b/Tests/Foundation/CPKeyValueObservingTest.j
@@ -28,7 +28,7 @@ var _getCheeseCounter;
         count = arguments.length;
 
     for (; index < count; ++index)
-        class_addMethod(theClass, arguments[index], function() { });
+        class_addMethod(theClass, arguments[index], function() { }, ["void"]);
 
     return [theClass new];
 }
@@ -268,7 +268,8 @@ var _getCheeseCounter;
 - (void)testOnlyInsertObject_AtKeyIndex_Implemented
 {
     var insertSelector = @selector(insertObject:inObjectsAtIndex:),
-        object = [self objectWithMethods:insertSelector];
+        object = [self objectWithMethods:insertSelector],
+        methodTypes = class_getInstanceMethod(object.isa, insertSelector).method_types;
 
     // Sanity check
     [self assert:class_getInstanceMethod(object.isa, insertSelector)
@@ -415,6 +416,64 @@ var _getCheeseCounter;
     // and we didn't call will/didChange.
     [self assert:@"cheese" equals:_lastKeyPath message:"no observation when automatically notifies is off"];
     [self assert:test equals:_lastObject];
+}
+
+- (void)testMethodTypesOnKVOForSet_Key_Implemented
+{
+    var setSelector = @selector(setObjects:),
+        object = [self objectWithMethods:setSelector],
+        methodTypes = class_getInstanceMethod(object.isa, setSelector).method_types;
+
+    // Sanity check
+    [self assert:class_getInstanceMethod(object.isa, setSelector)
+            same:class_getInstanceMethod([object class], setSelector)];
+
+    [object
+        addObserver:self
+         forKeyPath:@"objects"
+            options:CPKeyValueObservingOptionOld | CPKeyValueObservingOptionNew
+            context:NULL];
+
+    // Sanity check
+    [self assert:class_getInstanceMethod(object.isa, setSelector)
+            notSame:class_getInstanceMethod([object class], setSelector)];
+
+    // Check that the return and parameter types are the same on the new method as the old
+    [self assertTrue:methodTypes != nil message:@"methodTypes can not be nil or undefined"];
+    [self assert:methodTypes equals:class_getInstanceMethod(object.isa, setSelector).method_types];
+}
+
+- (void)testMethodTypesOnKVOForInsertObject_AtKeyIndex_Implemented_and_removeFromKeyAtIndex
+{
+    var insertSelector = @selector(insertObject:inObjectsAtIndex:),
+        removeSelector = @selector(removeObjectFromObjectsAtIndex:),
+        object = [self objectWithMethods:insertSelector, removeSelector],
+        methodTypesInsert = class_getInstanceMethod(object.isa, insertSelector).method_types,
+        methodTypesRemove = class_getInstanceMethod(object.isa, removeSelector).method_types;
+
+    // Sanity check
+    [self assert:class_getInstanceMethod(object.isa, insertSelector)
+            same:class_getInstanceMethod([object class], insertSelector)];
+    [self assert:class_getInstanceMethod(object.isa, removeSelector)
+            same:class_getInstanceMethod([object class], removeSelector)];
+
+    [object
+        addObserver:self
+         forKeyPath:@"objects"
+            options:CPKeyValueObservingOptionOld | CPKeyValueObservingOptionNew
+            context:NULL];
+
+    // Sanity check
+    [self assert:class_getInstanceMethod(object.isa, insertSelector)
+            notSame:class_getInstanceMethod([object class], insertSelector)];
+    [self assert:class_getInstanceMethod(object.isa, removeSelector)
+            notSame:class_getInstanceMethod([object class], removeSelector)];
+
+    // Check that the return and parameter types are the same on the new method as the old
+    [self assertTrue:methodTypesInsert != nil message:@"methodTypes can not be nil or undefined on insert selector"];
+    [self assertTrue:methodTypesRemove != nil message:@"methodTypes can not be nil or undefined in remove selector"];
+    [self assert:methodTypesInsert equals:class_getInstanceMethod(object.isa, insertSelector).method_types];
+    [self assert:methodTypesRemove equals:class_getInstanceMethod(object.isa, removeSelector).method_types];
 }
 
 @end

--- a/Tests/Objective-J/Preprocessor/OutputTests/Class/accessors.js
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Class/accessors.js
@@ -5,7 +5,7 @@ if(!the_class){
 throw new SyntaxError("*** Could not find definition for class \"TestClass\"");
 }
 var meta_class=the_class.isa;
-class_addIvars(the_class,[new objj_ivar("ivar")]);
+class_addIvars(the_class,[new objj_ivar("ivar","Type")]);
 class_addMethods(the_class,[new objj_method(sel_getUid("ivar"),function $TestClass__ivar(_1,_2){
 return _1.ivar;
 },["Type"]),new objj_method(sel_getUid("setIvar:"),function $TestClass__setIvar_(_3,_4,_5){

--- a/Tests/Objective-J/Preprocessor/OutputTests/Class/root-class-multiple-ivars.js
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Class/root-class-multiple-ivars.js
@@ -1,6 +1,6 @@
 var the_class = objj_allocateClassPair(Nil, "TestClass"),
     meta_class = the_class.isa;
 
-class_addIvars(the_class,[new objj_ivar("ivar"), new objj_ivar("array"), new objj_ivar("string"), new objj_ivar("integer")]);
+class_addIvars(the_class,[new objj_ivar("ivar","Type"), new objj_ivar("array","CPArray"), new objj_ivar("string","CPString"), new objj_ivar("integer","int")]);
 
 objj_registerClassPair(the_class);

--- a/Tests/Objective-J/Preprocessor/OutputTests/Class/root-class-one-ivar.js
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Class/root-class-one-ivar.js
@@ -2,6 +2,6 @@
 var the_class = objj_allocateClassPair(Nil, "TestClass"),
     meta_class = the_class.isa;
 
-class_addIvars(the_class,[new objj_ivar("ivar")]);
+class_addIvars(the_class,[new objj_ivar("ivar","Type")]);
 
 objj_registerClassPair(the_class);

--- a/Tests/Objective-J/Preprocessor/OutputTests/Misc/ref-self.js
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Misc/ref-self.js
@@ -1,5 +1,5 @@
 {var the_class = objj_allocateClassPair(Nil, "TC"),
-meta_class = the_class.isa;class_addIvars(the_class, [new objj_ivar("_control")]);objj_registerClassPair(the_class);
+meta_class = the_class.isa;class_addIvars(the_class, [new objj_ivar("_control","id")]);objj_registerClassPair(the_class);
 class_addMethods(the_class, [new objj_method(sel_getUid("a"), function $TC__a(self, _cmd)
 {
     function(__input) { if (arguments.length) return self._control = __input; return self._control; };

--- a/Tests/Objective-J/Preprocessor/OutputTests/OutputTest.j
+++ b/Tests/Objective-J/Preprocessor/OutputTests/OutputTest.j
@@ -53,12 +53,12 @@ var FILENAMES = [
                     correctInlined = FILE.exists(p) ? FILE.read(p) : correct; // Get inlined version if it exists. Otherwise use the regular one.
 
                 [self assertNoThrow:function() {
-                    preprocessed = ObjectiveJ.ObjJAcornCompiler.compileToExecutable(unpreprocessed, nil, ObjectiveJ.ObjJAcornCompiler.Flags.IncludeDebugSymbols/* | ObjectiveJ.ObjJAcornCompiler.Flags.IncludeTypeSignatures*/).code();
+                    preprocessed = ObjectiveJ.ObjJAcornCompiler.compileToExecutable(unpreprocessed, nil, ObjectiveJ.ObjJAcornCompiler.Flags.IncludeDebugSymbols | ObjectiveJ.ObjJAcornCompiler.Flags.IncludeTypeSignatures).code();
                     preprocessed = compressor.compress(preprocessed, { charset : "UTF-8", useServer : true });
                     correct = compressor.compress(correct, { charset : "UTF-8", useServer : true });
 
                     // Get an Inlined version
-                    preprocessedInlined = ObjectiveJ.ObjJAcornCompiler.compileToExecutable(unpreprocessed, nil, ObjectiveJ.ObjJAcornCompiler.Flags.IncludeDebugSymbols | ObjectiveJ.ObjJAcornCompiler.Flags.InlineMsgSend/* | ObjectiveJ.ObjJAcornCompiler.Flags.IncludeTypeSignatures*/).code();
+                    preprocessedInlined = ObjectiveJ.ObjJAcornCompiler.compileToExecutable(unpreprocessed, nil, ObjectiveJ.ObjJAcornCompiler.Flags.IncludeDebugSymbols | ObjectiveJ.ObjJAcornCompiler.Flags.InlineMsgSend | ObjectiveJ.ObjJAcornCompiler.Flags.IncludeTypeSignatures).code();
                     preprocessedInlined = compressor.compress(preprocessedInlined, { charset : "UTF-8", useServer : true });
                     correctInlined = compressor.compress(correctInlined, { charset : "UTF-8", useServer : true });
                 }];

--- a/Tools/capp/Resources/Templates/Application/index-debug.html
+++ b/Tools/capp/Resources/Templates/Application/index-debug.html
@@ -33,8 +33,18 @@
         <script type="text/javascript">
             OBJJ_MAIN_FILE = "main.j";
             OBJJ_INCLUDE_PATHS = ["Frameworks/Debug", "Frameworks"];
-            // Uncomment below to generate debug symbols, type signatures and inline objj_msgSend functions
-            // OBJJ_COMPILER_FLAGS = ["IncludeDebugSymbols", "IncludeTypeSignatures", "InlineMsgSend"];
+            // The below will tell the compiler to generate debug symbols, type signatures and not inline objj_msgSend functions.
+            // This will affect only Objective-J code that is compiled when loading the application. It will not affect precompiled
+            // code like the Cappuccino frameworks.
+            //
+            // Debug symbols will give each Objective-J method a Javascript function name. Without a name it will be very hard to find
+            // the methods in the debugger.
+            // Type Signatures will give type information to the Objective-J runtime for instance variables and methods.
+            // Inline objj_msgSend will give a speed increase but decorators will not work. Check below on debug options for
+            // more information on decorators.
+            //
+            // Uncomment or comment on the line below to change the flags
+            OBJJ_COMPILER_FLAGS = ["IncludeDebugSymbols", "IncludeTypeSignatures"/*, "InlineMsgSend"*/];
 
             var progressBar = null;
 
@@ -64,6 +74,7 @@
             objj_msgSend_reset();
 
             // DEBUG OPTIONS:
+            // Decorators will only work when the code is compiled without the compiler option 'InlineMsgSend'. Check above.
 
             // Uncomment to enable printing of backtraces on exceptions:
             //objj_msgSend_decorate(objj_backtrace_decorator);

--- a/Tools/capp/Resources/Templates/Application/index.html
+++ b/Tools/capp/Resources/Templates/Application/index.html
@@ -32,6 +32,11 @@
 
         <script type="text/javascript">
             OBJJ_MAIN_FILE = "main.j";
+            // The below will tell the compiler to not generate debug symbols but will generate type signatures and inline objj_msgSend functions.
+            // This will affect only Objective-J code that is compiled when loading the application. It will not affect precompiled
+            // code like the Cappuccino frameworks.
+            // Uncomment or comment on the line below to change the flags
+            OBJJ_COMPILER_FLAGS = [/*"IncludeDebugSymbols"*/, "IncludeTypeSignatures", "InlineMsgSend"];
 
             var progressBar = null;
 

--- a/Tools/capp/Resources/Templates/NibApplication/index-debug.html
+++ b/Tools/capp/Resources/Templates/NibApplication/index-debug.html
@@ -33,8 +33,18 @@
         <script type="text/javascript">
             OBJJ_MAIN_FILE = "main.j";
             OBJJ_INCLUDE_PATHS = ["Frameworks/Debug", "Frameworks"];
-            // Uncomment below to generate debug symbols, type signatures and inline objj_msgSend functions
-            // OBJJ_COMPILER_FLAGS = ["IncludeDebugSymbols", "IncludeTypeSignatures", "InlineMsgSend"];
+            // The below will tell the compiler to generate debug symbols, type signatures and not inline objj_msgSend functions.
+            // This will affect only Objective-J code that is compiled when loading the application. It will not affect precompiled
+            // code like the Cappuccino frameworks.
+            //
+            // Debug symbols will give each Objective-J method a Javascript function name. Without a name it will be very hard to find
+            // the methods in the debugger.
+            // Type Signatures will give type information to the Objective-J runtime for instance variables and methods.
+            // Inline objj_msgSend will give a speed increase but decorators will not work. Check below on debug options for
+            // more information on decorators.
+            //
+            // Uncomment or comment on the line below to change the flags
+            OBJJ_COMPILER_FLAGS = ["IncludeDebugSymbols", "IncludeTypeSignatures"/*, "InlineMsgSend"*/];
 
             var progressBar = null;
 
@@ -64,6 +74,7 @@
             objj_msgSend_reset();
 
             // DEBUG OPTIONS:
+            // Decorators will only work when the code is compiled without the compiler option 'InlineMsgSend'. Check above.
 
             // Uncomment to enable printing of backtraces on exceptions:
             //objj_msgSend_decorate(objj_backtrace_decorator);

--- a/Tools/capp/Resources/Templates/NibApplication/index.html
+++ b/Tools/capp/Resources/Templates/NibApplication/index.html
@@ -32,6 +32,11 @@
 
         <script type="text/javascript">
             OBJJ_MAIN_FILE = "main.j";
+            // The below will tell the compiler to not generate debug symbols but will generate type signatures and inline objj_msgSend functions.
+            // This will affect only Objective-J code that is compiled when loading the application. It will not affect precompiled
+            // code like the Cappuccino frameworks.
+            // Uncomment or comment on the line below to change the flags
+            OBJJ_COMPILER_FLAGS = [/*"IncludeDebugSymbols"*/, "IncludeTypeSignatures", "InlineMsgSend"];
 
             var progressBar = null;
 

--- a/Tools/capp/Resources/Templates/ThemeDescriptor/index-debug.html
+++ b/Tools/capp/Resources/Templates/ThemeDescriptor/index-debug.html
@@ -33,8 +33,18 @@
         <script type="text/javascript">
             OBJJ_MAIN_FILE = "main.j";
             OBJJ_INCLUDE_PATHS = ["Frameworks/Debug", "Frameworks"];
-            // Uncomment below to generate debug symbols, type signatures and inline objj_msgSend functions
-            // OBJJ_COMPILER_FLAGS = ["IncludeDebugSymbols", "IncludeTypeSignatures", "InlineMsgSend"];
+            // The below will tell the compiler to generate debug symbols, type signatures and not inline objj_msgSend functions.
+            // This will affect only Objective-J code that is compiled when loading the application. It will not affect precompiled
+            // code like the Cappuccino frameworks.
+            //
+            // Debug symbols will give each Objective-J method a Javascript function name. Without a name it will be very hard to find
+            // the methods in the debugger.
+            // Type Signatures will give type information to the Objective-J runtime for instance variables and methods.
+            // Inline objj_msgSend will give a speed increase but decorators will not work. Check below on debug options for
+            // more information on decorators.
+            //
+            // Uncomment or comment on the line below to change the flags
+            OBJJ_COMPILER_FLAGS = ["IncludeDebugSymbols", "IncludeTypeSignatures"/*, "InlineMsgSend"*/];
 
             var progressBar = null;
 
@@ -64,6 +74,7 @@
             objj_msgSend_reset();
 
             // DEBUG OPTIONS:
+            // Decorators will only work when the code is compiled without the compiler option 'InlineMsgSend'. Check above.
 
             // Uncomment to enable printing of backtraces on exceptions:
             //objj_msgSend_decorate(objj_backtrace_decorator);

--- a/Tools/capp/Resources/Templates/ThemeDescriptor/index.html
+++ b/Tools/capp/Resources/Templates/ThemeDescriptor/index.html
@@ -32,6 +32,11 @@
 
         <script type="text/javascript">
             OBJJ_MAIN_FILE = "main.j";
+            // The below will tell the compiler to not generate debug symbols but will generate type signatures and inline objj_msgSend functions.
+            // This will affect only Objective-J code that is compiled when loading the application. It will not affect precompiled
+            // code like the Cappuccino frameworks.
+            // Uncomment or comment on the line below to change the flags
+            OBJJ_COMPILER_FLAGS = [/*"IncludeDebugSymbols"*/, "IncludeTypeSignatures", "InlineMsgSend"];
 
             var progressBar = null;
 


### PR DESCRIPTION
This will make sure method and ivar type information is provided to the Objective-J runtime for all types of builds. It is done by providing the Objective-J compiler with option ```IncludeTypeSignatures```. It can optionally be turned off.

This will fix: #2398

A fix is also included that make sure that type signatures are copied to KVO method implementation for a object that is observed with KVO.

Some test cases are added for this.