### PR TITLE
FIXED: Subquery expressions were ignoring evaluation context

### DIFF
--- a/Foundation/CPPredicate/_CPSubqueryExpression.j
+++ b/Foundation/CPPredicate/_CPSubqueryExpression.j
@@ -47,23 +47,25 @@
         _collection = collection;
         _variableExpression = variableExpression;
     }
+
     return self;
 }
 
-- (id)expressionValueWithObject:(id)object context:(id)context
+- (id)expressionValueWithObject:(id)object context:(id)aContext
 {
-    var collection = [_collection expressionValueWithObject:object context:context],
-        count = [collection count],
+    var collection = [_collection expressionValueWithObject:object context:aContext],
         result = [CPArray array],
-        bindings = @{ [self variable]: [CPExpression expressionForEvaluatedObject] },
-        i = 0;
+        variable = [self variable],
+        context = aContext || @{};
 
-    for (; i < count; i++)
+    if ([context objectForKey:variable] == nil)
+        [context setObject:[CPExpression expressionForEvaluatedObject] forKey:variable];
+
+    [collection enumerateObjectsUsingBlock:function(exp, idx, stop)
     {
-        var item = [collection objectAtIndex:i];
-        if ([_subpredicate evaluateWithObject:item substitutionVariables:bindings])
-            [result addObject:item];
-    }
+        if ([_subpredicate evaluateWithObject:exp substitutionVariables:context])
+            [result addObject:exp];
+    }];
 
     return result;
 }

--- a/Tests/Foundation/CPPredicateTest.j
+++ b/Tests/Foundation/CPPredicateTest.j
@@ -139,10 +139,10 @@
 {
     var collection = [CPExpression expressionForKeyPath:@"Record1.Children"],
         iteratorVariable = @"x",
-        predicate = [CPPredicate predicateWithFormat:@"$x BEGINSWITH 'Kid'"];
+        predicate = [CPPredicate predicateWithFormat:@"$x BEGINSWITH $KidVariable"];
 
     var expression = [CPExpression expressionForSubquery:collection usingIteratorVariable:iteratorVariable predicate:predicate],
-        eval = [expression expressionValueWithObject:dict context:nil],
+        eval = [expression expressionValueWithObject:dict context:@{"KidVariable":[CPExpression expressionForConstantValue:"Kid"]}],
         expected = [CPArray arrayWithObjects:"Kid1", "Kid2"];
     [self assertTrue:([eval isEqual:expected]) message:"'" + [expression predicateFormat]  + "' result is "+ eval + "but should be " + expected];
 }
@@ -369,8 +369,8 @@
     [self assertTrue:[predicate evaluateWithObject:nil] message:"Predicate " + predicate + " should be TRUE"];
 
     // TEST Subquery -- This means: search people who have 2 boys.
-    predicate = [CPPredicate predicateWithFormat: @"SUBQUERY(Record1.Children, $x, $x BEGINSWITH 'Kid')[SIZE] = 2"];
-    [self assertTrue:[predicate evaluateWithObject:dict] message:"Predicate " + predicate + " should evaluate to TRUE"];
+    predicate = [CPPredicate predicateWithFormat: @"SUBQUERY(Record1.Children, $x, $x BEGINSWITH $Begining)[SIZE] = 2"];
+    [self assertTrue:[predicate evaluateWithObject:dict substitutionVariables:@{"Begining":"Kid"}] message:"Predicate " + predicate + " should evaluate to TRUE"];
 
     // Test Set expressions
     // Parsing is ok but the evaluation of this predicate will return NO because:


### PR DESCRIPTION
When the predicate part of a subquery expression was containing
variables, the substitution was ignored.
Now, the subpredicate can contain variables that will be substituted
when calling evaluateWithObject:substitutionVariables:.

Added expression test and predicate parsing test.