### PR TITLE
Fixed: nib2cib on a NSBox fails when having a CPTableView in it

### DIFF
--- a/AppKit/CPBox.j
+++ b/AppKit/CPBox.j
@@ -598,7 +598,8 @@ var CPBoxTypeKey          = @"CPBoxTypeKey",
     CPBoxBorderTypeKey    = @"CPBoxBorderTypeKey",
     CPBoxTitle            = @"CPBoxTitle",
     CPBoxTitlePosition    = @"CPBoxTitlePosition",
-    CPBoxTitleView        = @"CPBoxTitleView";
+    CPBoxTitleView        = @"CPBoxTitleView",
+    CPBoxContentView      = @"CPBoxContentView";
 
 @implementation CPBox (CPCoding)
 
@@ -615,7 +616,8 @@ var CPBoxTypeKey          = @"CPBoxTypeKey",
         _titlePosition = [aCoder decodeIntForKey:CPBoxTitlePosition];
         _titleView     = [aCoder decodeObjectForKey:CPBoxTitleView] || [CPTextField labelWithTitle:_title];
 
-        _contentView   = [self subviews][0];
+        _contentView   = [aCoder decodeObjectForKey:CPBoxContentView] || [[CPView alloc] initWithFrame:[self bounds]];
+        [self replaceSubview:_contentView with:[self subviews][0]];
 
         [self setAutoresizesSubviews:YES];
         [_contentView setAutoresizingMask:CPViewWidthSizable | CPViewHeightSizable];
@@ -635,6 +637,7 @@ var CPBoxTypeKey          = @"CPBoxTypeKey",
     [aCoder encodeObject:_title forKey:CPBoxTitle];
     [aCoder encodeInt:_titlePosition forKey:CPBoxTitlePosition];
     [aCoder encodeObject:_titleView forKey:CPBoxTitleView];
+    [aCoder encodeObject:_contentView forKey:CPBoxContentView];
 }
 
 @end

--- a/Tools/nib2cib/NSBox.j
+++ b/Tools/nib2cib/NSBox.j
@@ -30,8 +30,8 @@
 
     if (self)
     {
-        _boxType       = [aCoder decodeIntForKey:@"NSBoxType"];
-        _borderType    = [aCoder decodeIntForKey:@"NSBorderType"];
+        _boxType        = [aCoder decodeIntForKey:@"NSBoxType"];
+        _borderType     = [aCoder decodeIntForKey:@"NSBorderType"];
 
         var borderColor = [aCoder decodeObjectForKey:@"NSBorderColor2"],
             fillColor = [aCoder decodeObjectForKey:@"NSFillColor2"],
@@ -52,7 +52,8 @@
             frame.size.height -= 6;
         }
 
-        [self setFrame:frame];
+        _frame = frame;
+        _bounds.size = CGSizeMakeCopy(frame.size);
 
         if (_boxType !== CPBoxPrimary && _boxType !== CPBoxSecondary)
         {


### PR DESCRIPTION
Previously, when having a CPTableView in a CPBox, nib2cib failed due to a superview not defined yet. This was raised because in nib2cib we used the method setFrame on the CPBox to modify the frame of the CPBox (we need to modify this frame because the sizing difference between cappuccino and cocoa). We now directly modify the attribute _frame from the object and update the bounds in the same time.

This PR fixed another bug as well. Previously the contentView of the CPBox was not encoded, we now encode it. This allows us to get a full CPView object for the contentView, previously we got a weird (I have no idea how this object was created though...) object CPView with some missing attributes. This raised a crash because _trackingAreas or _themeState were not defined in this object.

Fixed #2400