### PR TITLE
FIXED: CPPredicate's predicateFormat with a CPNull value as right exp…

### DIFF
--- a/Foundation/CPPredicate/_CPConstantValueExpression.j
+++ b/Foundation/CPPredicate/_CPConstantValueExpression.j
@@ -66,6 +66,9 @@
     if ([_value isKindOfClass:[CPString class]])
         return @"\"" + _value + @"\"";
 
+    if (_value === [CPNull null])
+        return @"nil";
+
     return [_value description];
 }
 

--- a/Tests/Foundation/CPPredicateTest.j
+++ b/Tests/Foundation/CPPredicateTest.j
@@ -577,6 +577,17 @@
     }
 }
 
+- (void)testPredicateFormatWithNullGeneratesCorrectString
+{
+    var predicate1 = [CPPredicate predicateWithFormat:@"value == %@", [CPNull null]],
+        predicate2 = [CPPredicate predicateWithFormat:@"value == null"],
+        predicate3 = [CPPredicate predicateWithFormat:@"value == nil"];
+
+    [self assert:[predicate1 predicateFormat] equals:@"value == nil"];
+    [self assert:[predicate2 predicateFormat] equals:@"value == nil"];
+    [self assert:[predicate3 predicateFormat] equals:@"value == nil"];
+}
+
 @end
 
 @implementation CPObject (PredicateTesting)


### PR DESCRIPTION
…ression wasn't working

Previously a CPPredicate created with format `value == nil` was converted back to `value == <CPNull @ xxxx>`

This patch ensures `predicateFormat` returns `value == nil`

Test added in CPPredicateTest.j