### PR TITLE
FIXED: crash when opening a CPPopover opened on platform window A on …

### DIFF
--- a/AppKit/Platform/DOM/CPDOMWindowLayer.j
+++ b/AppKit/Platform/DOM/CPDOMWindowLayer.j
@@ -84,23 +84,35 @@
     // We will have to adjust the z-index of all windows starting at this index.
     var count = [_windows count],
         zIndex = (anIndex === CPNotFound ? count : anIndex),
-        isVisible = aWindow._isVisible;
+        isVisible = aWindow._isVisible,
+        isLocal = [_windows containsObject:aWindow];
 
-    // If the window is already a resident of this layer, remove it.
+    // if the window is visible
     if (isVisible)
     {
-        // Adjust the z-index to start at the window being inserted
-        zIndex = MIN(zIndex, aWindow._index);
+        // If the window is already a resident of this layer, remove it.
+        if (isLocal)
+        {
+            // Adjust the z-index to start at the window being inserted
+            zIndex = MIN(zIndex, aWindow._index);
 
-        // If the window being inserted is below the insertion index,
-        // the index will be one less after we remove the window below.
-        if (aWindow._index < anIndex)
-            --anIndex;
+            // If the window being inserted is below the insertion index,
+            // the index will be one less after we remove the window below.
+            if (aWindow._index < anIndex)
+                --anIndex;
 
-        [_windows removeObjectAtIndex:aWindow._index];
+            [_windows removeObjectAtIndex:aWindow._index];
+
+         }
+         else
+             ++count;
     }
     else
-        ++count;
+    {
+        // otherwise, remove the window from it's previous layer
+        var windowLayer = [[aWindow platformWindow]._windowLayers objectForKey:aWindow._level];
+        [windowLayer removeWindow:aWindow];
+    }
 
     if (anIndex === CPNotFound || anIndex >= count)
         [_windows addObject:aWindow];


### PR DESCRIPTION
…platform window B

Previously, if a child window was opened on platform window A, then the user opened it on different platfrom window, the application would crash.

This patch contains a fix that ensure the window is correctly removed from the good CPDOMWindowLayer
