### PR TITLE
Allow CPObjectController to get more attributes from the xib/cib file.

### DIFF
--- a/AppKit/CPObjectController.j
+++ b/AppKit/CPObjectController.j
@@ -27,6 +27,9 @@
 @import "CPController.j"
 @import "CPKeyValueBinding.j"
 
+@class _CPManagedProxy
+@class CPPredicate;
+
 /*!
     @class
 
@@ -47,6 +50,9 @@
 
     BOOL            _isEditable;
     BOOL            _automaticallyPreparesContent;
+    BOOL            _usesLazyFetching @accessors(getter=usesLazyFetching, setter=setUsesLazyFetching:);
+    BOOL            _isUsingManagedProxy;
+    _CPManagedProxy _managedProxy;
 
     CPCountedSet    _observedKeys;
 }
@@ -180,6 +186,46 @@
 }
 
 /*!
+    Sets the entity name the controller handles.
+
+    @param CPString newEntityName - The new entity name.
+*/
+- (void)setEntityName:(CPString)newEntityName
+{
+    [_managedProxy setEntityName:newEntityName];
+}
+
+/*!
+    Returns the entity name.
+
+    @return CPString - The name of the entity.
+*/
+- (CPString)entityName
+{
+    return [_managedProxy entityName];
+}
+
+/*!
+    Sets the predicate used to fetch content.
+
+    @param CPPredicate newPredicate - The fetch predicate.
+*/
+- (void)setFetchPredicate:(CPPredicate)newPredicate
+{
+    [_managedProxy setFetchPredicate:newPredicate];
+}
+
+/*!
+    Returns the fetch predicate.
+
+    @return CPPredicate - The predicate used to fetch content.
+*/
+- (CPPredicate)fetchPredicate
+{
+    return [_managedProxy fetchPredicate];
+}
+
+/*!
     Overridden by a subclass that require control over the creation of new objects.
 */
 - (void)prepareContent
@@ -189,6 +235,7 @@
 
 /*!
     Sets the object class when creating new objects.
+
     @param Class - the class of new objects that will be created.
 */
 - (void)setObjectClass:(Class)aClass
@@ -363,7 +410,10 @@
 var CPObjectControllerContentKey                        = @"CPObjectControllerContentKey",
     CPObjectControllerObjectClassNameKey                = @"CPObjectControllerObjectClassNameKey",
     CPObjectControllerIsEditableKey                     = @"CPObjectControllerIsEditableKey",
-    CPObjectControllerAutomaticallyPreparesContentKey   = @"CPObjectControllerAutomaticallyPreparesContentKey";
+    CPObjectControllerAutomaticallyPreparesContentKey   = @"CPObjectControllerAutomaticallyPreparesContentKey",
+    CPObjectControllerUsesLazyFetchingKey               = @"CPObjectControllerUsesLazyFetchingKey",
+    CPObjectControllerIsUsingManagedProxyKey            = @"CPObjectControllerIsUsingManagedProxyKey",
+    CPObjectControllerManagedProxyKey                   = @"CPObjectControllerManagedProxyKey";
 
 @implementation CPObjectController (CPCoding)
 
@@ -374,12 +424,17 @@ var CPObjectControllerContentKey                        = @"CPObjectControllerCo
     if (self)
     {
         var objectClassName = [aCoder decodeObjectForKey:CPObjectControllerObjectClassNameKey],
-            objectClass = CPClassFromString(objectClassName);
+            objectClass = CPClassFromString(objectClassName),
+            content = [aCoder decodeObjectForKey:CPObjectControllerContentKey];
 
         [self setObjectClass:objectClass || [CPMutableDictionary class]];
         [self setEditable:[aCoder decodeBoolForKey:CPObjectControllerIsEditableKey]];
         [self setAutomaticallyPreparesContent:[aCoder decodeBoolForKey:CPObjectControllerAutomaticallyPreparesContentKey]];
-        [self setContent:[aCoder decodeObjectForKey:CPObjectControllerContentKey]];
+        [self setUsesLazyFetching:[aCoder decodeBoolForKey:CPObjectControllerUsesLazyFetchingKey]];
+        _isUsingManagedProxy = [aCoder decodeBoolForKey:CPObjectControllerIsUsingManagedProxyKey];
+        _managedProxy = [aCoder decodeObjectForKey:CPObjectControllerManagedProxyKey];
+        if (content != nil)
+            [self setContent:content];
 
         _observedKeys = [[CPCountedSet alloc] init];
     }
@@ -398,6 +453,10 @@ var CPObjectControllerContentKey                        = @"CPObjectControllerCo
 
     [aCoder encodeBool:[self isEditable] forKey:CPObjectControllerIsEditableKey];
     [aCoder encodeBool:[self automaticallyPreparesContent] forKey:CPObjectControllerAutomaticallyPreparesContentKey];
+    [aCoder encodeBool:[self usesLazyFetching] forKey:CPObjectControllerUsesLazyFetchingKey];
+    [aCoder encodeBool:_isUsingManagedProxy forKey:CPObjectControllerIsUsingManagedProxyKey];
+    if (_managedProxy)
+        [aCoder encodeObject:_managedProxy forKey:CPObjectControllerManagedProxyKey];
 }
 
 - (void)awakeFromCib
@@ -822,6 +881,41 @@ var CPObjectControllerContentKey                        = @"CPObjectControllerCo
             stop(YES);
         }
     }];
+}
+
+@end
+
+
+@implementation _CPManagedProxy : CPObject
+{
+    CPString    _entityName @accessors(getter=entityName, setter=setEntityName:);
+    CPPredicate _fetchPredicate @accessors(getter=fetchPredicate, setter=setFetchPredicate:);
+}
+
+@end
+
+var CPManagedProxyEntityNameKey                         = @"CPManagedProxyEntityNameKey",
+    CPManagedProxyFetchPredicateKey                     = @"CPManagedProxyFetchPredicateKey";
+
+@implementation _CPManagedProxy (CPCoding)
+
+- (id)initWithCoder:(CPCoder)aCoder
+{
+    self = [super init];
+
+    if (self)
+    {
+        [self setEntityName:[aCoder decodeObjectForKey:CPManagedProxyEntityNameKey]];
+        [self setFetchPredicate:[aCoder decodeObjectForKey:CPManagedProxyFetchPredicateKey]];
+    }
+
+    return self;
+}
+
+- (void)encodeWithCoder:(CPCoder)aCoder
+{
+    [aCoder encodeObject:[self entityName] forKey:CPManagedProxyEntityNameKey];
+    [aCoder encodeObject:[self fetchPredicate] forKey:CPManagedProxyFetchPredicateKey];
 }
 
 @end

--- a/AppKit/CPObjectController.j
+++ b/AppKit/CPObjectController.j
@@ -433,6 +433,7 @@ var CPObjectControllerContentKey                        = @"CPObjectControllerCo
         [self setUsesLazyFetching:[aCoder decodeBoolForKey:CPObjectControllerUsesLazyFetchingKey]];
         _isUsingManagedProxy = [aCoder decodeBoolForKey:CPObjectControllerIsUsingManagedProxyKey];
         _managedProxy = [aCoder decodeObjectForKey:CPObjectControllerManagedProxyKey];
+
         if (content != nil)
             [self setContent:content];
 
@@ -455,6 +456,7 @@ var CPObjectControllerContentKey                        = @"CPObjectControllerCo
     [aCoder encodeBool:[self automaticallyPreparesContent] forKey:CPObjectControllerAutomaticallyPreparesContentKey];
     [aCoder encodeBool:[self usesLazyFetching] forKey:CPObjectControllerUsesLazyFetchingKey];
     [aCoder encodeBool:_isUsingManagedProxy forKey:CPObjectControllerIsUsingManagedProxyKey];
+
     if (_managedProxy)
         [aCoder encodeObject:_managedProxy forKey:CPObjectControllerManagedProxyKey];
 }

--- a/Tools/nib2cib/NSObjectController.j
+++ b/Tools/nib2cib/NSObjectController.j
@@ -43,6 +43,9 @@
 
         _isEditable = [aCoder decodeBoolForKey:@"NSEditable"];
         _automaticallyPreparesContent = [aCoder decodeBoolForKey:@"NSAutomaticallyPreparesContent"];
+        _usesLazyFetching = [aCoder decodeBoolForKey:@"_NSUsesLazyFetching"];
+        _isUsingManagedProxy = [aCoder decodeBoolForKey:@"_NSIsUsingManagedProxy"];
+        _managedProxy = [aCoder decodeObjectForKey:@"_NSManagedProxy"];
     }
 
     return self;
@@ -62,6 +65,40 @@
 - (Class)classForKeyedArchiver
 {
     return [CPObjectController class];
+}
+
+@end
+
+
+@implementation _CPManagedProxy (NSCoding)
+
+- (id)NS_initWithCoder:(CPCoder)aCoder
+{
+    self = [super init];
+
+    if (self)
+    {
+        _entityName = [aCoder decodeObjectForKey:@"NSEntityName"];
+        _fetchPredicate = [aCoder decodeObjectForKey:@"NSFetchPredicate"];
+    }
+
+    return self;
+}
+
+@end
+
+@implementation _NSManagedProxy : _CPManagedProxy
+{
+}
+
+- (id)initWithCoder:(CPCoder)aCoder
+{
+    return [self NS_initWithCoder:aCoder];
+}
+
+- (Class)classForKeyedArchiver
+{
+    return [_CPManagedProxy class];
 }
 
 @end


### PR DESCRIPTION
This pull request reads more attributes from the xib/cib file. The attributes are entity name and uses lazy fetching.