### PR TITLE
Does not throw exception if plist is not valid. It will return nil instead

### DIFF
--- a/Foundation/CPKeyedUnarchiver.j
+++ b/Foundation/CPKeyedUnarchiver.j
@@ -332,7 +332,7 @@ var CPArrayClass                                                            = Ni
 */
 - (id)decodeObjectForKey:(CPString)aKey
 {
-    var object = _plistObject.valueForKey(aKey),
+    var object = _plistObject && _plistObject.valueForKey(aKey),
         objectClass = (object != nil) && object.isa;
 
     if (objectClass === CPDictionaryClass || objectClass === CPMutableDictionaryClass)


### PR DESCRIPTION
If parsing of a plist is invalid it will return nil instead of throwing an 'undefined is not an object' exception