### PR TITLE
Fixed: //@ sourceURL=... is deprecated since many years ago.

### DIFF
--- a/Objective-J/Executable.js
+++ b/Objective-J/Executable.js
@@ -209,16 +209,16 @@ Executable.prototype.setCode = function(code)
     {
 #endif
 #if DEBUG
-    // "//@ sourceURL=" at the end lets us name our eval'd files for debuggers, etc.
+    // "//# sourceURL=" at the end lets us name our eval'd files for debuggers, etc.
     // * WebKit:  http://pmuellr.blogspot.com/2009/06/debugger-friendly.html
     // * Firebug: http://blog.getfirebug.com/2009/08/11/give-your-eval-a-name-with-sourceurl/
     //if (YES) {
         var absoluteString = this.URL().absoluteString();
 
-        code += "/**/\n//@ sourceURL=" + absoluteString;
+        code += "/**/\n//# sourceURL=" + absoluteString;
     //} else {
     //    // Firebug only does it for "eval()", not "new Function()". Ugh. Slower.
-    //    var functionText = "(function(){"+GET_CODE(aFragment)+"/**/\n})\n//@ sourceURL="+GET_FILE(aFragment).path;
+    //    var functionText = "(function(){"+GET_CODE(aFragment)+"/**/\n})\n//# sourceURL="+GET_FILE(aFragment).path;
     //    compiled = eval(functionText);
     //}
 #endif


### PR DESCRIPTION
We have not changed it for support of older browsers.
Chrome version 51 and above writes a warning about it
in the console so it is time now.