### PR TITLE
Fixed: Added ’integerValue’ method for CPNumber and CPString.

### DIFF
--- a/Foundation/CPNumber.j
+++ b/Foundation/CPNumber.j
@@ -256,6 +256,13 @@ FIXME: Do we need this?
     return self;
 }
 
+- (int)integerValue
+{
+    if (typeof self == "boolean")
+        return self ? 1 : 0;
+    return self;
+}
+
 - (long long)longLongValue
 {
     if (typeof self == "boolean")

--- a/Foundation/CPNumber.j
+++ b/Foundation/CPNumber.j
@@ -239,6 +239,7 @@ FIXME: Do we need this?
 {
     if (typeof self == "boolean")
         return self ? 1 : 0;
+
     return self;
 }
 
@@ -246,6 +247,7 @@ FIXME: Do we need this?
 {
     if (typeof self == "boolean")
         return self ? 1 : 0;
+
     return self;
 }
 
@@ -253,6 +255,7 @@ FIXME: Do we need this?
 {
     if (typeof self == "boolean")
         return self ? 1 : 0;
+
     return self;
 }
 
@@ -260,6 +263,7 @@ FIXME: Do we need this?
 {
     if (typeof self == "boolean")
         return self ? 1 : 0;
+
     return self;
 }
 
@@ -267,6 +271,7 @@ FIXME: Do we need this?
 {
     if (typeof self == "boolean")
         return self ? 1 : 0;
+
     return self;
 }
 
@@ -274,6 +279,7 @@ FIXME: Do we need this?
 {
     if (typeof self == "boolean")
         return self ? 1 : 0;
+
     return self;
 }
 
@@ -281,6 +287,7 @@ FIXME: Do we need this?
 {
     if (typeof self == "boolean")
         return self ? 1 : 0;
+
     return self;
 }
 
@@ -298,6 +305,7 @@ FIXME: Do we need this?
 {
     if (typeof self == "boolean")
         return self ? 1 : 0;
+
     return self;
 }
 /*
@@ -311,6 +319,7 @@ FIXME: Do we need this?
 {
     if (typeof self == "boolean")
         return self ? 1 : 0;
+
     return self;
 }
 
@@ -318,6 +327,7 @@ FIXME: Do we need this?
 {
     if (typeof self == "boolean")
         return self ? 1 : 0;
+
     return self;
 }
 

--- a/Foundation/CPString.j
+++ b/Foundation/CPString.j
@@ -732,6 +732,14 @@ var CPStringNull = [CPNull null];
 }
 
 /*!
+    Returns the text as an integer
+*/
+- (int)integerValue
+{
+    return parseInt(self, 10);
+}
+
+/*!
     Returns an the path components of this string. This
     method assumes that the string's content is a '/'
     separated file system path.

--- a/Tests/Foundation/CPNumberTest.j
+++ b/Tests/Foundation/CPNumberTest.j
@@ -12,4 +12,23 @@
     [self assertThrows:function () { [34 compare:[CPNull null]] }];
 }
 
+- (void)testintValue
+{
+    var testStrings = [
+            [090,   90],
+            [-1,    -1],
+            [3.1415, 3],
+            [2.7183, 2],
+            [-0,     0],
+            [00,     0],
+            [-00,    0],
+            [+001,   1],
+        ];
+
+    for (var i = 0; i < testStrings.length; i++)
+        [self assert:[testStrings[i][0] intValue] equals:testStrings[i][1]];
+    for (var i = 0; i < testStrings.length; i++)
+        [self assert:[testStrings[i][0] integerValue] equals:testStrings[i][1]];
+}
+
 @end

--- a/Tests/Foundation/CPNumberTest.j
+++ b/Tests/Foundation/CPNumberTest.j
@@ -15,7 +15,7 @@
 - (void)testintValue
 {
     var testStrings = [
-            [090,   90],
+//            [090,   90],   // Removed cause Rhino does not support numbers starting with '0'
             [-1,    -1],
             [3.1415, 3],
             [2.7183, 2],

--- a/Tests/Foundation/CPStringTest.j
+++ b/Tests/Foundation/CPStringTest.j
@@ -165,6 +165,25 @@
         [self assert:[testStrings[i][0] boolValue] equals:testStrings[i][1]];
 }
 
+- (void)testintValue
+{
+    var testStrings = [
+            ["  090",   90],
+            ["  -1",    -1],
+            ["  3.1415", 3],
+            ["  2.7183", 2],
+            ["  -0",     0],
+            ["  00",     0],
+            ["  -00",    0],
+            ["  +001",   1],
+        ];
+
+    for (var i = 0; i < testStrings.length; i++)
+        [self assert:[testStrings[i][0] intValue] equals:testStrings[i][1]];
+    for (var i = 0; i < testStrings.length; i++)
+        [self assert:[testStrings[i][0] integerValue] equals:testStrings[i][1]];
+}
+
 - (void)testCommonPrefixWithString
 {
     var testStringsCase = [


### PR DESCRIPTION
This makes the classes more compliant to Cocoa