### PR TITLE
FIXED: Cursor key binding methods do not fire in IE11 #2365

### DIFF
--- a/AppKit/CPCompatibility.j
+++ b/AppKit/CPCompatibility.j
@@ -116,7 +116,7 @@ if (typeof window !== "undefined" && window.opera)
 }
 
 // Internet Explorer
-else if (typeof window !== "undefined" && window.attachEvent) // Must follow Opera check.
+else if (typeof window !== "undefined" && (window.attachEvent || (!(window.ActiveXObject) && "ActiveXObject" in window))) // Must follow Opera check.
 {
     PLATFORM_ENGINE = CPInternetExplorerBrowserEngine;
 


### PR DESCRIPTION
Fix for issue: https://github.com/cappuccino/cappuccino/issues/2365