### PR TITLE
Fixed: crash when having a CPTableViewHeader without a CPTableView

### DIFF
--- a/AppKit/CPTableHeaderView.j
+++ b/AppKit/CPTableHeaderView.j
@@ -466,9 +466,12 @@ var CPTableHeaderViewResizeZone = 3.0,
 - (void)updateTrackingAreas
 {
     [self removeAllTrackingAreas];
-    
+
     var options = CPTrackingCursorUpdate | CPTrackingActiveInKeyWindow;
-    
+
+    if (!_tableView)
+      return;
+
     for (var i = 0; i < _tableView._tableColumns.length; i++)
         [self addTrackingArea:[[CPTrackingArea alloc] initWithRect:[self _cursorRectForColumn:i]
                                                            options:options


### PR DESCRIPTION
Previously, when having a CPTableViewHeader without a CPTableView, cappuccino just crashed.
We now check if _tableView is set before iterating on the tableview's columns.