### PR TITLE
Fixed: Setting entity name from code does not work

### DIFF
--- a/AppKit/CPObjectController.j
+++ b/AppKit/CPObjectController.j
@@ -192,6 +192,12 @@
 */
 - (void)setEntityName:(CPString)newEntityName
 {
+    if (!_managedProxy)
+    {
+        _managedProxy = [[_CPManagedProxy alloc] init];
+        _isUsingManagedProxy = YES;
+    }
+
     [_managedProxy setEntityName:newEntityName];
 }
 


### PR DESCRIPTION
When setting entity name from code the ```_managedProxy``` will be null and the name will not be stored