### PR TITLE
Fixed: date comparisons in CPPredicateEditor

### DIFF
--- a/AppKit/CPRuleEditor/CPPredicateEditorRowTemplate.j
+++ b/AppKit/CPRuleEditor/CPPredicateEditorRowTemplate.j
@@ -474,6 +474,8 @@ CPTransformableAttributeType = 1800;
         value = [aView intValue];
     else if (attributeType == CPBooleanAttributeType)
         value = [aView state];
+    else if (attributeType == CPDateAttributeType)
+        value = [aView dateValue];
     else
         value = [aView stringValue];
 


### PR DESCRIPTION
CPPredicateEditorRowTemplate has been modified to allow a correct comparision of date objects when using the CPDateAttributeType
Before this correction, the predicate format was using a string representation of a date instead of a date object.