### PR TITLE
enable autoscrolling for tableview columns

### DIFF
--- a/AppKit/CPTableHeaderView.j
+++ b/AppKit/CPTableHeaderView.j
@@ -414,8 +414,7 @@ var CPTableHeaderViewResizeZone = 3.0,
     }
     else if (_isDragging)
     {
-        // Disable autoscrolling until it behaves correctly.
-        //[self _autoscroll:theEvent localLocation:currentLocation];
+        [self _autoscroll:theEvent localLocation:currentLocation];
         [self _dragTableColumn:_activeColumn to:currentLocation];
     }
     else // tracking a press, could become a drag


### PR DESCRIPTION
previously, autoscrolling was turned off when dragging a tableview column.

this PR activates autoscrolling that had been deliberately blocked in the past.

you can verify that autoscrolling during column-dragging works in manual test TableTest/ColumnResize
(make the browser window narrow enough)

fixes #2421