### PR TITLE
Fixed: CPColorPanel always opens in main platform window.

### DIFF
--- a/AppKit/CPColorWell.j
+++ b/AppKit/CPColorWell.j
@@ -255,6 +255,8 @@ var _CPColorWellDidBecomeExclusiveNotification = @"_CPColorWellDidBecomeExclusiv
 
     var colorPanel = [CPColorPanel sharedColorPanel];
 
+    [colorPanel setPlatformWindow:[[self window] platformWindow]];
+
     [colorPanel setColor:_color];
     [colorPanel orderFront:self];
 }


### PR DESCRIPTION
When using a CPColorWell on a platform window other than the main platform window, the CPColorPanel was always opened on the main platform window.

This PR forces the CPColorWell to set the platform window of the CPColorPanel to its own platform window.

fixes #2387