### PR TITLE
Fixed: right mouse clic during a drag operation cancels it

### DIFF
--- a/AppKit/Platform/CPPlatformWindow.j
+++ b/AppKit/Platform/CPPlatformWindow.j
@@ -60,6 +60,7 @@ var PrimaryPlatformWindow   = NULL;
 
     BOOL                    _mouseIsDown;
     BOOL                    _mouseDownIsRightClick;
+    int                     _firstMouseDownButton;
     CGPoint                 _lastMouseEventLocation;
     CPWindow                _mouseDownWindow;
     CPTimeInterval          _lastMouseUp;

--- a/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
@@ -1245,12 +1245,16 @@ _CPPlatformWindowWillCloseNotification = @"_CPPlatformWindowWillCloseNotificatio
     {
         if (_mouseIsDown)
         {
+            if (aDOMEvent.button !== _firstMouseDownButton)
+                return;
+
             event = _CPEventFromNativeMouseEvent(aDOMEvent, _mouseDownIsRightClick ? CPRightMouseUp : CPLeftMouseUp, location, modifierFlags, timestamp, windowNumber, nil, -1, CPDOMEventGetClickCount(_lastMouseUp, timestamp, location), 0, nil);
 
             _mouseIsDown = NO;
             _lastMouseUp = event;
             _mouseDownWindow = nil;
             _mouseDownIsRightClick = NO;
+            _firstMouseDownButton = -1;
         }
 
         if (_DOMEventMode)
@@ -1269,6 +1273,16 @@ _CPPlatformWindowWillCloseNotification = @"_CPPlatformWindowWillCloseNotificatio
         var button = aDOMEvent.button;
 
         _mouseDownIsRightClick = button == 2 || (CPBrowserIsOperatingSystem(CPMacOperatingSystem) && button == 0 && modifierFlags & CPControlKeyMask);
+
+        // If mouse is already down, that means that a second mouse button is pushed. This could interfere in mouse events treatment. Just ignore it.
+        // BUT we have to track which button will be first released.
+        if (_mouseIsDown)
+        {
+            _mouseDownIsRightClick = !_mouseDownIsRightClick;
+            return;
+        }
+
+        _firstMouseDownButton = button;
 
         if ((sourceElement.tagName === "INPUT" || sourceElement.tagName === "TEXTAREA") && sourceElement != _DOMFocusElement)
         {


### PR DESCRIPTION
While dragging a window or a custom view, if the user also pushes on the right mouse button (by mistake), the drag operation is stopped (without any notification to the application).

This PR modifies the DOM event processing so that the behavior is now compatible with the Cocoa way.

fixes #2378