### PR TITLE
Fixed: brightness_bar.png was not displayed in CPColorPicker

### DIFF
--- a/AppKit/CPColorPicker.j
+++ b/AppKit/CPColorPicker.j
@@ -106,6 +106,7 @@
     CPView          _pickerView;
     CPView          _brightnessSlider;
     __CPColorWheel  _hueSaturationView;
+    DOMElement      _brightnessSliderImage;
 
     CPColor         _cachedColor;
 }
@@ -125,8 +126,6 @@
     _brightnessSlider = [[CPSlider alloc] initWithFrame:CGRectMake(0, (aFrame.size.height - 34), aFrame.size.width, 15)];
 
     [_brightnessSlider setValue:15.0 forThemeAttribute:@"track-width"];
-    [_brightnessSlider setValue:[CPColor colorWithPatternImage:[[CPImage alloc] initWithContentsOfFile:[[CPBundle bundleForClass:[CPColorPicker class]] pathForResource:@"brightness_bar.png"]]] forThemeAttribute:@"track-color"];
-
     [_brightnessSlider setMinValue:0.0];
     [_brightnessSlider setMaxValue:100.0];
     [_brightnessSlider setFloatValue:100.0];
@@ -141,6 +140,14 @@
 
     [_pickerView addSubview:_hueSaturationView];
     [_pickerView addSubview:_brightnessSlider];
+
+#if PLATFORM(DOM)
+    _brightnessSliderImage = new Image();
+    _brightnessSliderImage.src = [[CPBundle bundleForClass:CPColorPicker] pathForResource:@"brightness_bar.png"];
+    _brightnessSlider._DOMElement.appendChild(_brightnessSliderImage);
+    _brightnessSliderImage.style.width = (_brightnessSlider._frame.size.width - 16) + "px";
+    _brightnessSliderImage.style.height = "15px";
+#endif
 }
 
 - (void)brightnessSliderDidChange:(id)sender

--- a/AppKit/CPColorPicker.j
+++ b/AppKit/CPColorPicker.j
@@ -106,7 +106,6 @@
     CPView          _pickerView;
     CPView          _brightnessSlider;
     __CPColorWheel  _hueSaturationView;
-    DOMElement      _brightnessSliderImage;
 
     CPColor         _cachedColor;
 }
@@ -142,7 +141,7 @@
     [_pickerView addSubview:_brightnessSlider];
 
 #if PLATFORM(DOM)
-    _brightnessSliderImage = new Image();
+    var _brightnessSliderImage = new Image();
     _brightnessSliderImage.src = [[CPBundle bundleForClass:CPColorPicker] pathForResource:@"brightness_bar.png"];
     _brightnessSlider._DOMElement.appendChild(_brightnessSliderImage);
     _brightnessSliderImage.style.width = (_brightnessSlider._frame.size.width - 16) + "px";


### PR DESCRIPTION
Previously, the background of the brightness slider had a uniform color.
With this PR, there is a nice gradient from black to the selected color like in cocoa.
See screenshot.
![bildschirmfoto 2016-05-25 um 13 54 19](https://cloud.githubusercontent.com/assets/146335/15539179/4dec0c42-2281-11e6-9e13-1f42d2adc2d7.PNG)

fixes #2388 