### PR TITLE
fixed: cappuccino pasteboad is always clobbered by system pasteboard

### DIFF
--- a/AppKit/Platform/DOM/CPPlatformPasteboard.j
+++ b/AppKit/Platform/DOM/CPPlatformPasteboard.j
@@ -450,9 +450,10 @@ Return true if the event may be a copy and paste event, but the target is not an
 
     if ([value length])
     {
-        var pasteboard = [CPPasteboard generalPasteboard];
+        var pasteboard = [CPPasteboard generalPasteboard],
+            cappString = [pasteboard stringForType:CPStringPboardType];
 
-        if ([pasteboard _stateUID] != value)
+        if (cappString !== value)
         {
             [pasteboard declareTypes:[CPStringPboardType] owner:self];
             [pasteboard setString:value forType:CPStringPboardType];

--- a/AppKit/Platform/DOM/CPPlatformPasteboard.j
+++ b/AppKit/Platform/DOM/CPPlatformPasteboard.j
@@ -384,9 +384,10 @@ Return true if the event may be a copy and paste event, but the target is not an
 
     if ([value length])
     {
-        var pasteboard = [CPPasteboard generalPasteboard];
+        var pasteboard = [CPPasteboard generalPasteboard],
+            cappString = [pasteboard stringForType:CPStringPboardType];
 
-        if ([pasteboard _stateUID] != value)
+        if (cappString !== value)
         {
             [pasteboard declareTypes:[CPStringPboardType] owner:self];
             [pasteboard setString:value forType:CPStringPboardType];

--- a/AppKit/Platform/DOM/CPPlatformPasteboard.j
+++ b/AppKit/Platform/DOM/CPPlatformPasteboard.j
@@ -387,7 +387,7 @@ Return true if the event may be a copy and paste event, but the target is not an
         var pasteboard = [CPPasteboard generalPasteboard],
             cappString = [pasteboard stringForType:CPStringPboardType];
 
-        if (cappString !== value)
+        if (cappString != value)
         {
             [pasteboard declareTypes:[CPStringPboardType] owner:self];
             [pasteboard setString:value forType:CPStringPboardType];
@@ -454,7 +454,7 @@ Return true if the event may be a copy and paste event, but the target is not an
         var pasteboard = [CPPasteboard generalPasteboard],
             cappString = [pasteboard stringForType:CPStringPboardType];
 
-        if (cappString !== value)
+        if (cappString != value)
         {
             [pasteboard declareTypes:[CPStringPboardType] owner:self];
             [pasteboard setString:value forType:CPStringPboardType];


### PR DESCRIPTION
previously, every native nativePasteEvent: compared the pasted content to [pasteboard _stateUID], which is always undefined in the current implementation of CPPasteboard. This resulted in a call to pasteboard declareTypes:[CPStringPboardType] owner:self, effectively removing all other representations during each paste.

This PR makes capp to only call [CPStringPboardType] owner:self if the system and capp CPStringPboardType actually differ. This makes the system and capp pasteboards cooperate. This is a prerequisite for proper copy/paste support of the new text system.

Fixes #2062 and
https://github.com/daboe01/CPTextView/issues/109