### PR TITLE
fixed: scrolling events are missed on slower maschines in chrome 52

### DIFF
--- a/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
@@ -952,8 +952,8 @@ _CPPlatformWindowWillCloseNotification = @"_CPPlatformWindowWillCloseNotificatio
                                   timestamp:timestamp windowNumber:windowNumber context:nil eventNumber:-1 clickCount:1 pressure:0];
     event._DOMEvent = aDOMEvent;
 
-    // We lag 1 event behind without this timeout.
-    setTimeout(function()
+    // We lag 1 event behind without this approach
+    window.requestAnimationFrame(function()
     {
         if (aDOMEvent.deltaMode !== undefined && aDOMEvent.deltaMode !== 0)
         {
@@ -992,10 +992,10 @@ _CPPlatformWindowWillCloseNotification = @"_CPPlatformWindowWillCloseNotificatio
         _DOMScrollingElement.scrollLeft = 150;
         _DOMScrollingElement.scrollTop = 150;
 
-        // Is this needed?
-        //[[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
+        // this is needed to prevent flickering during scrolling
+        [[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
 
-    }, 0);
+    });
 
     // We hide the dom element after a little bit
     // so that other DOM elements such as inputs


### PR DESCRIPTION
Previously, the scrolling events were generated in a setTimeout with a delay of 0ms.
These were not reliably executed in recent chrome versions which caused freezes during scrolling with momentum on older systems such as a MBP late 2011.
This PR replaces the setTimeout with requestAnimationFrame and uncomments the limitDateForMode:CPDefaultRunLoopMode to enforce the visual updates.
Tested on FF, Safari and of course chrome.
Fixes #2468
