### PR TITLE
nib2cib: discard warnings in the nib file.

### DIFF
--- a/Tools/nib2cib/NSIBObjectData.j
+++ b/Tools/nib2cib/NSIBObjectData.j
@@ -50,7 +50,12 @@
         _classesKeys = [aCoder decodeObjectForKey:@"NSClassesKeys"];
         _classesValues = [aCoder decodeObjectForKey:@"NSClassesValues"];
 
-        _connections = [aCoder decodeObjectForKey:@"NSConnections"];
+        var connections = [aCoder decodeObjectForKey:@"NSConnections"];
+        // Filter out connections with invalid destinations.
+        _connections = [connections filteredArrayUsingBlock:function(conn, idx, stop)
+        {
+            return [conn destination] !== nil;
+        }];
 
         //_fontManager = [aCoder decodeObjectForKey:@"NSFontManager"] retain];
         _framework = [aCoder decodeObjectForKey:@"NSFramework"];

--- a/Tools/nib2cib/NSNibConnector.j
+++ b/Tools/nib2cib/NSNibConnector.j
@@ -42,6 +42,9 @@ NIB_CONNECTION_EQUIVALENCY_TABLE = {};
         _destination = [aCoder decodeObjectForKey:@"NSDestination"];
         _label = [aCoder decodeObjectForKey:@"NSLabel"];
 
+        if (_destination == nil)
+            CPLog.warn(_label);
+
         var sourceUID = [_source UID],
             destinationUID = [_destination UID];
 


### PR DESCRIPTION
ibtool optionally generates warnings in the nib file that are wrapped into a connection. Now we print the warning when nib2cibing but ignore this entry when converting to cib.