### PR TITLE
Fixed: CPTabView should not allow empty selection

### DIFF
--- a/AppKit/CPTabView.j
+++ b/AppKit/CPTabView.j
@@ -136,6 +136,8 @@ var CPTabViewDidSelectTabViewItemSelector           = 1 << 1,
 
 - (void)_insertTabViewItems:(CPArray)tabViewItems atIndexes:(CPIndexSet)indexes
 {
+    var prevItemsCount = [self numberOfTabViewItems];
+
     [_tabs insertSegments:tabViewItems atIndexes:indexes];
     [tabViewItems makeObjectsPerformSelector:@selector(_setTabView:) withObject:self];
 
@@ -143,6 +145,10 @@ var CPTabViewDidSelectTabViewItemSelector           = 1 << 1,
     [self _reverseSetContent];
 
     [self _sendDelegateTabViewDidChangeNumberOfTabViewItems];
+
+    // Do not allow empty selection if selection bindings are not enabled.
+    if (prevItemsCount == 0 && [self numberOfTabViewItems] > 0 && ![self _isSelectionBinded])
+        [self _selectTabViewItemAtIndex:0];
 }
 
 /*!
@@ -169,7 +175,7 @@ var CPTabViewDidSelectTabViewItemSelector           = 1 << 1,
 - (void)_didRemoveTabViewItem:(CPTabViewItem)aTabViewItem atIndex:(CPInteger)idx
 {
     // If the selection is managed by bindings, let the binder do that.
-    if ([self binderForBinding:CPSelectionIndexesBinding] || [self binderForBinding:CPSelectedIndexBinding])
+    if ([self _isSelectionBinded])
         return;
 
     if (_selectedTabViewItem == aTabViewItem)
@@ -613,6 +619,11 @@ var CPTabViewDidSelectTabViewItemSelector           = 1 << 1,
 {
     var cls = [[self class] _binderClassForBinding:aBinding]
     return [cls getBinding:aBinding forObject:self];
+}
+
+- (BOOL)_isSelectionBinded
+{
+    return [self binderForBinding:CPSelectionIndexesBinding] || [self binderForBinding:CPSelectedIndexBinding];
 }
 
 - (void)setItems:(CPArray)tabViewItems

--- a/Tests/AppKit/CPTabViewTest.j
+++ b/Tests/AppKit/CPTabViewTest.j
@@ -138,4 +138,16 @@
     [self assert:[_tabView selectedTabViewItem] equals:_tabItem2];
 }
 
+- (void)testTabViewItemSelectionNotEmpty
+{
+    // after insertion from empty and no explicit selection.
+    [self assert:[_tabView numberOfTabViewItems] equals:2];
+    [self assert:[_tabView selectedTabViewItem] equals:_tabItem1];
+
+    // Removes selected Item.
+    [_tabView removeTabViewItem:_tabItem1];
+    [self assert:[_tabView numberOfTabViewItems] equals:1];
+    [self assert:[_tabView selectedTabViewItem] equals:_tabItem2];
+}
+
 @end


### PR DESCRIPTION
Before this commit, a tab view could have an empty selection with the
following circumstances:
- The tab view was not created in IB
- the Tab View selection had not binding management

With test.