### PR TITLE
Fix RegEx for gcc > 4.9

### DIFF
--- a/AppKit/CPTextView/CPTextView.j
+++ b/AppKit/CPTextView/CPTextView.j
@@ -1853,13 +1853,13 @@ var kDelegateRespondsTo_textShouldBeginEditing                                  
 
 + (JSObject)_paragraphBoundaryRegex
 {
-    return new RegExp(/^.[^\n\r]/m);
+    return new RegExp("^.[^\\n\\r]", "m");
 }
 
 + (JSObject)_whitespaceRegex
 {
     // do not include \n here or we will get cross paragraph selections
-    return new RegExp(/^.[ \t]+/m);
+    return new RegExp("^.[ \\t]+", "m");
 }
 
 - (CPRange)_characterRangeForIndex:(unsigned)index asDefinedByRegex:(JSObject)regex

--- a/AppKit/CPTextView/CPTextView.j
+++ b/AppKit/CPTextView/CPTextView.j
@@ -1848,18 +1848,18 @@ var kDelegateRespondsTo_textShouldBeginEditing                                  
 
 + (JSObject)_wordBoundaryRegex
 {
-    return /(^[0-9][\.,])|(^.[^-\.,+#'"!§$%&/\(<\[\]>\)=?`´*\s{}\|¶])/m;
+    return new RegExp("/(^[0-9][\.,])|(^.[^-\.,+#'\"!§$%&/\(<\[\]>\)=?`´*\s{}\|¶])/m");
 }
 
 + (JSObject)_paragraphBoundaryRegex
 {
-    return /^.[^\n\r]/m;
+    return new RegExp("/^.[^\n\r]/m");
 }
 
 + (JSObject)_whitespaceRegex
 {
     // do not include \n here or we will get cross paragraph selections
-    return /^.[ \t]+/m;
+    return new RegExp("/^.[ \t]+/m");
 }
 
 - (CPRange)_characterRangeForIndex:(unsigned)index asDefinedByRegex:(JSObject)regex

--- a/AppKit/CPTextView/CPTextView.j
+++ b/AppKit/CPTextView/CPTextView.j
@@ -1848,18 +1848,18 @@ var kDelegateRespondsTo_textShouldBeginEditing                                  
 
 + (JSObject)_wordBoundaryRegex
 {
-    return new RegExp("/(^[0-9][\.,])|(^.[^-\.,+#'\"!§$%&/\(<\[\]>\)=?`´*\s{}\|¶])/m");
+    return new RegExp("(^[0-9][\\.,])|(^.[^-\\.,+#'\\\"!§$%&/\\(<\\[\\]>\\)=?`´*\\s{}\\|¶])", "m");
 }
 
 + (JSObject)_paragraphBoundaryRegex
 {
-    return new RegExp("/^.[^\n\r]/m");
+    return new RegExp(/^.[^\n\r]/m);
 }
 
 + (JSObject)_whitespaceRegex
 {
     // do not include \n here or we will get cross paragraph selections
-    return new RegExp("/^.[ \t]+/m");
+    return new RegExp(/^.[ \t]+/m);
 }
 
 - (CPRange)_characterRangeForIndex:(unsigned)index asDefinedByRegex:(JSObject)regex

--- a/AppKit/CPTextView/CPTextView.j
+++ b/AppKit/CPTextView/CPTextView.j
@@ -1848,7 +1848,7 @@ var kDelegateRespondsTo_textShouldBeginEditing                                  
 
 + (JSObject)_wordBoundaryRegex
 {
-    return new RegExp("(^[0-9][\\.,])|(^.[^-\\.,+#'\\\"!§$%&/\\(<\\[\\]>\\)=?`´*\\s{}\\|¶])", "m");
+    return new RegExp("(^[0-9][\\.,])|(^.[^-\\.,+#'\"!§$%&/\\(<\\[\\]>\\)=?`´*\\s{}\\|¶])", "m");
 }
 
 + (JSObject)_paragraphBoundaryRegex

--- a/AppKit/CPTextView/_CPRTFParser.j
+++ b/AppKit/CPTextView/_CPRTFParser.j
@@ -350,7 +350,7 @@ var kRgsymRtf = {
 
             var hex = '';
 
-            while (new RegExp("/[a-fA-F0-9\']/").test(ch))
+            while (new RegExp("[a-fA-F0-9\\']").test(ch))
             {
                 if (ch == "'")
                 {
@@ -377,7 +377,7 @@ var kRgsymRtf = {
 
              var code = '';
 
-             while (new RegExp("/[0-9]/").test(ch))
+             while (new RegExp("[0-9]").test(ch))
              {
                  code += (ch + '');
                  ch = _rtf.charAt(++_currentParseIndex);
@@ -621,7 +621,7 @@ var kRgsymRtf = {
     if (!/[a-zA-Z]/.test(ch))
         return [self _translateKeyword:ch parameter:nil fParameter:fParam];
 
-    while (new RegExp("/[a-zA-Z]/").test(ch))
+    while (new RegExp("[a-zA-Z]").test(ch))
     {
         keyword += ch;
         ch = rtf.charAt(++_currentParseIndex);
@@ -635,7 +635,7 @@ var kRgsymRtf = {
 
     fParam = true;
 
-    while (new RegExp("/[0-9]/").test(ch))
+    while (new RegExp("[0-9]").test(ch))
     {
         param += (ch + '');
         ch = rtf.charAt(++_currentParseIndex);

--- a/AppKit/CPTextView/_CPRTFParser.j
+++ b/AppKit/CPTextView/_CPRTFParser.j
@@ -350,7 +350,7 @@ var kRgsymRtf = {
 
             var hex = '';
 
-            while (/[a-fA-F0-9\']/.test(ch))
+            while (new RegExp("/[a-fA-F0-9\']/").test(ch))
             {
                 if (ch == "'")
                 {
@@ -377,7 +377,7 @@ var kRgsymRtf = {
 
              var code = '';
 
-             while (/[0-9]/.test(ch))
+             while (new RegExp("/[0-9]/").test(ch))
              {
                  code += (ch + '');
                  ch = _rtf.charAt(++_currentParseIndex);
@@ -621,7 +621,7 @@ var kRgsymRtf = {
     if (!/[a-zA-Z]/.test(ch))
         return [self _translateKeyword:ch parameter:nil fParameter:fParam];
 
-    while (/[a-zA-Z]/.test(ch))
+    while (new RegExp("/[a-zA-Z]/").test(ch))
     {
         keyword += ch;
         ch = rtf.charAt(++_currentParseIndex);
@@ -635,7 +635,7 @@ var kRgsymRtf = {
 
     fParam = true;
 
-    while (/[0-9]/.test(ch))
+    while (new RegExp("/[0-9]/").test(ch))
     {
         param += (ch + '');
         ch = rtf.charAt(++_currentParseIndex);

--- a/Foundation/CPDate.j
+++ b/Foundation/CPDate.j
@@ -115,7 +115,7 @@ var CPDateReferenceDate = new Date(Date.UTC(2001, 0, 1, 0, 0, 0, 0));
 */
 - (id)initWithString:(CPString)description
 {
-    var format = /(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2}) ([-+])(\d{2})(\d{2})/,
+    var format = new RegExp("/(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2}) ([-+])(\d{2})(\d{2})/"),
         d = description.match(new RegExp(format));
 
     if (!d || d.length != 10)
@@ -262,7 +262,7 @@ Date.parseISO8601 = function (date)
     // First, check for native parsing.
     timestamp = Date.parse(date);
 
-    if (isNaN(timestamp) && (struct = /^(\d{4}|[+\-]\d{6})(?:-(\d{2})(?:-(\d{2}))?)?(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{3}))?)?(?:(Z)|([+\-])(\d{2})(?::(\d{2}))?)?)?$/.exec(date)))
+    if (isNaN(timestamp) && (struct = new RegExp("/^(\d{4}|[+\-]\d{6})(?:-(\d{2})(?:-(\d{2}))?)?(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{3}))?)?(?:(Z)|([+\-])(\d{2})(?::(\d{2}))?)?)?$/").exec(date)))
     {
         // avoid NaN timestamps caused by "undefined" values being passed to Date.UTC
         for (var i = 0, k; (k = numericKeys[i]); ++i)

--- a/Foundation/CPDate.j
+++ b/Foundation/CPDate.j
@@ -115,7 +115,7 @@ var CPDateReferenceDate = new Date(Date.UTC(2001, 0, 1, 0, 0, 0, 0));
 */
 - (id)initWithString:(CPString)description
 {
-    var format = new RegExp("/(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2}) ([-+])(\d{2})(\d{2})/"),
+    var format = new RegExp("(\\d{4})-(\\d{2})-(\\d{2}) (\\d{2}):(\\d{2}):(\\d{2}) ([-+])(\\d{2})(\\d{2})"),
         d = description.match(new RegExp(format));
 
     if (!d || d.length != 10)
@@ -262,7 +262,7 @@ Date.parseISO8601 = function (date)
     // First, check for native parsing.
     timestamp = Date.parse(date);
 
-    if (isNaN(timestamp) && (struct = new RegExp("/^(\d{4}|[+\-]\d{6})(?:-(\d{2})(?:-(\d{2}))?)?(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{3}))?)?(?:(Z)|([+\-])(\d{2})(?::(\d{2}))?)?)?$/").exec(date)))
+    if (isNaN(timestamp) && (struct = new RegExp("^(\\d{4}|[+\\-]\\d{6})(?:-(\\d{2})(?:-(\\d{2}))?)?(?:T(\\d{2}):(\\d{2})(?::(\\d{2})(?:\\.(\\d{3}))?)?(?:(Z)|([+\\-])(\\d{2})(?::(\\d{2}))?)?)?$").exec(date)))
     {
         // avoid NaN timestamps caused by "undefined" values being passed to Date.UTC
         for (var i = 0, k; (k = numericKeys[i]); ++i)

--- a/Foundation/CPDateFormatter.j
+++ b/Foundation/CPDateFormatter.j
@@ -1931,7 +1931,7 @@ var defaultDateFormatterBehavior = CPDateFormatterBehavior10_4,
 */
 - (int)_secondsFromTimeZoneDefaultFormatString:(CPString)aTimeZoneFormatString
 {
-    var format = new RegExp("/\w*([HPG-GMT])?([+-])(\d{1,2})([:])?(\d{2})\w*/"),
+    var format = new RegExp("\\w*([HPG-GMT])?([+-])(\\d{1,2})([:])?(\\d{2})\\w*"),
         result = aTimeZoneFormatString.match(new RegExp(format)),
         seconds = 0;
 
@@ -1969,7 +1969,7 @@ var defaultDateFormatterBehavior = CPDateFormatterBehavior10_4,
     var character = [aToken characterAtIndex:0],
         length = [aToken length],
         targetedArray,
-        format = new RegExp("/\w*([HPG-GMT])?([+-])(\d{1,2})([:])?(\d{2})\w*/"),
+        format = new RegExp("\\w*([HPG-GMT])?([+-])(\\d{1,2})([:])?(\\d{2})\\w*"),
         result = aString.match(new RegExp(format));
 
     switch (character)

--- a/Foundation/CPDateFormatter.j
+++ b/Foundation/CPDateFormatter.j
@@ -1931,7 +1931,7 @@ var defaultDateFormatterBehavior = CPDateFormatterBehavior10_4,
 */
 - (int)_secondsFromTimeZoneDefaultFormatString:(CPString)aTimeZoneFormatString
 {
-    var format =  /\w*([HPG-GMT])?([+-])(\d{1,2})([:])?(\d{2})\w*/,
+    var format = new RegExp("/\w*([HPG-GMT])?([+-])(\d{1,2})([:])?(\d{2})\w*/"),
         result = aTimeZoneFormatString.match(new RegExp(format)),
         seconds = 0;
 
@@ -1969,7 +1969,7 @@ var defaultDateFormatterBehavior = CPDateFormatterBehavior10_4,
     var character = [aToken characterAtIndex:0],
         length = [aToken length],
         targetedArray,
-        format = /\w*([HPG-GMT])?([+-])(\d{1,2})([:])?(\d{2})\w*/,
+        format = new RegExp("/\w*([HPG-GMT])?([+-])(\d{1,2})([:])?(\d{2})\w*/"),
         result = aString.match(new RegExp(format));
 
     switch (character)

--- a/Foundation/CPDecimal.j
+++ b/Foundation/CPDecimal.j
@@ -119,7 +119,7 @@ function CPDecimalMakeWithString(string, locale)
     // Note: this doesn't accept .01 for example, should it?
     // If yes simply add '?' after integer part group, i.e. ([+\-]?)((?:0|[1-9]\d*)?)
     // Note: now it accept .01 style.
-    var matches = string.match(new RegExp("/^([+\-]?)((?:0|[0-9]\d*)?)(?:\.(\d*))?(?:[eE]([+\-]?)(\d+))?$/"));
+    var matches = string.match(new RegExp("^([+\\-]?)((?:0|[0-9]\\d*)?)(?:\\.(\\d*))?(?:[eE]([+\\-]?)(\\d+))?$"));
 
     if (!matches)
         return CPDecimalMakeNaN();

--- a/Foundation/CPDecimal.j
+++ b/Foundation/CPDecimal.j
@@ -119,7 +119,7 @@ function CPDecimalMakeWithString(string, locale)
     // Note: this doesn't accept .01 for example, should it?
     // If yes simply add '?' after integer part group, i.e. ([+\-]?)((?:0|[1-9]\d*)?)
     // Note: now it accept .01 style.
-    var matches = string.match(/^([+\-]?)((?:0|[0-9]\d*)?)(?:\.(\d*))?(?:[eE]([+\-]?)(\d+))?$/);
+    var matches = string.match(new RegExp("/^([+\-]?)((?:0|[0-9]\d*)?)(?:\.(\d*))?(?:[eE]([+\-]?)(\d+))?$/"));
 
     if (!matches)
         return CPDecimalMakeNaN();

--- a/Foundation/_CPCollectionKVCOperators.j
+++ b/Foundation/_CPCollectionKVCOperators.j
@@ -22,7 +22,7 @@
 
 @import "CPObject.j"
 
-var _CPCollectionKVCOperatorSimpleRE = new RegExp("/^@(avg|count|m(ax|in)|sum|unionOfObjects|distinctUnionOfObjects|unionOfArrays|distinctUnionOfArrays|distinctUnionOfSets)(\.|$)/");
+var _CPCollectionKVCOperatorSimpleRE = new RegExp("^@(avg|count|m(ax|in)|sum|unionOfObjects|distinctUnionOfObjects|unionOfArrays|distinctUnionOfArrays|distinctUnionOfSets)(\\.|$)");
 
 
 @implementation _CPCollectionKVCOperator : CPObject

--- a/Foundation/_CPCollectionKVCOperators.j
+++ b/Foundation/_CPCollectionKVCOperators.j
@@ -22,7 +22,7 @@
 
 @import "CPObject.j"
 
-var _CPCollectionKVCOperatorSimpleRE = /^@(avg|count|m(ax|in)|sum|unionOfObjects|distinctUnionOfObjects|unionOfArrays|distinctUnionOfArrays|distinctUnionOfSets)(\.|$)/;
+var _CPCollectionKVCOperatorSimpleRE = new RegExp("/^@(avg|count|m(ax|in)|sum|unionOfObjects|distinctUnionOfObjects|unionOfArrays|distinctUnionOfArrays|distinctUnionOfSets)(\.|$)/");
 
 
 @implementation _CPCollectionKVCOperator : CPObject

--- a/Tools/nib2cib/Converter.j
+++ b/Tools/nib2cib/Converter.j
@@ -165,7 +165,7 @@ ConverterConversionException = @"ConverterConversionException";
         if (system.engine === "rhino")
             plistContents = String(java.lang.String(plistContents).replaceAll("\\<key\\>\\s*CF\\$UID\\s*\\<\/key\\>", "<key>CP\\$UID</key>"));
         else
-            plistContents = plistContents.replace(/\<key\>\s*CF\$UID\s*\<\/key\>/g, "<key>CP$UID</key>");
+            plistContents = plistContents.replace("/\<key\>\s*CF\$UID\s*\<\/key\>/g", "<key>CP$UID</key>");
 
         plistContents = plistContents.replace(/<string>[\u0000-\u0008\u000B\u000C\u000E-\u001F]<\/string>/g, function(c)
         {

--- a/Tools/nib2cib/Converter.j
+++ b/Tools/nib2cib/Converter.j
@@ -165,7 +165,7 @@ ConverterConversionException = @"ConverterConversionException";
         if (system.engine === "rhino")
             plistContents = String(java.lang.String(plistContents).replaceAll("\\<key\\>\\s*CF\\$UID\\s*\\<\/key\\>", "<key>CP\\$UID</key>"));
         else
-            plistContents = plistContents.replace("/\<key\>\s*CF\$UID\s*\<\/key\>/g", "<key>CP$UID</key>");
+            plistContents = plistContents.replace(new RegExp("\\<key\\>\\s*CF\\$UID\\s*\\<\\/key\\>", "g"), "<key>CP$UID</key>");
 
         plistContents = plistContents.replace(/<string>[\u0000-\u0008\u000B\u000C\u000E-\u001F]<\/string>/g, function(c)
         {


### PR DESCRIPTION
On linux distributions with gcc > 4.9 cappuccino does not build because of the format of the RegEx.
I replaced all RegEx by a construct like new RegExp("xxx")
In the RegEx itself the \ had to be escaped for this to work.

This Pull Request refers to this [issue](https://github.com/cappuccino/cappuccino/issues/2499)