### PR TITLE
New: CPObject -instancesImplementSelector:(SEL)aSelector

### DIFF
--- a/Foundation/CPObject.j
+++ b/Foundation/CPObject.j
@@ -275,13 +275,13 @@ CPLog(@"Got some class: %@", inst);
 }
 
 /*!
-    Tests if the receiver implements the provided selector regardless of inheritance.
-    @param aSelector the selector for which to test the receiver
-    @return \c YES if the receiver implements the selector
+    Tests if instances of a given class implement the provided selector regardless of inheritance.
+    @param aSelector the selector for which to test the class
+    @return \c YES if instances of the class implement the selector
 */
-- (BOOL)implementsSelector:(SEL)aSelector
++ (BOOL)instancesImplementSelector:(SEL)aSelector
 {
-    var methods = class_copyMethodList([self class]),
+    var methods = class_copyMethodList(self),
         count = methods.length;
 
     while (count--)
@@ -289,6 +289,16 @@ CPLog(@"Got some class: %@", inst);
             return YES;
 
     return NO;
+}
+
+/*!
+    Tests if the receiver implements the provided selector regardless of inheritance.
+    @param aSelector the selector for which to test the receiver
+    @return \c YES if the receiver implements the selector
+*/
+- (BOOL)implementsSelector:(SEL)aSelector
+{
+    return [[self class] instancesImplementSelector:aSelector];
 }
 
 /*!

--- a/Tests/Foundation/CPObjectTest.j
+++ b/Tests/Foundation/CPObjectTest.j
@@ -25,6 +25,15 @@
     [self assertFalse:[receiver implementsSelector:@selector(notImplementedInSuperNorReceiver)]];
 }
 
+- (void)testInstancesImplementSelector
+{
+    [self assertTrue:[Receiver instancesImplementSelector:@selector(implementedInReceiverAndSuper)]];
+    [self assertTrue:[Receiver instancesImplementSelector:@selector(implementedInReceiverOnly)]];
+
+    [self assertFalse:[Receiver instancesImplementSelector:@selector(implementedInSuperOnly)]];
+    [self assertFalse:[Receiver instancesImplementSelector:@selector(notImplementedInSuperNorReceiver)]];
+}
+
 - (void)testVersion
 {
     // zero by default


### PR DESCRIPTION
Tests if instances of given class implement a selector.
With test.

The naming is from cocoa where this method is semi-public, id est not documented but not underscored.

A possible usage is to compute in CPView the _viewFlags (custom layout & drawing) at the class level instead of the instance level and make them more accessible from outside.