### PR TITLE
New: Allow a text based control to stay on a single line when text wraps.

### DIFF
--- a/AppKit/CPSegmentedControl.j
+++ b/AppKit/CPSegmentedControl.j
@@ -604,7 +604,12 @@ CPSegmentSwitchTrackingMomentary = 2;
 - (CPView)createEphemeralSubviewNamed:(CPString)aName
 {
     if ([aName hasPrefix:@"segment-content"])
-        return [[_CPImageAndTextView alloc] initWithFrame:CGRectMakeZero()];
+    {
+        var view = [[_CPImageAndTextView alloc] initWithFrame:CGRectMakeZero()];
+        [view _setUsesSingleLineMode:YES];
+
+        return view;
+    }
 
     return [[CPView alloc] initWithFrame:CGRectMakeZero()];
 }

--- a/AppKit/_CPImageAndTextView.j
+++ b/AppKit/_CPImageAndTextView.j
@@ -66,6 +66,7 @@ var _CPimageAndTextViewFrameSizeChangedFlag         = 1 << 0,
     CPString                _text;
 
     CGSize                  _textSize;
+    BOOL                    _usesSingleLineMode @accessors;
 
     unsigned                _flags;
 
@@ -107,6 +108,8 @@ var _CPimageAndTextViewFrameSizeChangedFlag         = 1 << 0,
         }
 
         _textSize = nil;
+        _usesSingleLineMode = NO;
+
         [self setHitTests:NO];
     }
 
@@ -725,6 +728,9 @@ var _CPimageAndTextViewFrameSizeChangedFlag         = 1 << 0,
                         _lineBreakMode === CPLineBreakByWordWrapping)
                     {
                         _textSize = [_text sizeWithFont:_font inWidth:textRectWidth];
+
+                        if (_usesSingleLineMode)
+                            _textSize.height = [_font defaultLineHeightForFont];
                     }
                     else
                     {


### PR DESCRIPTION
A private flag have been added in _CPImageAndTextView. It must be set
to YES when it does not make sense for a control to hold multiline text.
This is now the case for all CPSegmentedControl.

Test: In CPSegmentedControlTest, hit « Add Segment with flexible
width » button. The new label should be vertically centered.