### PR TITLE
Make variable local: key

### DIFF
--- a/AppKit/CPTheme.j
+++ b/AppKit/CPTheme.j
@@ -322,7 +322,7 @@ function ThemeState(stateNames)
     var stateNameKeys = [];
     this._stateNames = {};
 
-    for (key in stateNames)
+    for (var key in stateNames)
     {
         if (!stateNames.hasOwnProperty(key))
             continue;


### PR DESCRIPTION
This line of code was introduced years ago with a variable that
javascript is happy to add to the global name space.  Clearly it
was meant as a local variable.  Probably a cut and paste error
because other places in the code use the same syntax but there the
value is a local because the var statement for it appeared elsewhere
in the function.

Once code like this is cleaned up to use the new 'let' construct,
as well as 'use strict', mistakes like this will be much less likely
to go uncaught.