### PR TITLE
Fix aClass.protocol_list syntax

### DIFF
--- a/Objective-J/Runtime.js
+++ b/Objective-J/Runtime.js
@@ -322,7 +322,7 @@ GLOBAL(class_addProtocol) = function(/*Class*/ aClass, /*Protocol*/ aProtocol)
         return;
     }
 
-    (aClass.protocol_list || (aClass.protocol_list == [])).push(aProtocol);
+    (aClass.protocol_list || (aClass.protocol_list = [])).push(aProtocol);
 
     return true;
 }


### PR DESCRIPTION
A long standing bug that never mattered because each class is
initialized with a protocol_list set to an empty array.  This
is not the case for the protocol objects but there the syntax
was correct already.