### PR TITLE
Removed an unused variable: cachedSearchResults.

### DIFF
--- a/Objective-J/Executable.js
+++ b/Objective-J/Executable.js
@@ -475,7 +475,6 @@ Executable.fileExecutableSearcherForURL = function(/*CFURL*/ referenceURL)
     var referenceURLString = referenceURL.absoluteString(),
         cachedFileExecutableSearcher = cachedFileExecutableSearchers[referenceURLString],
         aFilenameTranslateDictionary = Executable.filenameTranslateDictionary ? Executable.filenameTranslateDictionary() : null;
-        cachedSearchResults = { };
 
     if (!cachedFileExecutableSearcher)
     {


### PR DESCRIPTION
It is polluting the global namespace.

Seven years ago this line was added and even then the variable wasn't
being used but it was a local variable so would have been hard to spot
unless a linter should catch things like that.

Then some four years ago it was accidently converted to a global
variable because the line above it ended in a semicolon rather than
a comma.  'use strict' didn't exist at the time this file was created
and hasn't been added in general yet.