### PR TITLE
Remove objj_class.sub_classes property

### DIFF
--- a/Objective-J/Runtime.js
+++ b/Objective-J/Runtime.js
@@ -64,7 +64,6 @@ GLOBAL(objj_class) = function(displayName)
     this.version        = 0;
 
     this.super_class    = NULL;
-    this.sub_classes    = [];
 
     this.name           = NULL;
     this.info           = 0;


### PR DESCRIPTION
From the first day this class was added to the repo, the sub_classes
property, which is initialized with an empty array, has gone unused.

Removing it.  A little less code.  A little subsequent processing
and memory used.