### PR TITLE
CPSplitView -trackDivider: performance

### DIFF
--- a/AppKit/CPSplitView.j
+++ b/AppKit/CPSplitView.j
@@ -532,6 +532,8 @@ var ShouldSuppressResizeNotifications   = 1,
                     _shouldAutosave = NO;
                     [self _postNotificationWillResize];
                 }
+
+                break;
             }
         }
 

--- a/AppKit/CPSplitView.j
+++ b/AppKit/CPSplitView.j
@@ -454,15 +454,25 @@ var ShouldSuppressResizeNotifications   = 1,
         return nil;
 
     var point = [self convertPoint:aPoint fromView:[self superview]],
-        count = [_subviews count] - 1;
+        dividerIndex = [self _dividerAtPoint:point];
+
+    if (dividerIndex !== CPNotFound)
+        return self;
+
+    return [super hitTest:aPoint];
+}
+
+- (CPInteger)_dividerAtPoint:(CGPoint)aPoint
+{
+    var count = [_subviews count] - 1;
 
     for (var i = 0; i < count; i++)
     {
-        if ([self cursorAtPoint:point hitDividerAtIndex:i])
-            return self;
+        if ([self cursorAtPoint:aPoint hitDividerAtIndex:i])
+            return i;
     }
 
-    return [super hitTest:aPoint];
+    return CPNotFound;
 }
 
 /*
@@ -568,8 +578,11 @@ var ShouldSuppressResizeNotifications   = 1,
 
 - (void)mouseDown:(CPEvent)anEvent
 {
-    // FIXME: This should not trap events if not on a divider!
-    [self trackDivider:anEvent];
+    var point = [self convertPoint:[anEvent locationInWindow] fromView:nil],
+        dividerIndex = [self _dividerAtPoint:point];
+
+    if (dividerIndex !== CPNotFound)
+        [self trackDivider:anEvent];
 }
 
 - (void)viewDidMoveToWindow

--- a/AppKit/CPSplitView.j
+++ b/AppKit/CPSplitView.j
@@ -215,6 +215,9 @@ var ShouldSuppressResizeNotifications   = 1,
             [_subviews[index] setFrame:CGRectMake(0, ROUND((eachSize + dividerThickness) * index), frame.size.width, eachSize)];
     }
 
+    if (_DOMDividerElements[_drawingDivider])
+        [self _setupDOMDivider];
+
     [self setNeedsDisplay:YES];
     [self _postNotificationDidResize];
 
@@ -365,9 +368,9 @@ var ShouldSuppressResizeNotifications   = 1,
         _DOMDividerElements[_drawingDivider].style.backgroundRepeat = "repeat";
 
         CPDOMDisplayServerAppendChild(_DOMElement, _DOMDividerElements[_drawingDivider]);
+        [self _setupDOMDivider];
     }
 
-    [self _setupDOMDivider];
     CPDOMDisplayServerSetStyleLeftTop(_DOMDividerElements[_drawingDivider], NULL, CGRectGetMinX(aRect), CGRectGetMinY(aRect));
     CPDOMDisplayServerSetStyleSize(_DOMDividerElements[_drawingDivider], CGRectGetWidth(aRect), CGRectGetHeight(aRect));
 #endif

--- a/Tests/Manual/CPSplitViewTest/AppController.j
+++ b/Tests/Manual/CPSplitViewTest/AppController.j
@@ -27,19 +27,14 @@
 - (void)awakeFromCib
 {
     [splitViewA setDelegate:self];
-
+    [splitViewB setDelegate:self];
+    [splitViewC setDelegate:self];
     // This is called when the cib is done loading.
     // You can implement this method on any object instantiated from a Cib.
     // It's a useful hook for setting up current UI values, and other things.
 
     // In this case, we want the window from Cib to become our full browser window
     [theWindow setFullPlatformWindow:YES];
-}
-
-- (BOOL)splitView:(CPSplitView)splitView shouldAdjustSizeOfSubview:(CPView)subview
-{
-    var subviews = [splitView subviews];
-    return (subview !== [subviews objectAtIndex:1]);
 }
 
 - (@action)deleteAutosave:(id)sender
@@ -84,5 +79,20 @@
     console.error(@"splitViewWillResizeSubviews")
 }
 
+- (BOOL)splitView:(CPSplitView)splitView shouldAdjustSizeOfSubview:(CPView)subview
+{
+    var subviews = [splitView subviews];
+    return (subview !== [subviews objectAtIndex:1]);
+}
+
+- (BOOL)splitView:(CPSplitView)splitView canCollapseSubview:(CPView)subview
+{
+    return subview == [[splitView subviews] objectAtIndex:0];
+}
+
+- (BOOL)splitView:(CPSplitView)splitView shouldCollapseSubview:(CPView)subview forDoubleClickOnDividerAtIndex:(CPInteger)dividerIndex
+{
+    return dividerIndex == 0;
+}
 
 @end


### PR DESCRIPTION
Perf: Exit a loop when the current divider is found.

Fixed: Do not start tracking when the mouse is not over a divider (see mouseDown:)

Fixed: Properly catch single-click, double-click, dragging on a divider.
Previously, 
• a double-click was also catched as a single-click on mouse up,
• dragging was handled in mouse down before tracking actually begins.

Manual test: All split views can be collapsed when double-clicking the first divider.