### PR TITLE
Fixed: Nib2Cib will replace a CPTextFieldCell with a CPTextField

### DIFF
--- a/Tools/nib2cib/NSTextField.j
+++ b/Tools/nib2cib/NSTextField.j
@@ -26,6 +26,7 @@
 @import "NSCell.j"
 @import "NSControl.j"
 
+@global NIB_CONNECTION_EQUIVALENCY_TABLE
 
 @implementation CPTextField (NSCoding)
 
@@ -82,6 +83,10 @@
     if (self)
     {
         var cell = [aCoder decodeObjectForKey:@"NSCell"];
+
+        // If we have bindings/connections connected to the text field cell make sure they are replaced
+        NIB_CONNECTION_EQUIVALENCY_TABLE[[cell UID]] = self;
+
         [self NS_initWithCell:cell];
         [self _adjustNib2CibSize];
     }


### PR DESCRIPTION
As Cappuccino does not use cells a binding or connection made to a ```CPTextFieldCell``` will get lost when the Cib file is read as the cell is never stored in the Cib file.

This fix make sure that the binding / connection is made to the ```CPTextField``` instead of the cell by replacing the cell with the text field when reading the xib file. The same mechanism is used in ```NSButton``` and ```NSMatrix```.

This fix allows view based TableView bindings from a text field cell to the table cell view in the Interface Builder in Xcode.

This works in Cocoa.
