### PR TITLE
 Fixed: CPComparisonPredicate does not handle nil inequality correctly.

### DIFF
--- a/Foundation/CPPredicate/CPComparisonPredicate.j
+++ b/Foundation/CPPredicate/CPComparisonPredicate.j
@@ -287,10 +287,21 @@
         rightIsNil = (rhs == nil || [rhs isEqual:[CPNull null]]);
 
     if ((leftIsNil || rightIsNil) && _type != CPCustomSelectorPredicateOperatorType)
-        return (leftIsNil == rightIsNil &&
-               (_type == CPEqualToPredicateOperatorType ||
-                _type == CPLessThanOrEqualToPredicateOperatorType ||
-                _type == CPGreaterThanOrEqualToPredicateOperatorType));
+    {
+        switch (_type)
+        {
+            case CPEqualToPredicateOperatorType:
+            case CPLessThanOrEqualToPredicateOperatorType:
+            case CPGreaterThanOrEqualToPredicateOperatorType:
+                return leftIsNil == rightIsNil;
+
+            case CPNotEqualToPredicateOperatorType:
+                return leftIsNil != rightIsNil;
+
+            default:
+                return NO;
+        }
+    }
 
     var string_compare_options = 0;
 

--- a/Tests/Foundation/CPPredicateTest.j
+++ b/Tests/Foundation/CPPredicateTest.j
@@ -271,6 +271,14 @@
     pred = [[CPComparisonPredicate alloc] initWithLeftExpression:[CPExpression expressionForConstantValue:nil] rightExpression:[CPExpression expressionForConstantValue:nil] modifier:CPDirectPredicateModifier type:CPBeginsWithPredicateOperatorType options:0];
 
     [self assertFalse:[pred evaluateWithObject:dict] message:"'" + [pred description]  + "' should be false"];
+
+    pred = [[CPComparisonPredicate alloc] initWithLeftExpression:[CPExpression expressionForConstantValue:nil] rightExpression:[CPExpression expressionForConstantValue:nil] modifier:CPDirectPredicateModifier type:CPNotEqualToPredicateOperatorType options:0];
+
+    [self assertFalse:[pred evaluateWithObject:dict] message:"'" + [pred description]  + "' should be false"];
+
+    pred = [[CPComparisonPredicate alloc] initWithLeftExpression:[CPExpression expressionForKeyPath:@"Record1.Age"] rightExpression:[CPExpression expressionForConstantValue:nil] modifier:CPDirectPredicateModifier type:CPNotEqualToPredicateOperatorType options:0];
+
+    [self assertTrue:[pred evaluateWithObject:dict] message:"'" + [pred description]  + "' should be true"+[dict description]];
 }
 
 - (void)testPredicateParsing


### PR DESCRIPTION
Fix and test for a bug where CPComparisonPredicate incorrectly evaluates inequality comparisons with a nil operand (e.g. value != nil) to false (NO) when they should be true (YES).