### PR TITLE
Fixed: Crash when triple click an empty CPTextField that is not editable but selectable

### DIFF
--- a/AppKit/_CPImageAndTextView.j
+++ b/AppKit/_CPImageAndTextView.j
@@ -836,7 +836,8 @@ var _CPimageAndTextViewFrameSizeChangedFlag         = 1 << 0,
 - (void)setSelectedRange:(CPRange)aRange
 {
 #if PLATFORM(DOM)
-    [[[self window] platformWindow] setSelectedRange:aRange inElement:_DOMTextElement];
+    if (_DOMTextElement)
+        [[[self window] platformWindow] setSelectedRange:aRange inElement:_DOMTextElement];
 #endif
 }
 


### PR DESCRIPTION
This call will crash as ```_DOMTextElement``` is ```nil```.

This check will make sure it is not called when no element is present. This is the same way as it is done in other parts of this class.