### PR TITLE
Fixed: Variable in if statement overshadows variable in enclosing block

### DIFF
--- a/AppKit/Cib/_CPCibObjectData.j
+++ b/AppKit/Cib/_CPCibObjectData.j
@@ -230,7 +230,7 @@ var _CPCibObjectDataNamesKeysKey                = @"_CPCibObjectDataNamesKeysKey
 
         if ([object respondsToSelector:@selector(_cibInstantiate)])
         {
-            var instantiatedObject = [object _cibInstantiate];
+            instantiatedObject = [object _cibInstantiate];
 
             if (instantiatedObject !== object)
             {


### PR DESCRIPTION
If statement variable `instantiatedObject` on line 233 of
_CPCibObjectData.j overshadows a variable with the same name declared
on line 229 in the enclosing block. This variable is later added to array outside
the enclosing if statement, resulting in a potential loss of information.

Refs: #2601