### PR TITLE
fixed: backspace did not trigger scrolling properly 927d6d2

### DIFF
--- a/AppKit/CPTextView/CPTextView.j
+++ b/AppKit/CPTextView/CPTextView.j
@@ -1614,6 +1614,7 @@ Sets the selection to a range of characters in response to user action.
     [self didChangeText];
     [_layoutManager _validateLayoutAndGlyphs];
     [self sizeToFit];
+    [self scrollRangeToVisible:CPMakeRange(changedRange.location, 0)]
     _stickyXLocation = _caret._rect.origin.x;
 }
 


### PR DESCRIPTION
previously, deleting text did not keep the selection visible under some circumstances.
this PR fixes that with a call to scrollRangeToVisible: