### PR TITLE
Formatting: add semi-colon to CPImage.j

### DIFF
--- a/AppKit/CPImage.j
+++ b/AppKit/CPImage.j
@@ -246,7 +246,7 @@ function CPAppKitImage(aFilename, aSize)
         var canvas = document.createElement("canvas"),
             ctx = canvas.getContext("2d");
 
-        canvas.width = _image.width,
+        canvas.width = _image.width;
         canvas.height = _image.height;
 
         ctx.drawImage(_image, 0, 0);


### PR DESCRIPTION
Variable value assignment terminated in comma, despite not being a variable list. 
Replaced comma with semi-colon.