### PR TITLE
Formatting: formally declared variable before use in CPColor.j

### DIFF
--- a/AppKit/CPColor.j
+++ b/AppKit/CPColor.j
@@ -1247,7 +1247,8 @@ var patternColorsFromPattern = function(pattern, attributes, imageFactory)
             bottomHeight,
             centerWidthHeight,
             centerIsNil,
-            numParts;
+            numParts,
+            isVertical;
 
         // positions are mandatory
         if (pattern.indexOf("{position}") < 0)


### PR DESCRIPTION
Variable `isVertical` is used throughout the function `patternColorsFromPattern` in CPColor.j despite never being declared.
Perhaps not necessary, in this pull request the variable `isVertical` is declared formally in the variable list before its use.