### PR TITLE
Formatting: Remove semi-colon after method header in CPLevelIndicator

### DIFF
--- a/AppKit/CPLevelIndicator.j
+++ b/AppKit/CPLevelIndicator.j
@@ -292,7 +292,7 @@ CPRatingLevelIndicatorStyle                 = 3;
     [self setNeedsLayout];
 }
 
-- (void)setWarningValue:(double)warningValue;
+- (void)setWarningValue:(double)warningValue
 {
     if (_warningValue === warningValue)
         return;
@@ -301,7 +301,7 @@ CPRatingLevelIndicatorStyle                 = 3;
     [self setNeedsLayout];
 }
 
-- (void)setCriticalValue:(double)criticalValue;
+- (void)setCriticalValue:(double)criticalValue
 {
     if (_criticalValue === criticalValue)
         return;


### PR DESCRIPTION
On lines 295 and 304, the selector for two method declarations are
followed by a semi-colon. Not sure if this causes problems or not, but
removed anyways.