### PR TITLE
Formatting: remove redundant variable in _CPRuleEditorViewSlice.j

### DIFF
--- a/AppKit/CPRuleEditor/_CPRuleEditorViewSliceRow.j
+++ b/AppKit/CPRuleEditor/_CPRuleEditorViewSliceRow.j
@@ -209,8 +209,7 @@
 
 - (void)_reconfigureSubviews
 {
-    var ruleItems,
-        criteria,
+    var criteria,
         repObject,
         menuItem,
         ruleView,


### PR DESCRIPTION
Variable `ruleItems` is declared at the beginning of a variable declaration list, and then again at the end of the same list. Removed first occurrence.