### PR TITLE
Formatting: removed redundant variable in CPSearchField.j

### DIFF
--- a/AppKit/CPSearchField.j
+++ b/AppKit/CPSearchField.j
@@ -386,9 +386,9 @@ var CPAutosavedRecentsChangedNotification = @"CPAutosavedRecentsChangedNotificat
 */
 - (void)setRecentSearches:(CPArray)searches
 {
-    var max = MIN([self maximumRecents], [searches count]),
-        searches = [searches subarrayWithRange:CPMakeRange(0, max)];
+    var max = MIN([self maximumRecents], [searches count]);
 
+    searches = [searches subarrayWithRange:CPMakeRange(0, max)];
     _recentSearches = searches;
     [self _autosaveRecentSearchList];
 }


### PR DESCRIPTION
Variable `searches` is defined in the method selector, and then
redeclared with the `var` keyword two lines later. Removed the
redundant declaration, moving the variable assignment to its own line.