### PR TITLE
Fix: CPProxy respondsToSelector incorrect parameter name

### DIFF
--- a/Foundation/CPProxy.j
+++ b/Foundation/CPProxy.j
@@ -48,7 +48,7 @@
     return class_createInstance(self);
 }
 
-+ (BOOL)respondsToSelector:(SEL)selector
++ (BOOL)respondsToSelector:(SEL)aSelector
 {
     return !!class_getInstanceMethod(isa, aSelector);
 }


### PR DESCRIPTION
Changed method selector parameter `selector` to `aSelector`, as that is the name of the variable used within the method.