### PR TITLE
Animating frame origin was not working on recent FireFox versions

### DIFF
--- a/AppKit/CoreAnimation/CPViewAnimator.j
+++ b/AppKit/CoreAnimation/CPViewAnimator.j
@@ -214,7 +214,7 @@ var transformSizeToHeight = function(start, current)
 
 var CSSStringFromCGAffineTransform = function(anAffineTransform)
 {
-    return "matrix(" + anAffineTransform.a + ", " + anAffineTransform.b + ", " + anAffineTransform.c + ", " + anAffineTransform.d + ", " + anAffineTransform.tx + (CPBrowserIsEngine(CPGeckoBrowserEngine) ? "px, " : ", ") + anAffineTransform.ty + (CPBrowserIsEngine(CPGeckoBrowserEngine) ? "px)" : ")");
+    return [CPString stringWithFormat:@"matrix(%d,%d,%d,%d,%d,%d)", anAffineTransform.a, anAffineTransform.b, anAffineTransform.c, anAffineTransform.d, anAffineTransform.tx, anAffineTransform.ty];
 };
 
 var frameOriginToCSSTransformMatrix = function(start, current)


### PR DESCRIPTION
Previously, the format for the matrix value of the transform property was matrix(a,b,c,d,tx,ty) where tx and ty had the "px" suffix. [According to Mozilla doc](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/matrix) , tx and ty were accepted (in my understanding not required) with this suffix before FireFox 16 and required after.

All parameters are now numbers without suffix and this code is expected to work
with all FireFox versions supporting css animations.