### PR TITLE
Fixed: _CPObjectAnimator initialize method did not match superclass return

### DIFF
--- a/AppKit/CoreAnimation/_CPObjectAnimator.j
+++ b/AppKit/CoreAnimation/_CPObjectAnimator.j
@@ -20,7 +20,7 @@ var _supportsCSSAnimations = null;
     id <CPAnimatablePropertyContainer> _target;
 }
 
-+ (void)initialize
++ (BOOL)initialize
 {
     if ([self class] !== [_CPObjectAnimator class])
         return;

--- a/AppKit/CoreAnimation/_CPObjectAnimator.j
+++ b/AppKit/CoreAnimation/_CPObjectAnimator.j
@@ -20,7 +20,7 @@ var _supportsCSSAnimations = null;
     id <CPAnimatablePropertyContainer> _target;
 }
 
-+ (BOOL)initialize
++ (void)initialize
 {
     if ([self class] !== [_CPObjectAnimator class])
         return;


### PR DESCRIPTION
_CPObject animator labeled return type as BOOL, not only is this value not returned, but the super class CPProxy's initialize method returns void. Changed return type to void in _CPObject animator, to match superclass