### PR TITLE
fixed: touch scrolling events to scrollviews also scrolled the document body

### DIFF
--- a/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
@@ -433,10 +433,10 @@ _CPPlatformWindowWillCloseNotification = @"_CPPlatformWindowWillCloseNotificatio
         theDocument.addEventListener("keydown", keyEventCallback, NO);
         theDocument.addEventListener("keypress", keyEventCallback, NO);
 
-        theDocument.addEventListener("touchstart", touchEventCallback, NO);
-        theDocument.addEventListener("touchend", touchEventCallback, NO);
-        theDocument.addEventListener("touchmove", touchEventCallback, NO);
-        theDocument.addEventListener("touchcancel", touchEventCallback, NO);
+        theDocument.addEventListener("touchstart", touchEventCallback, {passive: false});
+        theDocument.addEventListener("touchend", touchEventCallback, {passive: false});
+        theDocument.addEventListener("touchmove", touchEventCallback, {passive: false});
+        theDocument.addEventListener("touchcancel", touchEventCallback, {passive: false});
 
         _DOMWindow.addEventListener("DOMMouseScroll", scrollEventCallback, NO);
         _DOMWindow.addEventListener("wheel", scrollEventCallback, NO);
@@ -1196,6 +1196,12 @@ _CPPlatformWindowWillCloseNotification = @"_CPPlatformWindowWillCloseNotificatio
         // two fingers->simulate scrolling events
         if (aDOMEvent.touches && aDOMEvent.touches.length == 2)
         {
+            if (aDOMEvent.preventDefault)
+                aDOMEvent.preventDefault();
+
+            if (aDOMEvent.stopPropagation)
+                aDOMEvent.stopPropagation();
+
             switch (aDOMEvent.type)
             {
                 case CPDOMEventTouchStart:
@@ -1215,7 +1221,8 @@ _CPPlatformWindowWillCloseNotification = @"_CPPlatformWindowWillCloseNotificatio
                     return;
             }
         }
-        // handle other touch cases specifically
+        
+        // cancel other touch cases preventively
 
         if (aDOMEvent.preventDefault)
             aDOMEvent.preventDefault();

--- a/Tests/Manual/TableTest/TableBindings/index.html
+++ b/Tests/Manual/TableTest/TableBindings/index.html
@@ -1,77 +1,166 @@
-<!DOCTYPE html
-    PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <!--
  index.html
- TableBindings
+ __project.name__
 
- Created by You on January 16, 2011.
- Copyright 2011, Your Company All rights reserved.
+ Created by __user.name__ on __project.date__.
+ Copyright __project.year__, __organization.name__ All rights reserved.
 -->
     <head>
-        <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7, chrome=1" />
+        <meta charset="utf-8">
 
-        <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
+        <!--[if lte IE 8]>
+        <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7, chrome=1">
+        <![endif]-->
+        <!--[if gte IE 9]>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge, chrome=1">
+        <![endif]-->
 
-        <meta name="apple-mobile-web-app-capable" content="yes" />
-        <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+        <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
 
-        <link rel="apple-touch-icon" href="Resources/icon.png" />
-        <link rel="apple-touch-startup-image" href="Resources/default.png" />
+        <meta name="apple-mobile-web-app-capable" content="yes">
+        <meta name="apple-mobile-web-app-status-bar-style" content="black">
 
-        <title>TableBindings</title>
+        <link rel="apple-touch-icon" href="Resources/icon.png">
+        <link rel="apple-touch-startup-image" href="Resources/default.png">
+
+        <title>__project.name__</title>
+
+        <!-- Custom javascript goes here -->
+        <!-- End custom javascript -->
 
         <script type="text/javascript">
             OBJJ_MAIN_FILE = "main.j";
+            // The below will tell the compiler to not generate debug symbols but will generate type signatures and inline objj_msgSend functions.
+            // This will affect only Objective-J code that is compiled when loading the application. It will not affect precompiled
+            // code like the Cappuccino frameworks.
+            // Uncomment or comment on the line below to change the flags
+            OBJJ_COMPILER_FLAGS = [/*"IncludeDebugSymbols"*/, "IncludeTypeSignatures"/*, "SourceMap"*/, "InlineMsgSend"];
+
+            var progressBar = null;
+
+            OBJJ_PROGRESS_CALLBACK = function(percent, appSize, path)
+            {
+                percent = percent * 100;
+
+                if (!progressBar)
+                    progressBar = document.getElementById("progress-bar");
+
+                if (progressBar)
+                    progressBar.style.width = Math.min(percent, 100) + "%";
+            }
+
+            var loadingHTML =
+                    '<div id="loading">' +
+                    '    <div id="loading-text">Loading...</div>' +
+                    '    <div id="progress-indicator">' +
+                    '        <span id="progress-bar" style="width:0%"></span>' +
+                    '    </div>' +
+                    '</div>';
         </script>
 
         <script type="text/javascript" src="Frameworks/Objective-J/Objective-J.js" charset="UTF-8"></script>
 
         <style type="text/css">
-            body{margin:0; padding:0;}
-            #container {position: absolute; top:50%; left:50%;}
-            #content {width:800px; text-align:center; margin-left: -400px; height:50px; margin-top:-25px; line-height: 50px;}
-            #content {font-family: "Helvetica", "Arial", sans-serif; font-size: 18px; color: black; text-shadow: 0px 1px 0px white; }
-            #loadgraphic {margin-right: 0.2em; margin-bottom:-2px;}
+            html, body, h1, p {
+                margin: 0;
+                padding: 0;
+            }
+
+            /* We need a body wrapper because Cappuccino is unhappy if we change the body element */
+            #cappuccino-body {
+                /* Position it absolutely so it will fill the height without content */
+                position: absolute;
+                top: 0;
+                bottom: 0;
+                width: 100%;
+
+                /* Put it at the bottom of the stack so it doesn't interfere with UI */
+                z-index: 0;
+            }
+
+            #cappuccino-body .container {
+                display: table;
+                margin: 0 auto;
+                height: 100%;
+            }
+
+            #cappuccino-body .content {
+                display: table-cell;
+                height: 100%;
+                vertical-align: top;
+            }
+
+            #loading {
+                position: relative;
+                top: 35%;
+            }
+
+            #loading-text {
+                height: 1.5em;
+                color: #555;
+                font: normal bold 36px/36px Arial, sans-serif;
+            }
+
+            #progress-indicator {
+                padding: 0px;
+                height: 16px;
+                border: 5px solid #555;
+                border-radius: 18px;
+                background-color: white;
+            }
+
+            #progress-bar {
+                position: relative;
+                top: -1px;
+                left: -1px;
+                display: block;
+                height: 18px;
+
+                /* Compensate for moving the bar left 1px to overlap the indicator border */
+                border-right: 1px solid #555;
+                background-color: #555;
+            }
+
+            #noscript {
+                position: relative;
+                top: 35%;
+                padding: 1em 1.5em;
+                border: 5px solid #555;
+                border-radius: 16px;
+                background-color: white;
+                color: #555;
+                text-align: center;
+                font: bold 24px Arial, sans-serif;
+            }
+
+            #noscript a {
+                color: #98c0ff;
+                text-decoration: none;
+            }
         </style>
-
-        <!--[if lt IE 7]>
-        <STYLE type="text/css">
-            #container { position: relative; top: 50%; }
-            #content { position: relative;}
-        </STYLE>
-        <![endif]-->
-
     </head>
 
-    <body style="">
+    <body>
         <div id="cappuccino-body">
-            <div id="loadingcontainer" style="background-color: #eeeeee; overflow:hidden; width:100%; height:100%; position: absolute; top: 0; left: 0;">
-                <script type="text/javascript">
-                    document.write("<div id='container'><p id='content'>" +
-                                   "<img id='loadgraphic' width='16' height='16' src='Resources/spinner.gif' /> " +
-                                   "Loading TableBindings...</p></div>");
-                </script>
-
-                <noscript>
-                    <div id="container">
-                        <div style="width: 440px; padding: 10px 25px 20px 25px; font-family: sans-serif; background-color: #ffffff; position: relative; left: -245px; top: -120px; text-align: center; -moz-border-radius: 20px; -webkit-border-radius: 20px; color: #555555">
-                            <p style="line-height: 1.4em;">JavaScript is required for this site to work correctly but is either disabled or not supported by your browser.</p>
-                            <p style="font-size:120%; padding:10px;"><a href="http://cappuccino-project.org/noscript">Show me how to enable JavaScript</a></p>
-                            <p style="font-size:80%;">You may want to upgrade to a newer browser while you're at it:</p>
-                            <ul style="margin:0;padding:0; text-align: center; font-size:80%;" >
-                                <li style="display: inline;"><a href="http://www.apple.com/safari/download/">Safari</a></li>
-                                <li style="display: inline;"><a href="http://www.mozilla.com/en-US/firefox/">Firefox</a></li>
-                                <li style="display: inline;"><a href="http://www.google.com/chrome/">Chrome</a></li>
-                                <li style="display: inline;"><a href="http://www.opera.com/download/">Opera</a></li>
-                                <li style="display: inline;"><a href="http://www.microsoft.com/windows/downloads/ie/getitnow.mspx">Internet Explorer</a></li>
-                            </ul>
+            <div class="container">
+                <div class="content">
+                    <script type="text/javascript">
+                        document.write(loadingHTML);
+                    </script>
+                </div>
+            </div>
+            <noscript style="position:absolute; top:0; left:0; width:100%; height:100%">
+                <div class="container">
+                    <div class="content">
+                        <div id="noscript">
+                            <p style="font-size:120%; margin-bottom:.75em">JavaScript is required for this application.</p>
+                            <p><a href="http://www.enable-javascript.com" target="_blank">Enable JavaScript</a></p>
                         </div>
                     </div>
-                </noscript>
-            </div>
+                </div>
+            </noscript>
         </div>
     </body>
-
 </html>

--- a/Tests/Manual/TableTest/TableBindings/index.html
+++ b/Tests/Manual/TableTest/TableBindings/index.html
@@ -1,166 +1,77 @@
-<!DOCTYPE html>
-<html lang="en">
+<!DOCTYPE html
+    PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <!--
  index.html
- __project.name__
+ TableBindings
 
- Created by __user.name__ on __project.date__.
- Copyright __project.year__, __organization.name__ All rights reserved.
+ Created by You on January 16, 2011.
+ Copyright 2011, Your Company All rights reserved.
 -->
     <head>
-        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7, chrome=1" />
 
-        <!--[if lte IE 8]>
-        <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7, chrome=1">
-        <![endif]-->
-        <!--[if gte IE 9]>
-        <meta http-equiv="X-UA-Compatible" content="IE=edge, chrome=1">
-        <![endif]-->
+        <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
 
-        <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="black" />
 
-        <meta name="apple-mobile-web-app-capable" content="yes">
-        <meta name="apple-mobile-web-app-status-bar-style" content="black">
+        <link rel="apple-touch-icon" href="Resources/icon.png" />
+        <link rel="apple-touch-startup-image" href="Resources/default.png" />
 
-        <link rel="apple-touch-icon" href="Resources/icon.png">
-        <link rel="apple-touch-startup-image" href="Resources/default.png">
-
-        <title>__project.name__</title>
-
-        <!-- Custom javascript goes here -->
-        <!-- End custom javascript -->
+        <title>TableBindings</title>
 
         <script type="text/javascript">
             OBJJ_MAIN_FILE = "main.j";
-            // The below will tell the compiler to not generate debug symbols but will generate type signatures and inline objj_msgSend functions.
-            // This will affect only Objective-J code that is compiled when loading the application. It will not affect precompiled
-            // code like the Cappuccino frameworks.
-            // Uncomment or comment on the line below to change the flags
-            OBJJ_COMPILER_FLAGS = [/*"IncludeDebugSymbols"*/, "IncludeTypeSignatures"/*, "SourceMap"*/, "InlineMsgSend"];
-
-            var progressBar = null;
-
-            OBJJ_PROGRESS_CALLBACK = function(percent, appSize, path)
-            {
-                percent = percent * 100;
-
-                if (!progressBar)
-                    progressBar = document.getElementById("progress-bar");
-
-                if (progressBar)
-                    progressBar.style.width = Math.min(percent, 100) + "%";
-            }
-
-            var loadingHTML =
-                    '<div id="loading">' +
-                    '    <div id="loading-text">Loading...</div>' +
-                    '    <div id="progress-indicator">' +
-                    '        <span id="progress-bar" style="width:0%"></span>' +
-                    '    </div>' +
-                    '</div>';
         </script>
 
         <script type="text/javascript" src="Frameworks/Objective-J/Objective-J.js" charset="UTF-8"></script>
 
         <style type="text/css">
-            html, body, h1, p {
-                margin: 0;
-                padding: 0;
-            }
-
-            /* We need a body wrapper because Cappuccino is unhappy if we change the body element */
-            #cappuccino-body {
-                /* Position it absolutely so it will fill the height without content */
-                position: absolute;
-                top: 0;
-                bottom: 0;
-                width: 100%;
-
-                /* Put it at the bottom of the stack so it doesn't interfere with UI */
-                z-index: 0;
-            }
-
-            #cappuccino-body .container {
-                display: table;
-                margin: 0 auto;
-                height: 100%;
-            }
-
-            #cappuccino-body .content {
-                display: table-cell;
-                height: 100%;
-                vertical-align: top;
-            }
-
-            #loading {
-                position: relative;
-                top: 35%;
-            }
-
-            #loading-text {
-                height: 1.5em;
-                color: #555;
-                font: normal bold 36px/36px Arial, sans-serif;
-            }
-
-            #progress-indicator {
-                padding: 0px;
-                height: 16px;
-                border: 5px solid #555;
-                border-radius: 18px;
-                background-color: white;
-            }
-
-            #progress-bar {
-                position: relative;
-                top: -1px;
-                left: -1px;
-                display: block;
-                height: 18px;
-
-                /* Compensate for moving the bar left 1px to overlap the indicator border */
-                border-right: 1px solid #555;
-                background-color: #555;
-            }
-
-            #noscript {
-                position: relative;
-                top: 35%;
-                padding: 1em 1.5em;
-                border: 5px solid #555;
-                border-radius: 16px;
-                background-color: white;
-                color: #555;
-                text-align: center;
-                font: bold 24px Arial, sans-serif;
-            }
-
-            #noscript a {
-                color: #98c0ff;
-                text-decoration: none;
-            }
+            body{margin:0; padding:0;}
+            #container {position: absolute; top:50%; left:50%;}
+            #content {width:800px; text-align:center; margin-left: -400px; height:50px; margin-top:-25px; line-height: 50px;}
+            #content {font-family: "Helvetica", "Arial", sans-serif; font-size: 18px; color: black; text-shadow: 0px 1px 0px white; }
+            #loadgraphic {margin-right: 0.2em; margin-bottom:-2px;}
         </style>
+
+        <!--[if lt IE 7]>
+        <STYLE type="text/css">
+            #container { position: relative; top: 50%; }
+            #content { position: relative;}
+        </STYLE>
+        <![endif]-->
+
     </head>
 
-    <body>
+    <body style="">
         <div id="cappuccino-body">
-            <div class="container">
-                <div class="content">
-                    <script type="text/javascript">
-                        document.write(loadingHTML);
-                    </script>
-                </div>
-            </div>
-            <noscript style="position:absolute; top:0; left:0; width:100%; height:100%">
-                <div class="container">
-                    <div class="content">
-                        <div id="noscript">
-                            <p style="font-size:120%; margin-bottom:.75em">JavaScript is required for this application.</p>
-                            <p><a href="http://www.enable-javascript.com" target="_blank">Enable JavaScript</a></p>
+            <div id="loadingcontainer" style="background-color: #eeeeee; overflow:hidden; width:100%; height:100%; position: absolute; top: 0; left: 0;">
+                <script type="text/javascript">
+                    document.write("<div id='container'><p id='content'>" +
+                                   "<img id='loadgraphic' width='16' height='16' src='Resources/spinner.gif' /> " +
+                                   "Loading TableBindings...</p></div>");
+                </script>
+
+                <noscript>
+                    <div id="container">
+                        <div style="width: 440px; padding: 10px 25px 20px 25px; font-family: sans-serif; background-color: #ffffff; position: relative; left: -245px; top: -120px; text-align: center; -moz-border-radius: 20px; -webkit-border-radius: 20px; color: #555555">
+                            <p style="line-height: 1.4em;">JavaScript is required for this site to work correctly but is either disabled or not supported by your browser.</p>
+                            <p style="font-size:120%; padding:10px;"><a href="http://cappuccino-project.org/noscript">Show me how to enable JavaScript</a></p>
+                            <p style="font-size:80%;">You may want to upgrade to a newer browser while you're at it:</p>
+                            <ul style="margin:0;padding:0; text-align: center; font-size:80%;" >
+                                <li style="display: inline;"><a href="http://www.apple.com/safari/download/">Safari</a></li>
+                                <li style="display: inline;"><a href="http://www.mozilla.com/en-US/firefox/">Firefox</a></li>
+                                <li style="display: inline;"><a href="http://www.google.com/chrome/">Chrome</a></li>
+                                <li style="display: inline;"><a href="http://www.opera.com/download/">Opera</a></li>
+                                <li style="display: inline;"><a href="http://www.microsoft.com/windows/downloads/ie/getitnow.mspx">Internet Explorer</a></li>
+                            </ul>
                         </div>
                     </div>
-                </div>
-            </noscript>
+                </noscript>
+            </div>
         </div>
     </body>
+
 </html>


### PR DESCRIPTION
modern mobile browsers forbid to cancel touch events via preventDefault() by default.
this caused touch scrolling events to scrollviews to also scroll the document body.
this is fixed by this PR by means of providing the passive: false option.
i tested this on an ipad pro with both mobile safari and mobile firefox.
i also tested this on macbook pro chrome / firefox -> no issues