### PR TITLE
FIXED: Before this PR, some cursors were badly or not displayed

### DIFF
--- a/Tests/Manual/CPCursor/AppController.j
+++ b/Tests/Manual/CPCursor/AppController.j
@@ -119,7 +119,10 @@
                                                         cursor:[CPCursor closedHandCursor]],
         disappearingItemCursorTester = [[CursorTester alloc] initWithText:@"Disappearing item cursor"
                                                         origin:CGPointMake(x, y+=yInc)
- 													    cursor:[CPCursor disappearingItemCursor]];
+ 													    cursor:[CPCursor disappearingItemCursor]],
+        verticalTextCursorTester = [[CursorTester alloc] initWithText:@"Vertical text cursor"
+                                                               origin:CGPointMake(x, y+=yInc)
+                                                               cursor:[CPCursor IBeamCursorForVerticalLayout]];
 
     [contentView addSubview:imageCursorTester];
     [contentView addSubview:arrowCursorTester];
@@ -139,6 +142,7 @@
     [contentView addSubview:openHandCursorTester];
     [contentView addSubview:closedHandCursorTester];
     [contentView addSubview:disappearingItemCursorTester];
+    [contentView addSubview:verticalTextCursorTester];
 
     [theWindow orderFront:self];
 }


### PR DESCRIPTION
This PR is originally aimed to fix a problem that was blocking the "grabbing hand" cursor (the one used when dragging things).

This is done by simply changing the string used "-moz-grabbing" to "grabbing".
Another name change is done for the "grab" (or open hand) cursor, from "move" to "grab".

Then, after reading NSCursor documentation, a new cursor is added : IBeamCursorForVerticalLayout

Then, in order to use modern Cocoa cursors, a new cursor creation method is proposed (very similar to the original one) : 

We now have 3 internal methods (instead of 1) :
```+ (CPCursor)_nativeSystemCursorWithName:(CPString)cursorName cssString:(CPString)aString``` 
This one is used when a direct system (browser) cursor exists, for example : crosshair

```+ (CPCursor)_imageCursorWithName:(CPString)cursorName cssString:(CPString)aString```
This one is used when we want to create a custom cursor not provided by the system (browser) and based on an image

Those first 2 methods were present initially but have been splitted.

And finally : 
```+ (CPCursor)_tryUsingNativeSystemCursorWithName:(CPString)cursorName cssString:(CPString)cssName onPlatform:(CPCursorPlatform)shouldUseNativeCursorOn fallingBackWithImageAndCSSPointer:(CPString)aString```

This one will try to use, if possible, a direct system cursor but if not available, will fall back on using an image. It uses a special method : ```+ (BOOL)_nativeCursorExists:(CPString)cursorCSSName``` to test if a system cursor exists on the specific browser used.

When creating a new cursor, you can specify when you want the system cursor (on Mac only, on Windows only, on both, on none).

This is used, for example, for the grabbing hand cursor where all browsers on Mac implement the system cursor but on Windows, IE and Edge use a ugly huge hand (FF & Chrome are OK). So, for this one, we specify ```CPCursorPlatformMac```.

This way, on Mac, system cursors are used for every Cappuccino cursor but ```disappearingItemCursor``` ; On Windows, we use system cursor for contextual menu cursor when it's available (that is on IE and Edge) and image cursor everywhere else (that is FF and Chrome) ; and image cursors for open and closed hands.

This PR needs PR #2751 in order to detect Edge browser.
