### PR TITLE
FIXED: Before this PR, starting a column drag within a scrolled down table would scroll the table content to the bottom

### DIFF
--- a/AppKit/CPTableHeaderView.j
+++ b/AppKit/CPTableHeaderView.j
@@ -550,7 +550,7 @@ var CPTableHeaderViewResizeZone = 3.0,
 - (void)_autoscroll:(CPEvent)theEvent localLocation:(CGPoint)theLocation
 {
     // Constrain the y coordinate so we don't autoscroll vertically
-    var constrainedLocation = CGPointMake(theLocation.x, CGRectGetMinY([_tableView visibleRect])),
+    var constrainedLocation = CGPointMake(theLocation.x, self._frame.size.height),
         constrainedEvent = [CPEvent mouseEventWithType:CPLeftMouseDragged
                                              location:[self convertPoint:constrainedLocation toView:nil]
                                         modifierFlags:[theEvent modifierFlags]

--- a/AppKit/CPTableHeaderView.j
+++ b/AppKit/CPTableHeaderView.j
@@ -550,7 +550,7 @@ var CPTableHeaderViewResizeZone = 3.0,
 - (void)_autoscroll:(CPEvent)theEvent localLocation:(CGPoint)theLocation
 {
     // Constrain the y coordinate so we don't autoscroll vertically
-    var constrainedLocation = CGPointMake(theLocation.x, self._frame.size.height),
+    var constrainedLocation = CGPointMake(theLocation.x, CGRectGetMaxY([self frame])),
         constrainedEvent = [CPEvent mouseEventWithType:CPLeftMouseDragged
                                              location:[self convertPoint:constrainedLocation toView:nil]
                                         modifierFlags:[theEvent modifierFlags]


### PR DESCRIPTION
Say you have a table with 50 rows. Scroll your table until you see row 30 on top of the visible rect like this :

![bug1](https://user-images.githubusercontent.com/2394110/44287851-a699ce00-a26e-11e8-8ca4-5ebfc2bb8cd3.png)

Then start dragging a column left or right.

Your table will automatically scroll down until reaching the last row like this : 

![bug2](https://user-images.githubusercontent.com/2394110/44287938-ebbe0000-a26e-11e8-9d25-5513d99c32d6.png)

The problem is in the way used to constrain the drag of the column to avoid autoscroll vertically.
The bug here is in the method `[view convertPoint:aPoint toView:aView]` : `aPoint` should be in the coordinate system of view and it is not.

This PR fixes this by always setting the vertical coordinate to the height of the header. This way, mouse is considered at the very top of the visible rect and starts then no autoscroll.