### PR TITLE
FIXED: Before this PR, when dragging a partially masked column, the dragged view was truncated

### DIFF
--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -3154,7 +3154,7 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
     // Now a view that clips the column data views, which itself is clipped to the content view
     var columnVisRect = CGRectIntersection(columnRect, visibleRect);
 
-    frame = CGRectMake(0.0, CGRectGetHeight(headerFrame), CGRectGetWidth(columnRect), CGRectGetHeight(columnRect));
+    frame = CGRectMake(0.0, CGRectGetHeight(headerFrame), CGRectGetWidth(columnRect), CGRectGetHeight(columnVisRect));
 
     var columnClipView = [[CPView alloc] initWithFrame:frame];
 

--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -3154,7 +3154,7 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
     // Now a view that clips the column data views, which itself is clipped to the content view
     var columnVisRect = CGRectIntersection(columnRect, visibleRect);
 
-    frame = CGRectMake(0.0, CGRectGetHeight(headerFrame), CGRectGetWidth(columnVisRect), CGRectGetHeight(columnVisRect));
+    frame = CGRectMake(0.0, CGRectGetHeight(headerFrame), CGRectGetWidth(columnRect), CGRectGetHeight(columnRect));
 
     var columnClipView = [[CPView alloc] initWithFrame:frame];
 


### PR DESCRIPTION
Say you have a CPTableView with 3 columns, the rightmost one being partially masked like this : 

![bug1](https://user-images.githubusercontent.com/2394110/44288658-5ff9a300-a271-11e8-92a2-934c95b41ef0.png)

When you drag this column, the dragged view (or ghost view) is clipped : 

![bug2](https://user-images.githubusercontent.com/2394110/44288702-7ef83500-a271-11e8-92c8-d8a25ee498bc.png)

This PR fixes this by using columnRect width instead of columnVisRect width.