### PR TITLE
FIXED: Before this PR, when dragging a selected column, selection color remained in place (visual artefact)

### DIFF
--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -3189,6 +3189,7 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
 
     // While dragging, the column is deselected in the table view
     [_selectedColumnIndexes removeIndex:columnIndex];
+    [self setNeedsDisplay:YES];
 
     return dragView;
 }


### PR DESCRIPTION
Say you have a table with a selected column, like : 

![bug1](https://user-images.githubusercontent.com/2394110/44289526-e95ea480-a274-11e8-9e2f-48b114cade04.png)

If you start dragging this column, the selection color remains on the freed space : 

![bug2](https://user-images.githubusercontent.com/2394110/44289545-06937300-a275-11e8-9444-78ce2bd1f1af.png)

This is because, when creating the dragged view (or ghost view), the "will be dragged" column was indeed unselected but without any refresh of the display.

This PR fixes this by simply adding a setNeedsDisplay:YES.