### PR TITLE
FIXED: Before this PR, when an unfocused selected column was dragged, focused selection color was used

### DIFF
--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -6368,7 +6368,7 @@ var CPTableViewDataSourceKey                = @"CPTableViewDataSourceKey",
 
     if (tableView._draggedColumnIsSelected)
     {
-        CGContextSetFillColor(context, [tableView selectionHighlightColor]);
+        CGContextSetFillColor(context, [tableView _isFocused] ? [tableView selectionHighlightColor] : [tableView unfocusedSelectionHighlightColor]);
         CGContextFillRect(context, bounds);
     }
     else


### PR DESCRIPTION
Unfocused selected column should draw in unfocused selection color (gray). Before this, when dragging the column, it was using the focused selection color (blue), then returned to gray when drag ended.

This was due to an unconditional use of selectionHighlightColor.

This PR fixes this by conditionally using selectionHightlightColor or unfocusedSelectionHighlightColor.