### PR TITLE
FIXED: Before this PR, Nib2Cib wasn't using theme attribute "header-view-height"

### DIFF
--- a/Tools/nib2cib/NSTableHeaderView.j
+++ b/Tools/nib2cib/NSTableHeaderView.j
@@ -38,7 +38,7 @@
         if (_bounds.size.height === 17)
         {
             var theme = [Nib2Cib defaultTheme],
-                height = [theme valueForAttributeWithName:@"header-view-height" forClass:CPTableView] ? [theme valueForAttributeWithName:@"header-view-height" forClass:CPTableView] : [theme valueForAttributeWithName:@"default-row-height" forClass:CPTableView];
+                height = [theme valueForAttributeWithName:@"header-view-height" forClass:CPTableView];
 
             _bounds.size.height = height;
             _frame.size.height = height;

--- a/Tools/nib2cib/NSTableHeaderView.j
+++ b/Tools/nib2cib/NSTableHeaderView.j
@@ -38,7 +38,7 @@
         if (_bounds.size.height === 17)
         {
             var theme = [Nib2Cib defaultTheme],
-                height = [theme valueForAttributeWithName:@"default-row-height" forClass:CPTableView];
+                height = [theme valueForAttributeWithName:@"header-view-height" forClass:CPTableView] ? [theme valueForAttributeWithName:@"header-view-height" forClass:CPTableView] : [theme valueForAttributeWithName:@"default-row-height" forClass:CPTableView];
 
             _bounds.size.height = height;
             _frame.size.height = height;


### PR DESCRIPTION
Nib2Cib was forcing the header view height to the default-row-height attribute.

With this PR, if a header-view-height attribute value exists, Nib2Cib uses it. If not, Nib2Cib uses default-row-height attribute value, as before.