### PR TITLE
FIXED: Support for CPLineBreakMode in editing mode

### DIFF
--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -273,7 +273,7 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
         CPTextFieldDOMStandardInputElement.style.border     = "0px";
         CPTextFieldDOMStandardInputElement.style.padding    = "0px";
         CPTextFieldDOMStandardInputElement.style.margin     = "0px";
-        CPTextFieldDOMStandardInputElement.style.whiteSpace = "pre";
+        CPTextFieldDOMStandardInputElement.style.whiteSpace = "pre-wrap";
         CPTextFieldDOMStandardInputElement.style.background = "transparent";
         CPTextFieldDOMStandardInputElement.style.outline    = "none";
         CPTextFieldDOMStandardInputElement.spellcheck       = NO;
@@ -286,7 +286,7 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
         CPTextFieldDOMPasswordInputElement.style.border     = "0px";
         CPTextFieldDOMPasswordInputElement.style.padding    = "0px";
         CPTextFieldDOMPasswordInputElement.style.margin     = "0px";
-        CPTextFieldDOMPasswordInputElement.style.whiteSpace = "pre";
+        CPTextFieldDOMPasswordInputElement.style.whiteSpace = "pre-wrap";
         CPTextFieldDOMPasswordInputElement.style.background = "transparent";
         CPTextFieldDOMPasswordInputElement.style.outline    = "none";
         CPTextFieldDOMPasswordInputElement.type             = "password";
@@ -791,7 +791,7 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
     element.style.font          = [font cssString];
 
     if (isTextArea)
-        element.style.whiteSpace = _wraps ? "pre" : "nowrap";
+        element.style.whiteSpace = _wraps ? "pre-wrap" : "nowrap";
 
 #endif
 }

--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -273,7 +273,7 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
         CPTextFieldDOMStandardInputElement.style.border     = "0px";
         CPTextFieldDOMStandardInputElement.style.padding    = "0px";
         CPTextFieldDOMStandardInputElement.style.margin     = "0px";
-        CPTextFieldDOMStandardInputElement.style.whiteSpace = "pre-wrap";
+        CPTextFieldDOMStandardInputElement.style.whiteSpace = "pre";
         CPTextFieldDOMStandardInputElement.style.background = "transparent";
         CPTextFieldDOMStandardInputElement.style.outline    = "none";
         CPTextFieldDOMStandardInputElement.spellcheck       = NO;
@@ -286,7 +286,7 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
         CPTextFieldDOMPasswordInputElement.style.border     = "0px";
         CPTextFieldDOMPasswordInputElement.style.padding    = "0px";
         CPTextFieldDOMPasswordInputElement.style.margin     = "0px";
-        CPTextFieldDOMPasswordInputElement.style.whiteSpace = "pre-wrap";
+        CPTextFieldDOMPasswordInputElement.style.whiteSpace = "pre";
         CPTextFieldDOMPasswordInputElement.style.background = "transparent";
         CPTextFieldDOMPasswordInputElement.style.outline    = "none";
         CPTextFieldDOMPasswordInputElement.type             = "password";
@@ -791,7 +791,48 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
     element.style.font          = [font cssString];
 
     if (isTextArea)
-        element.style.whiteSpace = _wraps ? "pre-wrap" : "nowrap";
+    {
+        switch ([self lineBreakMode])
+        {
+            case CPLineBreakByClipping:
+                element.style.overflow = "hidden";
+                element.style.textOverflow = "clip";
+                element.style.whiteSpace = "pre";
+                element.style.wordWrap = "normal";
+                break;
+
+            case CPLineBreakByTruncatingHead:
+            case CPLineBreakByTruncatingMiddle: // Don't have support for these (yet?), so just degrade to truncating tail.
+            case CPLineBreakByTruncatingTail:
+                element.style.textOverflow = "ellipsis";
+                element.style.whiteSpace = "pre";
+                element.style.overflow = "hidden";
+                element.style.wordWrap = "normal";
+                break;
+
+            case CPLineBreakByCharWrapping:
+            case CPLineBreakByWordWrapping:
+                element.style.wordWrap = "break-word";
+                try
+                {
+                    element.style.whiteSpace = "pre";
+                    element.style.whiteSpace = "-o-pre-wrap";
+                    element.style.whiteSpace = "-pre-wrap";
+                    element.style.whiteSpace = "-moz-pre-wrap";
+                    element.style.whiteSpace = "pre-wrap";
+                }
+                catch (e)
+                {
+                    //internet explorer doesn't like these properties
+                    element.style.whiteSpace = "pre";
+                }
+                element.style.overflow = "hidden";
+                element.style.textOverflow = "clip";
+                break;
+        }
+    }
+    else
+        element.style.whiteSpace = "nowrap";
 
 #endif
 }

--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -791,46 +791,7 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
     element.style.font          = [font cssString];
 
     if (isTextArea)
-    {
-        switch ([self lineBreakMode])
-        {
-            case CPLineBreakByClipping:
-                element.style.overflow = "hidden";
-                element.style.textOverflow = "clip";
-                element.style.whiteSpace = "pre";
-                element.style.wordWrap = "normal";
-                break;
-
-            case CPLineBreakByTruncatingHead:
-            case CPLineBreakByTruncatingMiddle: // Don't have support for these (yet?), so just degrade to truncating tail.
-            case CPLineBreakByTruncatingTail:
-                element.style.textOverflow = "ellipsis";
-                element.style.whiteSpace = "pre";
-                element.style.overflow = "hidden";
-                element.style.wordWrap = "normal";
-                break;
-
-            case CPLineBreakByCharWrapping:
-            case CPLineBreakByWordWrapping:
-                element.style.wordWrap = "break-word";
-                try
-                {
-                    element.style.whiteSpace = "pre";
-                    element.style.whiteSpace = "-o-pre-wrap";
-                    element.style.whiteSpace = "-pre-wrap";
-                    element.style.whiteSpace = "-moz-pre-wrap";
-                    element.style.whiteSpace = "pre-wrap";
-                }
-                catch (e)
-                {
-                    //internet explorer doesn't like these properties
-                    element.style.whiteSpace = "pre";
-                }
-                element.style.overflow = "hidden";
-                element.style.textOverflow = "clip";
-                break;
-        }
-    }
+        element.style.whiteSpace = _wraps ? "pre-wrap" : "nowrap";
     else
         element.style.whiteSpace = "nowrap";
 

--- a/Foundation/CPAttributedString.j
+++ b/Foundation/CPAttributedString.j
@@ -27,6 +27,8 @@
 @import "CPRange.j"
 @import "CPString.j"
 
+CPAttachmentCharacter = "\ufffc";
+
 /*!
     @class CPAttributedString
     @ingroup foundation
@@ -767,6 +769,11 @@
     {
         return copyRangeEntry(entry);
     }];
+}
+
++ (CPAttributedString)attributedStringWithAttachment//(CPTextAttachment)attachment
+{
+    return [self initWithString:CPAttachmentCharacter];
 }
 
 //Private methods

--- a/Foundation/CPAttributedString.j
+++ b/Foundation/CPAttributedString.j
@@ -27,8 +27,6 @@
 @import "CPRange.j"
 @import "CPString.j"
 
-CPAttachmentCharacter = "\ufffc";
-
 /*!
     @class CPAttributedString
     @ingroup foundation
@@ -769,11 +767,6 @@ CPAttachmentCharacter = "\ufffc";
     {
         return copyRangeEntry(entry);
     }];
-}
-
-+ (CPAttributedString)attributedStringWithAttachment//(CPTextAttachment)attachment
-{
-    return [self initWithString:CPAttachmentCharacter];
 }
 
 //Private methods


### PR DESCRIPTION
Pull request following on issue #2708.

Changing the values for "whiteSpace" from pre to pre-wrap seems to fix the problem for me. Don't really understand why the lines in the CPTableView where wrapping correctly when displayed but not edited.

- pre | Whitespace is preserved by the browser. Text will only wrap on line breaks. Acts like the pre tag in HTML
- pre-wrap | Whitespace is preserved by the browser. Text will wrap when necessary, and on line breaks

The fix appears to only work when using the method [textField _setWraps:YES];