### PR TITLE
Update XcodeCapp code and Jakefile to install properly and launch wit…

### DIFF
--- a/Tools/XcodeCapp/Jakefile
+++ b/Tools/XcodeCapp/Jakefile
@@ -44,14 +44,14 @@ task ("build", function()
 
     if (executableExists("xcodebuild"))
     {
-        var args = "-sdk macosx -alltargets -configuration Release",
-            installPath = FILE.join("/", "Applications", applicationName);
+        var args = installPath = FILE.join("/", "Applications", applicationName);
 
-        // Remove an old symlink, the application is built directly into /Applications now.
+        // Remove old symlink, if present.
+		//The application is now built directly into /Applications
         if (FILE.isLink(installPath))
             FILE.remove(installPath);
 
-        if (OS.system("xcodebuild " + args))
+		if (!OS.system("xcodebuild install"))
             colorPrint("Unable to build XcodeCapp. Skipping", "orange");
     }
     else

--- a/Tools/XcodeCapp/XcodeCapp.xcodeproj/project.pbxproj
+++ b/Tools/XcodeCapp/XcodeCapp.xcodeproj/project.pbxproj
@@ -516,6 +516,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DSTROOT = /;
 				INFOPLIST_FILE = XcodeCapp/Info.plist;
+				INSTALL_PATH = "$(LOCAL_APPS_DIR)";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -530,6 +531,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DSTROOT = /;
 				INFOPLIST_FILE = XcodeCapp/Info.plist;
+				INSTALL_PATH = "$(LOCAL_APPS_DIR)";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Tools/XcodeCapp/XcodeCapp/Base.lproj/MainMenu.xib
+++ b/Tools/XcodeCapp/XcodeCapp/Base.lproj/MainMenu.xib
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14313.13.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
-        <development version="6300" identifier="xcode"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14313.13.2"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -375,10 +375,10 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" drawsBackground="NO" id="Zlj-Y5-TaS">
                                             <rect key="frame" x="0.0" y="0.0" width="263" height="634"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <tableView appearanceType="vibrantLight" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="72" rowSizeStyle="automatic" viewBased="YES" id="Mss-Tu-7kR">
-                                                    <rect key="frame" x="0.0" y="0.0" width="263" height="0.0"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="263" height="634"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                     <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
@@ -409,22 +409,19 @@
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                        <box autoresizesSubviews="NO" borderWidth="0.0" cornerRadius="100" title="Box" boxType="custom" borderType="line" titlePosition="noTitle" id="kpw-qm-NQG">
+                                                                        <box autoresizesSubviews="NO" boxType="custom" borderType="line" borderWidth="0.0" cornerRadius="100" title="Box" titlePosition="noTitle" id="kpw-qm-NQG">
                                                                             <rect key="frame" x="5" y="52" width="10" height="10"/>
                                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <view key="contentView">
+                                                                            <view key="contentView" id="S9K-TP-K5A">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="10" height="10"/>
                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                             </view>
                                                                             <color key="borderColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                                             <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                                                         </box>
-                                                                        <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="MsY-oY-iIn">
+                                                                        <box verticalHuggingPriority="750" boxType="separator" id="MsY-oY-iIn">
                                                                             <rect key="frame" x="-12" y="-2" width="279" height="5"/>
                                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                                                                            <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                                                                            <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                                                            <font key="titleFont" metaFont="system"/>
                                                                         </box>
                                                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="PN4-Zx-XTz">
                                                                             <rect key="frame" x="17" y="36" width="223" height="11"/>
@@ -533,10 +530,10 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                     </scrollView>
-                                    <box autoresizesSubviews="NO" transparent="YES" title="Box" boxType="custom" borderType="line" titlePosition="noTitle" id="atN-bp-ONR">
+                                    <box autoresizesSubviews="NO" boxType="custom" borderType="line" title="Box" titlePosition="noTitle" transparent="YES" id="atN-bp-ONR">
                                         <rect key="frame" x="0.0" y="0.0" width="263" height="32"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                                        <view key="contentView">
+                                        <view key="contentView" id="lgd-3C-ZcF">
                                             <rect key="frame" x="1" y="1" width="261" height="30"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
@@ -582,19 +579,16 @@
                                         <rect key="frame" x="0.0" y="0.0" width="599" height="634"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <subviews>
-                                            <box autoresizesSubviews="NO" borderWidth="0.0" title="Box" boxType="custom" borderType="line" titlePosition="noTitle" id="SrB-rO-09w">
+                                            <box autoresizesSubviews="NO" boxType="custom" borderType="line" borderWidth="0.0" title="Box" titlePosition="noTitle" id="SrB-rO-09w">
                                                 <rect key="frame" x="0.0" y="588" width="615" height="46"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
-                                                <view key="contentView">
+                                                <view key="contentView" id="98G-pQ-oIM">
                                                     <rect key="frame" x="0.0" y="0.0" width="615" height="46"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
-                                                        <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="QMT-Ui-fxI">
+                                                        <box verticalHuggingPriority="750" boxType="separator" id="QMT-Ui-fxI">
                                                             <rect key="frame" x="-1" y="-3" width="613" height="5"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                                                            <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                                                            <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                                            <font key="titleFont" metaFont="system"/>
                                                         </box>
                                                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" id="krM-95-waf">
                                                             <rect key="frame" x="14" y="24" width="580" height="17"/>
@@ -625,10 +619,10 @@
                                                 <color key="borderColor" red="0.96862745098039216" green="0.50588235294117645" blue="0.16470588235294117" alpha="1" colorSpace="calibratedRGB"/>
                                                 <color key="fillColor" red="0.34509803921568627" green="0.34509803921568627" blue="0.34509803921568627" alpha="1" colorSpace="calibratedRGB"/>
                                             </box>
-                                            <box autoresizesSubviews="NO" borderWidth="0.0" title="Box" boxType="custom" borderType="line" id="ic3-Xg-i5j">
+                                            <box autoresizesSubviews="NO" boxType="custom" borderType="line" borderWidth="0.0" title="Box" id="ic3-Xg-i5j">
                                                 <rect key="frame" x="0.0" y="562" width="599" height="26"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
-                                                <view key="contentView">
+                                                <view key="contentView" id="Tuy-VW-JIc">
                                                     <rect key="frame" x="0.0" y="0.0" width="599" height="26"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
@@ -680,12 +674,9 @@
                                                                 <action selector="updateSelectedTab:" target="923-ke-ovW" id="V56-Vq-dcX"/>
                                                             </connections>
                                                         </button>
-                                                        <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="0Lp-Tm-YXi">
+                                                        <box verticalHuggingPriority="750" boxType="separator" id="0Lp-Tm-YXi">
                                                             <rect key="frame" x="0.0" y="-2" width="599" height="5"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                                                            <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                                                            <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                                            <font key="titleFont" metaFont="system"/>
                                                         </box>
                                                     </subviews>
                                                 </view>
@@ -696,7 +687,6 @@
                                                 <rect key="frame" x="0.0" y="0.0" width="599" height="562"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <font key="font" metaFont="system"/>
-                                                <tabViewItems/>
                                                 <connections>
                                                     <outlet property="delegate" destination="923-ke-ovW" id="A2n-ft-vRP"/>
                                                 </connections>
@@ -721,7 +711,7 @@
             </connections>
             <point key="canvasLocation" x="244.5" y="112"/>
         </window>
-        <window title="About" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="EMp-Db-uhU" customClass="NSPanel">
+        <window title="About" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="EMp-Db-uhU" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <rect key="contentRect" x="196" y="240" width="296" height="191"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
@@ -738,18 +728,6 @@
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField verticalHuggingPriority="750" id="vIx-Hh-v8Z">
-                        <rect key="frame" x="117" y="42" width="63" height="14"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Version 4.0" id="WUW-Ut-m7V">
-                            <font key="font" metaFont="smallSystem"/>
-                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                        <connections>
-                            <binding destination="Voe-Tx-rLC" name="value" keyPath="self.version" id="Nfs-HY-nea"/>
-                        </connections>
-                    </textField>
                     <textField verticalHuggingPriority="750" id="IH1-cn-Xc9">
                         <rect key="frame" x="18" y="20" width="260" height="14"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
@@ -764,12 +742,24 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="logo" id="zF2-py-kAi"/>
                     </imageView>
+                    <textField verticalHuggingPriority="750" id="vIx-Hh-v8Z">
+                        <rect key="frame" x="108" y="42" width="81" height="14"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Version 4.0" id="WUW-Ut-m7V">
+                            <font key="font" metaFont="smallSystem"/>
+                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                        <connections>
+                            <binding destination="Voe-Tx-rLC" name="value" keyPath="self.version" id="Nfs-HY-nea"/>
+                        </connections>
+                    </textField>
                 </subviews>
             </view>
             <point key="canvasLocation" x="-218" y="94.5"/>
         </window>
         <userDefaultsController representsSharedInstance="YES" id="GHK-nR-IEq" userLabel="User Defaults Controller"/>
-        <window title="XcodeCapp Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" frameAutosaveName="xcc-prefs" animationBehavior="default" id="ekp-cc-W2F">
+        <window title="XcodeCapp Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="xcc-prefs" animationBehavior="default" id="ekp-cc-W2F">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES"/>
             <rect key="contentRect" x="534" y="231" width="357" height="132"/>
@@ -838,10 +828,10 @@
             </view>
             <point key="canvasLocation" x="-156.5" y="-126"/>
         </window>
-        <box borderWidth="0.0" title="Box" boxType="custom" borderType="line" titlePosition="noTitle" id="fYW-ua-i1m">
+        <box boxType="custom" borderType="line" borderWidth="0.0" title="Box" titlePosition="noTitle" id="fYW-ua-i1m">
             <rect key="frame" x="0.0" y="0.0" width="271" height="313"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <view key="contentView">
+            <view key="contentView" id="oa8-a7-MJz">
                 <rect key="frame" x="0.0" y="0.0" width="271" height="313"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
@@ -883,10 +873,10 @@
             <color key="fillColor" red="0.98039221759999995" green="0.98039221759999995" blue="0.98039221759999995" alpha="1" colorSpace="deviceRGB"/>
             <point key="canvasLocation" x="310.5" y="-302.5"/>
         </box>
-        <box borderWidth="0.0" title="Box" boxType="custom" borderType="line" titlePosition="noTitle" id="stz-Vu-tYo" customClass="XCCWelcomeView">
+        <box boxType="custom" borderType="line" borderWidth="0.0" title="Box" titlePosition="noTitle" id="stz-Vu-tYo" customClass="XCCWelcomeView">
             <rect key="frame" x="0.0" y="0.0" width="464" height="401"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <view key="contentView">
+            <view key="contentView" id="zK0-DV-DoN">
                 <rect key="frame" x="0.0" y="0.0" width="464" height="401"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
@@ -894,17 +884,14 @@
                         <rect key="frame" x="15" y="16" width="434" height="369"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                         <subviews>
-                            <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="FVR-yM-GAZ">
+                            <box verticalHuggingPriority="750" boxType="separator" id="FVR-yM-GAZ">
                                 <rect key="frame" x="40" y="116" width="354" height="5"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
-                                <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                                <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                <font key="titleFont" metaFont="system"/>
                             </box>
-                            <box autoresizesSubviews="NO" cornerRadius="100" title="Box" boxType="custom" borderType="line" titlePosition="noTitle" id="Tbj-mM-87j">
+                            <box autoresizesSubviews="NO" boxType="custom" borderType="line" cornerRadius="100" title="Box" titlePosition="noTitle" id="Tbj-mM-87j">
                                 <rect key="frame" x="189" y="28" width="57" height="57"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
-                                <view key="contentView">
+                                <view key="contentView" id="aoX-nH-ofv">
                                     <rect key="frame" x="1" y="1" width="55" height="55"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>

--- a/Tools/XcodeCapp/XcodeCapp/Info.plist
+++ b/Tools/XcodeCapp/XcodeCapp/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSUserNotificationAlertStyle</key>
-	<string>alert</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDocumentTypes</key>
@@ -36,7 +34,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>Version 4.0</string>
+	<string>Version 4.0.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
@@ -51,6 +49,8 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSUserNotificationAlertStyle</key>
+	<string>alert</string>
 	<key>XCCCompatibilityVersion</key>
 	<string>4</string>
 	<key>XCCLastCappuccinoMasterBranchURL</key>

--- a/Tools/XcodeCapp/XcodeCapp/YRKSpinningProgressIndicator.m
+++ b/Tools/XcodeCapp/XcodeCapp/YRKSpinningProgressIndicator.m
@@ -66,6 +66,7 @@ const NSTimeInterval kFadeOutTime = 0.7;  // seconds
     _indeterminate = YES;
     _currentValue = 0.0;
     _maxValue = 100.0;
+    _usesThreadedAnimation = NO; // YES crashes on launch when compiled with Xcode 10 beta 6
 }
 
 #pragma mark - NSView overrides


### PR DESCRIPTION
…hout crashing when built with Xcode 10/ macOSSDK10.14

Disable YRKSpinningProgressIndicator threaded animation (causing immediate crash on launch since Xcode 10 beta 6).
Simplify Jakefile build process to 'xcodebuild install' to avoid permissions problems when building (still requires sudo when using Cappuccino defaults).
Increment version number to 4.0.1 to reflect minor nature of change.
Update About window version number field to fully display and properly align longer version numbers.