### PR TITLE
Update XcodeCapp copyright notice in 'About' window

### DIFF
--- a/Tools/XcodeCapp/XcodeCapp/AppDelegate.h
+++ b/Tools/XcodeCapp/XcodeCapp/AppDelegate.h
@@ -28,6 +28,7 @@
 @property IBOutlet  XCCMainController       *mainWindowController;
 @property NSOperationQueue                  *mainOperationQueue;
 @property NSString                          *version;
+@property NSString                          *copyright;
 
 - (IBAction)openAbout:(id)aSender;
 - (IBAction)openPreferences:(id)aSender;

--- a/Tools/XcodeCapp/XcodeCapp/AppDelegate.m
+++ b/Tools/XcodeCapp/XcodeCapp/AppDelegate.m
@@ -98,6 +98,8 @@
     NSLog(@"\n******************************\n**    XcodeCapp started     **\n******************************\n");
 
     self.version = [NSBundle mainBundle].infoDictionary[@"CFBundleShortVersionString"];
+    NSString *copyrightString = [NSBundle mainBundle].infoDictionary[@"NSHumanReadableCopyright"];
+    self.copyright = [NSString stringWithFormat:@"%@\nAll rights reserved", copyrightString];
 
     [self _initUserDefaults];
     [self _initOperationQueue];

--- a/Tools/XcodeCapp/XcodeCapp/Base.lproj/MainMenu.xib
+++ b/Tools/XcodeCapp/XcodeCapp/Base.lproj/MainMenu.xib
@@ -350,6 +350,7 @@
                     </menu>
                 </menuItem>
             </items>
+            <point key="canvasLocation" x="-225" y="-276"/>
         </menu>
         <window title="XcodeCapp" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="main-window" animationBehavior="default" id="QvC-M9-y7g">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
@@ -713,39 +714,30 @@
         </window>
         <window title="About" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="EMp-Db-uhU" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
-            <rect key="contentRect" x="196" y="240" width="296" height="191"/>
+            <rect key="contentRect" x="196" y="240" width="324" height="200"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
             <view key="contentView" id="dj4-iP-S2b">
-                <rect key="frame" x="0.0" y="0.0" width="296" height="191"/>
+                <rect key="frame" x="0.0" y="0.0" width="324" height="200"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="3j4-r5-Ybe">
-                        <rect key="frame" x="74" y="64" width="149" height="17"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <rect key="frame" x="88" y="73" width="149" height="17"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="XcodeCapp" id="qvL-bN-A9R">
                             <font key="font" metaFont="systemBold" size="15"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField verticalHuggingPriority="750" id="IH1-cn-Xc9">
-                        <rect key="frame" x="18" y="20" width="260" height="14"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Copyright © 2012-2016 Cappuccino Project." id="8lT-Ky-ecV">
-                            <font key="font" metaFont="smallSystem"/>
-                            <color key="textColor" white="0.5" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
-                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                    </textField>
                     <imageView id="Q2t-aL-TDg">
-                        <rect key="frame" x="107" y="89" width="82" height="82"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <rect key="frame" x="121" y="98" width="82" height="82"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="logo" id="zF2-py-kAi"/>
                     </imageView>
                     <textField verticalHuggingPriority="750" id="vIx-Hh-v8Z">
-                        <rect key="frame" x="108" y="42" width="81" height="14"/>
+                        <rect key="frame" x="18" y="51" width="288" height="14"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Version 4.0" id="WUW-Ut-m7V">
+                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Value from Info.plist displayed using bindings" id="WUW-Ut-m7V">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -754,9 +746,21 @@
                             <binding destination="Voe-Tx-rLC" name="value" keyPath="self.version" id="Nfs-HY-nea"/>
                         </connections>
                     </textField>
+                    <textField verticalHuggingPriority="750" textCompletion="NO" id="IH1-cn-Xc9">
+                        <rect key="frame" x="18" y="0.0" width="292" height="43"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" controlSize="small" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="Set in Info.plist, displayed using bindings" id="8lT-Ky-ecV">
+                            <font key="font" metaFont="smallSystem"/>
+                            <color key="textColor" white="0.5" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                        <connections>
+                            <binding destination="Voe-Tx-rLC" name="value" keyPath="self.copyright" id="cHX-2a-APu"/>
+                        </connections>
+                    </textField>
                 </subviews>
             </view>
-            <point key="canvasLocation" x="-218" y="94.5"/>
+            <point key="canvasLocation" x="-304" y="-20"/>
         </window>
         <userDefaultsController representsSharedInstance="YES" id="GHK-nR-IEq" userLabel="User Defaults Controller"/>
         <window title="XcodeCapp Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="xcc-prefs" animationBehavior="default" id="ekp-cc-W2F">
@@ -826,7 +830,7 @@
                     </textField>
                 </subviews>
             </view>
-            <point key="canvasLocation" x="-156.5" y="-126"/>
+            <point key="canvasLocation" x="136" y="-20"/>
         </window>
         <box boxType="custom" borderType="line" borderWidth="0.0" title="Box" titlePosition="noTitle" id="fYW-ua-i1m">
             <rect key="frame" x="0.0" y="0.0" width="271" height="313"/>

--- a/Tools/XcodeCapp/XcodeCapp/Info.plist
+++ b/Tools/XcodeCapp/XcodeCapp/Info.plist
@@ -34,7 +34,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>Version 4.0.1</string>
+	<string>Version 4.0.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
@@ -44,7 +44,7 @@
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2012-2017 Cappuccino Project. All rights reserved.</string>
+	<string>Copyright © 2012-2018 Cappuccino Project</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
* Use copyright string from Info.plist
    (was previously hard-coded in About window, despite also being set in Info.plist).
* Create copyright property on AppDelegate.
* Append 'All rights reserved' in code, remove from Info.plist value
    (make line breaking in About window easier to manage, ease localization, ease automated checking of copyright dates.)
* Display copyright notice using bindings.
* Resize copyright field to prevent truncated text.
* Set resize masks for all window fields - not currently set.
* Resize window to golden ratio for improved visual presentation.