### PR TITLE
fixed: smart copy/paste cycle was leaving an additional whitespace on the LHS

### DIFF
--- a/AppKit/CPTextView/CPTextView.j
+++ b/AppKit/CPTextView/CPTextView.j
@@ -450,12 +450,20 @@ var kDelegateRespondsTo_textShouldBeginEditing                                  
 
     var shouldUseSmartPasting = [self _shouldUseSmartPasting];
 
-    if (shouldUseSmartPasting && _selectionRange.location > 0)
+    if (shouldUseSmartPasting)
     {
-        if (!_isWhitespaceCharacter([[_textStorage string] characterAtIndex:_selectionRange.location - 1]) &&
-            _selectionRange.location != [_layoutManager numberOfCharacters])
+        if (_isWhitespaceCharacter([[stringForPasting string] characterAtIndex:0]))
         {
-            [self insertText:" "];
+            if (_selectionRange.location == 0 ||
+                _isWhitespaceCharacter([[_textStorage string] characterAtIndex:_selectionRange.location - 1]) &&
+                _selectionRange.location != [_layoutManager numberOfCharacters])
+                [stringForPasting deleteCharactersInRange:CPMakeRange(0, 1)];
+        }
+        else
+        {
+            if (_selectionRange.location > 0 &
+                !_isWhitespaceCharacter([[_textStorage string] characterAtIndex:_selectionRange.location - 1]))
+                [self insertText:" "];
         }
     }
 


### PR DESCRIPTION
previously, the whitespace on the pasteboard was not taken into account when preparing the smart paste.
this is corrected by this PR.
the bug was exposed on cappcon 2018 during the live demo ;-)