### PR TITLE
fixed: typo in function call to _CPDecimalSetZero

### DIFF
--- a/Foundation/CPDecimal.j
+++ b/Foundation/CPDecimal.j
@@ -941,7 +941,7 @@ function CPDecimalDivide(result, leftOperand, rightOperand, roundingMode)
 
         if (result._exponent + exp < CPDecimalMinExponent)
         {
-            CPDecimalSetZero(result);
+            _CPDecimalSetZero(result);
             return error;
         }
     }

--- a/Tests/Foundation/CPDecimalNumberTest.j
+++ b/Tests/Foundation/CPDecimalNumberTest.j
@@ -291,6 +291,7 @@
 
     // underflow  , if dcnm2 is < 10 this is LossOfPrecision, is this correct? check vs cocoa.
     dcmn1 = [CPDecimalNumber decimalNumberWithString:@"-1e-128"];
+    dcmn1._raiseOnExactness = YES;
     dcmn2 = [CPDecimalNumber decimalNumberWithString:@"10"];
 
     try

--- a/Tests/Foundation/CPDecimalNumberTest.j
+++ b/Tests/Foundation/CPDecimalNumberTest.j
@@ -291,12 +291,16 @@
 
     // underflow  , if dcnm2 is < 10 this is LossOfPrecision, is this correct? check vs cocoa.
     dcmn1 = [CPDecimalNumber decimalNumberWithString:@"-1e-128"];
-    dcmn1._raiseOnExactness = YES;
     dcmn2 = [CPDecimalNumber decimalNumberWithString:@"10"];
 
     try
     {
-        dcmn3 = [dcmn1 decimalNumberByDividingBy:dcmn2];
+        dcmn3 = [dcmn1 decimalNumberByDividingBy:dcmn2
+                                    withBehavior:[CPDecimalNumberHandler decimalNumberHandlerWithRoundingMode:CPRoundPlain scale:0
+                                                                                             raiseOnExactness:YES
+                                                                                              raiseOnOverflow:YES
+                                                                                             raiseOnUnderflow:YES
+                                                                                          raiseOnDivideByZero:YES]];
         [self fail:"decimalNumberByDividingBy: TEX3 - should have thrown underflow error "];
     }
     catch (e)


### PR DESCRIPTION
previously, the code in CPDecimalDivide called a nonexistant function under certain conditions.
this is fixed by this PR
fixes #2818 