### PR TITLE
Fixed: If sourcemap is available include it when building with a nondebug version of the tools.

### DIFF
--- a/Objective-J/Executable.js
+++ b/Objective-J/Executable.js
@@ -231,7 +231,6 @@ Executable.prototype.setCode = function(code, sourceMap)
     else
     {
 #endif
-#if DEBUG
         // Check if base64 source map is available
         sourceMapBase64 = this._base64EncodedSourceMap;
 
@@ -265,11 +264,8 @@ Executable.prototype.setCode = function(code, sourceMap)
     //    var functionText = "(function(){"+GET_CODE(aFragment)+"/**/\n})\n//# sourceURL="+GET_FILE(aFragment).path;
     //    compiled = eval(functionText);
     //}
-#endif
         this._function = new Function(parameters, code);
-#if DEBUG
-    this._function.displayName = absoluteString;
-#endif
+        this._function.displayName = absoluteString;
 #if COMMONJS
     }
 #endif


### PR DESCRIPTION
The sourcemap was not included when building from command line with the release (the default) version of the tools. This results in compiled code without the source map included for debug