### PR TITLE
New: msgSend will return undefined instead of nil when the receiver is undefined [+1]

### DIFF
--- a/AppKit/CPBrowser.j
+++ b/AppKit/CPBrowser.j
@@ -463,7 +463,7 @@ var CPBrowserDelegate_browser_acceptDrop_atRow_column_dropOperation_            
 
 - (id)itemAtRow:(CPInteger)row inColumn:(CPInteger)column
 {
-    return [_tableDelegates[column] childAtIndex:row];
+    return [_tableDelegates[column] childAtIndex:row] || nil;
 }
 
 - (BOOL)isLeafItem:(id)item
@@ -473,7 +473,7 @@ var CPBrowserDelegate_browser_acceptDrop_atRow_column_dropOperation_            
 
 - (id)parentForItemsInColumn:(CPInteger)column
 {
-    return [_tableDelegates[column] _item];
+    return [_tableDelegates[column] _item] || nil;
 }
 
 - (CPSet)selectedItems

--- a/Objective-J/ObjJAcornCompiler.js
+++ b/Objective-J/ObjJAcornCompiler.js
@@ -2447,7 +2447,9 @@ ArrayLiteral: function(node, st, c) {
             buffer.concat(++st.receiverLevel + "");
             buffer.concat(" = (CPArray.isa.method_msgSend[\"alloc\"] || _objj_forward)(CPArray, \"alloc\"), ___r");
             buffer.concat(st.receiverLevel + "");
-            buffer.concat(" == null ? null : (___r");
+            buffer.concat(" == null ? ___r");
+            buffer.concat(st.receiverLevel + "");
+            buffer.concat(" : (___r");
             buffer.concat(st.receiverLevel + "");
             buffer.concat(".isa.method_msgSend[\"init\"] || _objj_forward)(___r");
             buffer.concat(st.receiverLevel + "");
@@ -2457,7 +2459,9 @@ ArrayLiteral: function(node, st, c) {
             buffer.concat(++st.receiverLevel + "");
             buffer.concat(" = CPArray.isa.objj_msgSend0(CPArray, \"alloc\"), ___r");
             buffer.concat(st.receiverLevel + "");
-            buffer.concat(" == null ? null : ___r");
+            buffer.concat(" == null ? ___r");
+            buffer.concat(st.receiverLevel + "");
+            buffer.concat(" : ___r");
             buffer.concat(st.receiverLevel + "");
             buffer.concat(".isa.objj_msgSend0(___r");
             buffer.concat(st.receiverLevel + "");
@@ -2472,7 +2476,9 @@ ArrayLiteral: function(node, st, c) {
             buffer.concat(++st.receiverLevel + "");
             buffer.concat(" = (CPArray.isa.method_msgSend[\"alloc\"] || _objj_forward)(CPArray, \"alloc\"), ___r");
             buffer.concat(st.receiverLevel + "");
-            buffer.concat(" == null ? null : (___r");
+            buffer.concat(" == null ? ___r");
+            buffer.concat(st.receiverLevel + "");
+            buffer.concat(" : (___r");
             buffer.concat(st.receiverLevel + "");
             buffer.concat(".isa.method_msgSend[\"initWithObjects:count:\"] || _objj_forward)(___r");
             buffer.concat(st.receiverLevel + "");
@@ -2482,7 +2488,9 @@ ArrayLiteral: function(node, st, c) {
             buffer.concat(++st.receiverLevel + "");
             buffer.concat(" = CPArray.isa.objj_msgSend0(CPArray, \"alloc\"), ___r");
             buffer.concat(st.receiverLevel + "");
-            buffer.concat(" == null ? null : ___r");
+            buffer.concat(" == null ? ___r");
+            buffer.concat(st.receiverLevel + "");
+            buffer.concat(" : ___r");
             buffer.concat(st.receiverLevel + "");
             buffer.concat(".isa.objj_msgSend2(___r");
             buffer.concat(st.receiverLevel + "");
@@ -2541,7 +2549,9 @@ DictionaryLiteral: function(node, st, c) {
             buffer.concat(++st.receiverLevel + "");
             buffer.concat(" = (CPDictionary.isa.method_msgSend[\"alloc\"] || _objj_forward)(CPDictionary, \"alloc\"), ___r");
             buffer.concat(st.receiverLevel + "");
-            buffer.concat(" == null ? null : (___r");
+            buffer.concat(" == null ? ___r");
+            buffer.concat(st.receiverLevel + "");
+            buffer.concat(" : (___r");
             buffer.concat(st.receiverLevel + "");
             buffer.concat(".isa.method_msgSend[\"init\"] || _objj_forward)(___r");
             buffer.concat(st.receiverLevel + "");
@@ -2551,7 +2561,9 @@ DictionaryLiteral: function(node, st, c) {
             buffer.concat(++st.receiverLevel + "");
             buffer.concat(" = CPDictionary.isa.objj_msgSend0(CPDictionary, \"alloc\"), ___r");
             buffer.concat(st.receiverLevel + "");
-            buffer.concat(" == null ? null : ___r");
+            buffer.concat(" == null ? ___r");
+            buffer.concat(st.receiverLevel + "");
+            buffer.concat(" : ___r");
             buffer.concat(st.receiverLevel + "");
             buffer.concat(".isa.objj_msgSend0(___r");
             buffer.concat(st.receiverLevel + "");
@@ -2566,7 +2578,9 @@ DictionaryLiteral: function(node, st, c) {
             buffer.concat(++st.receiverLevel + "");
             buffer.concat(" = (CPDictionary.isa.method_msgSend[\"alloc\"] || _objj_forward)(CPDictionary, \"alloc\"), ___r");
             buffer.concat(st.receiverLevel + "");
-            buffer.concat(" == null ? null : (___r");
+            buffer.concat(" == null ? ___r");
+            buffer.concat(st.receiverLevel + "");
+            buffer.concat(" : (___r");
             buffer.concat(st.receiverLevel + "");
             buffer.concat(".isa.method_msgSend[\"initWithObjects:forKeys:\"] || _objj_forward)(___r");
             buffer.concat(st.receiverLevel + "");
@@ -2576,7 +2590,9 @@ DictionaryLiteral: function(node, st, c) {
             buffer.concat(++st.receiverLevel + "");
             buffer.concat(" = CPDictionary.isa.objj_msgSend0(CPDictionary, \"alloc\"), ___r");
             buffer.concat(st.receiverLevel + "");
-            buffer.concat(" == null ? null : ___r");
+            buffer.concat(" == null ? ___r");
+            buffer.concat(st.receiverLevel + "");
+            buffer.concat(" : ___r");
             buffer.concat(st.receiverLevel + "");
             buffer.concat(".isa.objj_msgSend2(___r");
             buffer.concat(st.receiverLevel + "");
@@ -3408,7 +3424,9 @@ MessageSendExpression: function(node, st, c) {
                 if (receiverIsNotSelf) {
                     buffer.concat("(", node);
                     c(nodeObject, st, "Expression");
-                    buffer.concat(" == null ? null : ", node);
+                    buffer.concat(" == null ? ", node);
+                    c(nodeObject, st, "Expression");
+                    buffer.concat(" : ", node);
                 }
                 if (inlineMsgSend)
                     buffer.concat("(", node);
@@ -3421,7 +3439,9 @@ MessageSendExpression: function(node, st, c) {
                 c(nodeObject, st, "Expression");
                 buffer.concat(")", node);
                 buffer.concat(", ___r" + st.receiverLevel, node);
-                buffer.concat(" == null ? null : ", node);
+                buffer.concat(" == null ? ", node);
+                buffer.concat("___r" + st.receiverLevel, node);
+                buffer.concat(" : ", node);
                 if (inlineMsgSend)
                     buffer.concat("(", node);
                 buffer.concat("___r" + st.receiverLevel, node);

--- a/Objective-J/Runtime.js
+++ b/Objective-J/Runtime.js
@@ -838,7 +838,7 @@ var __objj_msgSend__StackDepth = 0;
 GLOBAL(objj_msgSend) = function(/*id*/ aReceiver, /*SEL*/ aSelector)
 {
     if (aReceiver == nil)
-        return nil;
+        return aReceiver;
 
     var isa = aReceiver.isa;
 

--- a/Tests/Objective-J/Preprocessor/BehaviorTests/MethodTest.j
+++ b/Tests/Objective-J/Preprocessor/BehaviorTests/MethodTest.j
@@ -41,6 +41,16 @@
     return anotherNumber - aNumber;
 }
 
+-(id)nil
+{
+    return nil;
+}
+
+-(id)undefined
+{
+    return undefined;
+}
+
 @end
 
 @implementation MethodTest : OJTestCase
@@ -133,6 +143,16 @@
     [self assert:method_copyArgumentType(method, 1) equals:@"SEL"];
     [self assertTrue:method_copyArgumentType(method, 2) === nil];
     [self assert:method_getNumberOfArguments(method) equals:3];
+}
+
+- (void)testReturnNil
+{
+    [self assert:[[testClass nil] someSelector] equals:null];
+}
+
+- (void)testReturnUndefined
+{
+    [self assert:[[testClass undefined] someSelector] equals:undefined];
 }
 
 @end

--- a/Tests/Objective-J/Preprocessor/OutputTests/Messages/colon-selector-inlined.js
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Messages/colon-selector-inlined.js
@@ -1,2 +1,2 @@
 
-(object==null?null:(object.isa.method_msgSend[":"]||_objj_forward)(object,":",argument));
+(object==null?object:(object.isa.method_msgSend[":"]||_objj_forward)(object,":",argument));

--- a/Tests/Objective-J/Preprocessor/OutputTests/Messages/colon-selector.js
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Messages/colon-selector.js
@@ -1,2 +1,2 @@
 
-(object==null?null:object.isa.objj_msgSend1(object,":",argument));
+(object==null?object:object.isa.objj_msgSend1(object,":",argument));

--- a/Tests/Objective-J/Preprocessor/OutputTests/Messages/complex-receiver-inlined.js
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Messages/complex-receiver-inlined.js
@@ -1,2 +1,2 @@
 var a=0;
-((___r1=a++<2?small_target:big_target),___r1==null?null:(___r1.isa.method_msgSend["doStuff"]||_objj_forward)(___r1,"doStuff"));
+((___r1=a++<2?small_target:big_target),___r1==null?___r1:(___r1.isa.method_msgSend["doStuff"]||_objj_forward)(___r1,"doStuff"));

--- a/Tests/Objective-J/Preprocessor/OutputTests/Messages/complex-receiver.js
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Messages/complex-receiver.js
@@ -1,2 +1,2 @@
 var a=0;
-((___r1=a++<2?small_target:big_target),___r1==null?null:___r1.isa.objj_msgSend0(___r1,"doStuff"));
+((___r1=a++<2?small_target:big_target),___r1==null?___r1:___r1.isa.objj_msgSend0(___r1,"doStuff"));

--- a/Tests/Objective-J/Preprocessor/OutputTests/Messages/keyword-in-selector-inlined.js
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Messages/keyword-in-selector-inlined.js
@@ -1,1 +1,1 @@
-(object==null?null:(object.isa.method_msgSend["for:in:nil:"]||_objj_forward)(object,"for:in:nil:",a,b,nil));
+(object==null?object:(object.isa.method_msgSend["for:in:nil:"]||_objj_forward)(object,"for:in:nil:",a,b,nil));

--- a/Tests/Objective-J/Preprocessor/OutputTests/Messages/keyword-in-selector.js
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Messages/keyword-in-selector.js
@@ -1,1 +1,1 @@
-(object==null?null:object.isa.objj_msgSend3(object,"for:in:nil:",a,b,nil));
+(object==null?object:object.isa.objj_msgSend3(object,"for:in:nil:",a,b,nil));

--- a/Tests/Objective-J/Preprocessor/OutputTests/Messages/multiple-parameters-inlined.js
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Messages/multiple-parameters-inlined.js
@@ -1,2 +1,2 @@
 
-(object==null?null:(object.isa.method_msgSend["label:label2:label3:label4:"]||_objj_forward)(object,"label:label2:label3:label4:",argument,argument2,argument3,argument4));
+(object==null?object:(object.isa.method_msgSend["label:label2:label3:label4:"]||_objj_forward)(object,"label:label2:label3:label4:",argument,argument2,argument3,argument4));

--- a/Tests/Objective-J/Preprocessor/OutputTests/Messages/multiple-parameters.js
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Messages/multiple-parameters.js
@@ -1,2 +1,2 @@
 
-(object==null?null:object.isa.objj_msgSend(object,"label:label2:label3:label4:",argument,argument2,argument3,argument4));
+(object==null?object:object.isa.objj_msgSend(object,"label:label2:label3:label4:",argument,argument2,argument3,argument4));

--- a/Tests/Objective-J/Preprocessor/OutputTests/Messages/no-parameters-inlined.js
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Messages/no-parameters-inlined.js
@@ -1,2 +1,2 @@
 (CPArray.isa.method_msgSend["new"]||_objj_forward)(CPArray,"new");
-(object==null?null:(object.isa.method_msgSend["message"]||_objj_forward)(object,"message"));
+(object==null?object:(object.isa.method_msgSend["message"]||_objj_forward)(object,"message"));

--- a/Tests/Objective-J/Preprocessor/OutputTests/Messages/no-parameters.js
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Messages/no-parameters.js
@@ -1,2 +1,2 @@
 CPArray.isa.objj_msgSend0(CPArray,"new");
-(object==null?null:object.isa.objj_msgSend0(object,"message"));
+(object==null?object:object.isa.objj_msgSend0(object,"message"));

--- a/Tests/Objective-J/Preprocessor/OutputTests/Messages/one-parameter-inlined.js
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Messages/one-parameter-inlined.js
@@ -1,2 +1,2 @@
 (CPArray.isa.method_msgSend["arrayWithArray:"]||_objj_forward)(CPArray,"arrayWithArray:",[]);
-(object==null?null:(object.isa.method_msgSend["label:"]||_objj_forward)(object,"label:",argument));
+(object==null?object:(object.isa.method_msgSend["label:"]||_objj_forward)(object,"label:",argument));

--- a/Tests/Objective-J/Preprocessor/OutputTests/Messages/one-parameter.js
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Messages/one-parameter.js
@@ -1,2 +1,2 @@
 CPArray.isa.objj_msgSend1(CPArray,"arrayWithArray:",[]);
-(object==null?null:object.isa.objj_msgSend1(object,"label:",argument));
+(object==null?object:object.isa.objj_msgSend1(object,"label:",argument));

--- a/Tests/Objective-J/Preprocessor/OutputTests/Messages/self-as-receiver-inlined.js
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Messages/self-as-receiver-inlined.js
@@ -3,9 +3,9 @@ objj_registerClassPair(the_class);
 class_addMethods(the_class,[new objj_method(sel_getUid("mySelector"),function $MyClass__mySelector(_1,_2){
 (_1.isa.method_msgSend["init"]||_objj_forward)(_1,"init");
 _1=nil;
-(_1==null?null:(_1.isa.method_msgSend["init"]||_objj_forward)(_1,"init"));
+(_1==null?_1:(_1.isa.method_msgSend["init"]||_objj_forward)(_1,"init"));
 },["id"]),new objj_method(sel_getUid("mySelector2"),function $MyClass__mySelector2(_3,_4){
 (_3.isa.method_msgSend["init"]||_objj_forward)(_3,"init");
 eval("self = null;");
-(_3==null?null:(_3.isa.method_msgSend["init"]||_objj_forward)(_3,"init"));
+(_3==null?_3:(_3.isa.method_msgSend["init"]||_objj_forward)(_3,"init"));
 },["id"])]);

--- a/Tests/Objective-J/Preprocessor/OutputTests/Messages/self-as-receiver.js
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Messages/self-as-receiver.js
@@ -3,9 +3,9 @@ objj_registerClassPair(the_class);
 class_addMethods(the_class,[new objj_method(sel_getUid("mySelector"),function $MyClass__mySelector(_1,_2){
 _1.isa.objj_msgSend0(_1,"init");
 _1=nil;
-(_1==null?null:_1.isa.objj_msgSend0(_1,"init"));
+(_1==null?_1:_1.isa.objj_msgSend0(_1,"init"));
 },["id"]),new objj_method(sel_getUid("mySelector2"),function $MyClass__mySelector2(_3,_4){
 _3.isa.objj_msgSend0(_3,"init");
 eval("self = null;");
-(_3==null?null:_3.isa.objj_msgSend0(_3,"init"));
+(_3==null?_3:_3.isa.objj_msgSend0(_3,"init"));
 },["id"])]);

--- a/Tests/Objective-J/Preprocessor/OutputTests/Messages/ternary-operator-argument-inlined.js
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Messages/ternary-operator-argument-inlined.js
@@ -1,4 +1,4 @@
 
-(object==null?null:(object.isa.method_msgSend["label:"]||_objj_forward)(object,"label:",condition?true:false));
-(object==null?null:(object.isa.method_msgSend["label:"]||_objj_forward)(object,"label:",condition?true:false));
-(object==null?null:(object.isa.method_msgSend["label:"]||_objj_forward)(object,"label:",condition?true:false));
+(object==null?object:(object.isa.method_msgSend["label:"]||_objj_forward)(object,"label:",condition?true:false));
+(object==null?object:(object.isa.method_msgSend["label:"]||_objj_forward)(object,"label:",condition?true:false));
+(object==null?object:(object.isa.method_msgSend["label:"]||_objj_forward)(object,"label:",condition?true:false));

--- a/Tests/Objective-J/Preprocessor/OutputTests/Messages/ternary-operator-argument.js
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Messages/ternary-operator-argument.js
@@ -1,4 +1,4 @@
 
-(object==null?null:object.isa.objj_msgSend1(object,"label:",condition?true:false));
-(object==null?null:object.isa.objj_msgSend1(object,"label:",condition?true:false));
-(object==null?null:object.isa.objj_msgSend1(object,"label:",condition?true:false));
+(object==null?object:object.isa.objj_msgSend1(object,"label:",condition?true:false));
+(object==null?object:object.isa.objj_msgSend1(object,"label:",condition?true:false));
+(object==null?object:object.isa.objj_msgSend1(object,"label:",condition?true:false));

--- a/Tests/Objective-J/Preprocessor/OutputTests/Misc/parenthesis-return-inlined.js
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Misc/parenthesis-return-inlined.js
@@ -1,3 +1,3 @@
 x=function(){
-return (someIval==null?null:(someIval.isa.method_msgSend["someMethod"]||_objj_forward)(someIval,"someMethod"));
+return (someIval==null?someIval:(someIval.isa.method_msgSend["someMethod"]||_objj_forward)(someIval,"someMethod"));
 };

--- a/Tests/Objective-J/Preprocessor/OutputTests/Misc/parenthesis-return.js
+++ b/Tests/Objective-J/Preprocessor/OutputTests/Misc/parenthesis-return.js
@@ -1,3 +1,3 @@
 x=function(){
-return (someIval==null?null:someIval.isa.objj_msgSend0(someIval,"someMethod"));
+return (someIval==null?someIval:someIval.isa.objj_msgSend0(someIval,"someMethod"));
 };


### PR DESCRIPTION
The ```msgSend``` function has always returned ```nil``` if the receiver has been ```nil``` or ```undefined```.
Example:
```
var a = undefined;
var b = [a someSelector]; // b = nil
```

The variable ```b``` is now ```nil```.

This pull request adds the ability for the ```msgSend``` function to return ```undefined``` if the receiver is ```undefined```. If the receiver is ```nil``` it still return ```nil```.
The above example again:
```
var a = undefined;
var b = [a someSelector]; // b = undefined
```

The variable ```b``` is now ```undefined```.

### Background.
The use of ```nil``` in Objective-C corresponds to the use of ```null``` in C and C++ and stands for "no value". A fundamental function in Objective-C is when you send a message to a receiver that is ```nil``` the result is again a ```nil``` value. This can be very convenient as you don't need the check if a receiver is nil before sending a message to it.

Objective-J adds the ability the use class structures and message send functionality for Javascript in the same way as Objective-C adds this to C and C++. Javascript also has the value ```null``` and is handled in the same way for Objective-J. Javascript also has the value ```undefined``` that stands for "not yet defined". This can sometimes be confusing and many try to handle ```null``` and ```undefined``` as the same thing. This is almost what Objective-J and the Cappuccino frameworks always has been doing. They try to always check for both ```null``` and ```undefined``` and always return ```nil``` but never ```undefined```. We can say that Objective-J understands ```undefined``` but will try to translate it to ```nil```.

### Why do we need this change.
Javascript has both ```null``` and ```undefined``` and Objective-J is a superset of Javascript. It is now very hard to use ```undefined``` in Objective-J code as it will always try to translate it to ```nil```. There are some Javascript libraries that use both ```null``` and ```undefined``` values and they are very hard to use from Objective-J programs today.  Same if you decide to use ```nil``` and ```undefined``` as a value in your own Objective-J code. This small change will make ```undefined``` a full member of the Objective-J language. It should be as it is a superset of Javascript. The Cappuccino frameworks will still handle ```undefined``` but only return ```nil```.

### How will it impact.
Today most methods will never return ```undefined``` so this is a very limited problem. If any does this the main concern is if some code will only check for ```nil``` and not ```undefined```.
Example:
```
var a = [someObject someSelector];
If (a === nil) a = 42;
...
```
If the variable ```someObject``` contains ```undefined``` the variable ```a``` will now be set to ```undefined``` instead of ```nil```.  But the variable ```a``` will then never be set to 42.
The correct way is to check for both ```nil``` and ```undefined``` like this:
```
var a = [someObject someSelector];
If (a == nil) a = 42;
...
```

I have tried this pull request on our project that is fairly large and I don't find any problems.