### PR TITLE
fixed: pressing capslock inserted whitespaces under certain conditions

### DIFF
--- a/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
@@ -747,6 +747,8 @@ var _capsLockActive;
             if (_keyCode === CPKeyCodes.CAPS_LOCK)
             {
                 _capsLockActive = YES;
+
+                // we need to break out in order to prevent a keyDown: event from pressing the CAPS_LOCK key
                 break;
             }
 

--- a/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
@@ -196,7 +196,8 @@ var ModifierKeyCodes = [
         CPKeyCodes.MAC_FF_META,
         CPKeyCodes.CTRL,
         CPKeyCodes.ALT,
-        CPKeyCodes.SHIFT
+        CPKeyCodes.SHIFT,
+        CPKeyCodes.CAPS_LOCK
     ],
 
     supportsNativeDragAndDrop = [CPPlatform supportsDragAndDrop];
@@ -691,7 +692,8 @@ _CPPlatformWindowWillCloseNotification = @"_CPPlatformWindowWillCloseNotificatio
         modifierFlags = (aDOMEvent.shiftKey ? CPShiftKeyMask : 0) |
                         (aDOMEvent.ctrlKey ? CPControlKeyMask : 0) |
                         (aDOMEvent.altKey ? CPAlternateKeyMask : 0) |
-                        (aDOMEvent.metaKey ? CPCommandKeyMask : 0);
+                        (aDOMEvent.metaKey ? CPCommandKeyMask : 0) |
+                        (_capsLockActive ? CPAlphaShiftKeyMask : 0);
 
     // With a few exceptions, all key events are blocked from propagating to
     // the browser.  Here the following exceptions are being allowed:
@@ -746,9 +748,8 @@ _CPPlatformWindowWillCloseNotification = @"_CPPlatformWindowWillCloseNotificatio
             {
                 _capsLockActive = YES;
 
-                // we need to break out in order to prevent a keyDown: event from pressing the CAPS_LOCK key
-                // this would cause insertion of weird whitespace characters in e.g. CPTextView, just by pressing CAPS_LOCK
-                break;
+                // Make sure the caps lock flag is set in modifierFlags
+                modifierFlags |= CPAlphaShiftKeyMask;
             }
 
             if ([ModifierKeyCodes containsObject:_keyCode])
@@ -822,7 +823,12 @@ _CPPlatformWindowWillCloseNotification = @"_CPPlatformWindowWillCloseNotificatio
 
             // check for caps lock state
             if (keyCode === CPKeyCodes.CAPS_LOCK)
+            {
                 _capsLockActive = NO;
+                
+                // Make sure the caps lock flag is cleared in modifierFlags
+                modifierFlags &= ~CPAlphaShiftKeyMask;
+            }
 
             if ([ModifierKeyCodes containsObject:keyCode])
             {

--- a/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
@@ -210,7 +210,7 @@ var touchStartingPointX,
 
 _CPPlatformWindowWillCloseNotification = @"_CPPlatformWindowWillCloseNotification";
 
-var _capsLockActive;
+var capsLockActive;
 
 // When scrolling with an old-style scroll wheel with discete steps ('clicks'), the scroll amount can indicate how many "lines" to
 // scroll.
@@ -741,12 +741,12 @@ var _capsLockActive;
             if (!characters)
                 characters = String.fromCharCode(_keyCode).toLowerCase();
 
-            overrideCharacters = (modifierFlags & CPShiftKeyMask || _capsLockActive) ? characters.toUpperCase() : characters;
+            overrideCharacters = (modifierFlags & CPShiftKeyMask || capsLockActive) ? characters.toUpperCase() : characters;
 
             // check for caps lock state
             if (_keyCode === CPKeyCodes.CAPS_LOCK)
             {
-                _capsLockActive = YES;
+                capsLockActive = YES;
 
                 // we need to break out in order to prevent a keyDown: event from pressing the CAPS_LOCK key
                 break;
@@ -804,7 +804,7 @@ var _capsLockActive;
             charactersIgnoringModifiers = characters.toLowerCase(); // FIXME: This isn't correct. It SHOULD include Shift.
 
             // Safari won't send proper capitalization during cmd-key events
-            if (!overrideCharacters && (modifierFlags & CPCommandKeyMask) && ((modifierFlags & CPShiftKeyMask) || _capsLockActive))
+            if (!overrideCharacters && (modifierFlags & CPCommandKeyMask) && ((modifierFlags & CPShiftKeyMask) || capsLockActive))
                 characters = characters.toUpperCase();
 
             event = [CPEvent keyEventWithType:CPKeyDown location:location modifierFlags:modifierFlags
@@ -823,7 +823,7 @@ var _capsLockActive;
 
             // check for caps lock state
             if (keyCode === CPKeyCodes.CAPS_LOCK)
-                _capsLockActive = NO;
+                capsLockActive = NO;
 
             if ([ModifierKeyCodes containsObject:keyCode])
             {
@@ -838,7 +838,7 @@ var _capsLockActive;
             var characters = KeyCodesToUnicodeMap[charCode] || String.fromCharCode(charCode);
             charactersIgnoringModifiers = characters.toLowerCase();
 
-            if (!(modifierFlags & CPShiftKeyMask) && (modifierFlags & CPCommandKeyMask) && !_capsLockActive)
+            if (!(modifierFlags & CPShiftKeyMask) && (modifierFlags & CPCommandKeyMask) && !capsLockActive)
                 characters = charactersIgnoringModifiers;
 
             event = [CPEvent keyEventWithType:CPKeyUp location:location modifierFlags:modifierFlags

--- a/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
@@ -210,8 +210,6 @@ var touchStartingPointX,
 
 _CPPlatformWindowWillCloseNotification = @"_CPPlatformWindowWillCloseNotification";
 
-var capsLockActive;
-
 // When scrolling with an old-style scroll wheel with discete steps ('clicks'), the scroll amount can indicate how many "lines" to
 // scroll.
 #define SCROLLWHEEL_LINE_PIXELS 6.0
@@ -741,12 +739,12 @@ var capsLockActive;
             if (!characters)
                 characters = String.fromCharCode(_keyCode).toLowerCase();
 
-            overrideCharacters = (modifierFlags & CPShiftKeyMask || capsLockActive) ? characters.toUpperCase() : characters;
+            overrideCharacters = (modifierFlags & CPShiftKeyMask || _capsLockActive) ? characters.toUpperCase() : characters;
 
             // check for caps lock state
             if (_keyCode === CPKeyCodes.CAPS_LOCK)
             {
-                capsLockActive = YES;
+                _capsLockActive = YES;
 
                 // we need to break out in order to prevent a keyDown: event from pressing the CAPS_LOCK key
                 // this would cause insertion of weird whitespace characters in e.g. CPTextView, just by pressing CAPS_LOCK
@@ -805,7 +803,7 @@ var capsLockActive;
             charactersIgnoringModifiers = characters.toLowerCase(); // FIXME: This isn't correct. It SHOULD include Shift.
 
             // Safari won't send proper capitalization during cmd-key events
-            if (!overrideCharacters && (modifierFlags & CPCommandKeyMask) && ((modifierFlags & CPShiftKeyMask) || capsLockActive))
+            if (!overrideCharacters && (modifierFlags & CPCommandKeyMask) && ((modifierFlags & CPShiftKeyMask) || _capsLockActive))
                 characters = characters.toUpperCase();
 
             event = [CPEvent keyEventWithType:CPKeyDown location:location modifierFlags:modifierFlags
@@ -824,7 +822,7 @@ var capsLockActive;
 
             // check for caps lock state
             if (keyCode === CPKeyCodes.CAPS_LOCK)
-                capsLockActive = NO;
+                _capsLockActive = NO;
 
             if ([ModifierKeyCodes containsObject:keyCode])
             {
@@ -839,7 +837,7 @@ var capsLockActive;
             var characters = KeyCodesToUnicodeMap[charCode] || String.fromCharCode(charCode);
             charactersIgnoringModifiers = characters.toLowerCase();
 
-            if (!(modifierFlags & CPShiftKeyMask) && (modifierFlags & CPCommandKeyMask) && !capsLockActive)
+            if (!(modifierFlags & CPShiftKeyMask) && (modifierFlags & CPCommandKeyMask) && !_capsLockActive)
                 characters = charactersIgnoringModifiers;
 
             event = [CPEvent keyEventWithType:CPKeyUp location:location modifierFlags:modifierFlags

--- a/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
@@ -749,6 +749,7 @@ var capsLockActive;
                 capsLockActive = YES;
 
                 // we need to break out in order to prevent a keyDown: event from pressing the CAPS_LOCK key
+                // this would cause insertion of weird whitespace characters in e.g. CPTextView, just by pressing CAPS_LOCK
                 break;
             }
 

--- a/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
@@ -210,6 +210,7 @@ var touchStartingPointX,
 
 _CPPlatformWindowWillCloseNotification = @"_CPPlatformWindowWillCloseNotification";
 
+var _capsLockActive;
 
 // When scrolling with an old-style scroll wheel with discete steps ('clicks'), the scroll amount can indicate how many "lines" to
 // scroll.
@@ -744,7 +745,10 @@ _CPPlatformWindowWillCloseNotification = @"_CPPlatformWindowWillCloseNotificatio
 
             // check for caps lock state
             if (_keyCode === CPKeyCodes.CAPS_LOCK)
+            {
                 _capsLockActive = YES;
+                break;
+            }
 
             if ([ModifierKeyCodes containsObject:_keyCode])
             {


### PR DESCRIPTION
the original implementation of CPPlatformWindow+DOM.j was faulty in two ways: firstly, _capsLockActive was accidentally a global variable, secondly, pressing capslock accidentally emitted keyDown:(CPEvent)events

both issues are fixed in this PR