### PR TITLE
clearsFilterPredicateOnInsertion option is for insertion only

### DIFF
--- a/AppKit/CPArrayController.j
+++ b/AppKit/CPArrayController.j
@@ -297,27 +297,18 @@
         class.
     */
 
-    if (_clearsFilterPredicateOnInsertion)
-        [self willChangeValueForKey:@"filterPredicate"];
-
     // Don't use [super setContent:] as that would fire the contentObject change.
     // We need to be in control of when notifications fire.
     // Note that if we have a contentArray binding, setting the content does /not/
     // cause a reverse binding set.
     _contentObject = value;
 
-    if (_clearsFilterPredicateOnInsertion && _filterPredicate != nil)
-        [self __setFilterPredicate:nil]; // Causes a _rearrangeObjects.
-    else
-        [self _rearrangeObjects];
+    [self _rearrangeObjects];
 
     if ([self preservesSelection])
         [self __setSelectedObjects:oldSelectedObjects];
     else
         [self __setSelectionIndexes:oldSelectionIndexes];
-
-    if (_clearsFilterPredicateOnInsertion)
-        [self didChangeValueForKey:@"filterPredicate"];
 }
 
 /*!

--- a/Tests/AppKit/CPArrayControllerTest.j
+++ b/Tests/AppKit/CPArrayControllerTest.j
@@ -1020,6 +1020,26 @@
     [self assertTrue:[[arrayController arrangedObjects] count] > 0];
 }
 
+- (void)testArrangedObjectsWhenSetContentAndClearsFilterOnInsertionIsTrue
+{
+    var arrayController = [[CPArrayController alloc] init];
+    [arrayController setClearsFilterPredicateOnInsertion:YES];
+    [arrayController setFilterPredicate:[CPPredicate predicateWithValue:NO]];
+    [arrayController setContent:[CPArray arrayWithObject:@"a"]];
+
+    [self assertTrue:[[arrayController arrangedObjects] count] == 0];
+}
+
+- (void)testArrangedObjectsWhenBindingAndClearsFilterOnInsertionIsTrue
+{
+    var arrayController = [[CPArrayController alloc] init];
+    [arrayController setClearsFilterPredicateOnInsertion:YES];
+    [arrayController setFilterPredicate:[CPPredicate predicateWithValue:NO]];
+    [arrayController bind:@"contentArray" toObject:self withKeyPath:@"_contentArray" options:nil];
+
+    [self assertTrue:[[arrayController arrangedObjects] count] == 0];
+}
+
 - (void)testArrangedObjectsWithPredicateFilteringAfterContentArrayBinding
 {
     _contentArray = [self makeTestArray];


### PR DESCRIPTION
Previously, the filter predicate was removed on setContent: or on content binding. When this option is on, the FP should be removed only on insertion, as the name of the option suggests it.

With Tests: Foundation unit test.
fixes #2791