### PR TITLE
Misc Fixes

### DIFF
--- a/AppKit/CPOutlineView.j
+++ b/AppKit/CPOutlineView.j
@@ -757,7 +757,7 @@ var CPOutlineViewCoalesceSelectionNotificationStateOff  = 0,
 
     var children = itemInfo.children;
 
-    for (var i = [children count]; i >= 0; i--)
+    for (var i = [children count] - 1; i >= 0; i--)
     {
         var child = children[i];
         [self _addPendingItem:child];
@@ -768,7 +768,7 @@ var CPOutlineViewCoalesceSelectionNotificationStateOff  = 0,
 
 - (void)_cleanPendingItem
 {
-    for (var i = [_pendingItemToClean count]; i >= 0; i--)
+    for (var i = [_pendingItemToClean count] - 1; i >= 0; i--)
     {
         var item = _pendingItemToClean[i];
 

--- a/AppKit/CPRuleEditor/CPPredicateEditor.j
+++ b/AppKit/CPRuleEditor/CPPredicateEditor.j
@@ -295,7 +295,7 @@
     var copyTemplate = [matchedTemplate copy],
         subpredicates = [matchedTemplate displayableSubpredicatesOfPredicate:predicate];
 
-    if (subpredicates == nil)
+    if (![predicate isKindOfClass:[CPCompoundPredicate class]])
     {
         [copyTemplate _setComparisonPredicate:predicate];
         type = CPRuleEditorRowTypeSimple;

--- a/AppKit/CPTokenField.j
+++ b/AppKit/CPTokenField.j
@@ -531,7 +531,14 @@ CPTokenFieldDeleteButtonType     = 1;
         CPTokenFieldBlurHandler();
 
     if (element.parentNode == [_tokenScrollView documentView]._DOMElement)
+    {
+        // Remove onblur while removing child because it is triggered
+        // when removing child, causing this function to be called infinitely
+        var onblur = CPTokenFieldDOMInputElement.onblur;
+        CPTokenFieldDOMInputElement.onblur = function(){};
         element.parentNode.removeChild(element);
+        CPTokenFieldDOMInputElement.onblur = onblur;   
+    }
 
     // Previosly, we unflagged CPTokenFieldInputDidBlur and CPTokenFieldInputResigning before
     // the call to removeChild. This may result in DOM exceptions in Chrome under certain conditions.
@@ -763,6 +770,7 @@ CPTokenFieldDeleteButtonType     = 1;
                         CPTokenFieldDOMInputElement,
                         CPTokenFieldInputResigning,
                         @ref(CPTokenFieldInputDidBlur));
+            CPTokenFieldDOMInputElement.style.display = "none";
         };
 
         // FIXME make this not onblur

--- a/AppKit/CPTokenField.j
+++ b/AppKit/CPTokenField.j
@@ -593,7 +593,7 @@ CPTokenFieldDeleteButtonType     = 1;
 {
     // We return super here because objectValue uses this method
     // If we called self we would loop infinitely
-    return [super objectValue];
+    return [super objectValue] || [];
 }
 
 - (CPString)stringValue
@@ -630,7 +630,7 @@ CPTokenFieldDeleteButtonType     = 1;
 
 - (void)setObjectValue:(id)aValue
 {
-    if (aValue !== nil && ![aValue isKindOfClass:[CPArray class]])
+    if (!aValue || ![aValue isKindOfClass:[CPArray class]])
     {
         [super setObjectValue:nil];
         return;

--- a/Foundation/CPURLConnection.j
+++ b/Foundation/CPURLConnection.j
@@ -252,8 +252,6 @@ var CPURLConnectionDelegate = nil;
     {
         _HTTPRequest.open([_request HTTPMethod], [[_request URL] absoluteString], YES);
 
-        _HTTPRequest.setWithCredentials(_withCredentials);
-
         _HTTPRequest.onreadystatechange = function() { [self _readyStateDidChange]; };
         _HTTPRequest.ontimeout = function() { [self _didTimeout]; };
 

--- a/Foundation/CPURLConnection.j
+++ b/Foundation/CPURLConnection.j
@@ -252,6 +252,8 @@ var CPURLConnectionDelegate = nil;
     {
         _HTTPRequest.open([_request HTTPMethod], [[_request URL] absoluteString], YES);
 
+        _HTTPRequest.setWithCredentials(_withCredentials);
+
         _HTTPRequest.onreadystatechange = function() { [self _readyStateDidChange]; };
         _HTTPRequest.ontimeout = function() { [self _didTimeout]; };
 
@@ -296,6 +298,14 @@ var CPURLConnectionDelegate = nil;
     catch (anException)
     {
     }
+}
+
+/*
+    Returns the current request
+*/
+- (CPURLRequest)currentRequest
+{
+    return _request;
 }
 
 - (BOOL)isLocalFileConnection

--- a/Foundation/CPURLConnection.j
+++ b/Foundation/CPURLConnection.j
@@ -21,6 +21,7 @@
  */
 
 @import "CPData.j"
+@import "CPError.j"
 @import "CPObject.j"
 @import "CPRunLoop.j"
 @import "CPURLRequest.j"

--- a/Objective-J/CommonJS/lib/objective-j/jake/bundletask.js
+++ b/Objective-J/CommonJS/lib/objective-j/jake/bundletask.js
@@ -470,6 +470,12 @@ BundleTask.prototype.resourcesPath = function()
 
 // Don't sprite images larger than 32KB, IE 8 doesn't like it.
 BundleTask.isSpritable = function(aResourcePath) {
+
+    if (FILE.size(aResourcePath) >= 32768)
+    {
+        TERM.stream.print("\0red(WARNING: " + aResourcePath + " is larger than 32KB. IE8 does not like this so this image will not be sprited.\0)");
+    }
+
     return isImage(aResourcePath) && FILE.size(aResourcePath) < 32768 &&
            ("data:" + mimeType(aResourcePath) + ";base64," +
             base64.encode(FILE.read(aResourcePath, "b"))).length < 32768;
@@ -642,14 +648,24 @@ BundleTask.prototype.defineSpritedImagesTask = function()
 
             prerequisites.forEach(function(aFilename)
             {
-                var resourcePath = "Resources/" + FILE.relative(resourcesPath, aFilename);
+                TERM.stream.print("Processing file: " + aFilename);
 
-                dataURLStream.write("u;" + resourcePath.length + ";" + resourcePath);
+                try 
+                {
+                    var resourcePath = "Resources/" + FILE.relative(resourcesPath, aFilename);
 
-                var contents =  "data:" + mimeType(aFilename) +
-                                ";base64," + FILE.read(aFilename, "b").decodeToString("UTF-8");
+                    dataURLStream.write("u;" + resourcePath.length + ";" + resourcePath);
 
-                dataURLStream.write(contents.length + ";" + contents);
+                    var contents =  "data:" + mimeType(aFilename) +
+                                    ";base64," + FILE.read(aFilename, "b").decodeToString("UTF-8");
+
+                    dataURLStream.write(contents.length + ";" + contents);
+                } 
+                catch (error)
+                {
+                    TERM.stream.print("Error: " + error);
+                }
+
             });
 
             dataURLStream.write("e;");


### PR DESCRIPTION
Hello Cappuccino maintainers

I enjoy using cappuccino and over the time I have been using it I discovered bugs. These fixes have been piling up and I think it is time I made them available to the main repo so people can enjoy the fixes.

Here is a summary of fixes in this PR:
- Break infinite recursion under chrome when removing tokens in a token field
- Fix stack overflow happening when CPOutline view receives a drop
- Fix some errors during compilation, and make a warning about 32KB image data-urls.