### PR TITLE
Fixed: In modal mode a focus event will make the modal window the key window

### DIFF
--- a/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
@@ -1098,7 +1098,9 @@ _CPPlatformWindowWillCloseNotification = @"_CPPlatformWindowWillCloseNotificatio
     var keyWindow = _previousKeyWindow;
 
     if (!keyWindow)
-       keyWindow = [[[_windowLayers objectForKey:[_windowLevels firstObject]] orderedWindows] firstObject];
+        // If we don't have a previous key window take the modal window if we are in a modal session.
+        // If not in a modal session just take the first window in the most background layer
+        keyWindow = (CPApp._currentSession && CPApp._currentSession._window) || [[[_windowLayers objectForKey:[_windowLevels firstObject]] orderedWindows] firstObject];
 
     if (!keyWindow)
         return;


### PR DESCRIPTION
The default was to make the first window in the most background layer the key window if nothing else was used.
This does not work well if there is a modal window that should have all the attention.

This solution will first choose the modal window if in modal mode. If not the old variant is used.