### PR TITLE
Fixed: Let the text field handle key commands when it is selectable

### DIFF
--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -1092,7 +1092,8 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
 
 - (void)keyDown:(CPEvent)anEvent
 {
-    if (!([self isEnabled] && [self isEditable]))
+    // Has to be enabled, and it also has to be editable or selectable.
+    if (![self isEnabled] || !([self isEditable] || [self isSelectable]))
         return;
 
     // CPTextField uses an HTML input element to take the input so we need to


### PR DESCRIPTION
There was a problem introduced by pull request #2600 when trying to select and copy text in a selectable text field. The problem only occurs when the text field is in a modal window.

It was caused by the modal run loop that is present as an eventListener on the CPApplication when in modal mode. It will force a bail out from the sendEvent: method in CPApplication when trying to handle the event. As the check for key equivalent is moved down by the #2600 pull request it will never be allowed to handle a copy command from the browser menu or key equivalent.

The solution is to allow the text field to handle the event if it is selectable. This will also allow the text selection to be altered from the keyboard with keys like shift-left/right/up/down arrow. Combinations like shift-option arrow also work for whole word selection.