### PR TITLE
Fixed: CPTextView keyboard issue in recent Firefox versions

### DIFF
--- a/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
@@ -739,8 +739,8 @@ _CPPlatformWindowWillCloseNotification = @"_CPPlatformWindowWillCloseNotificatio
                 characters = KeyCodesToUnicodeMap[_keyCode];
 
             // The problem with keyCode is that this property refers to keys on the keyboard and not to characters
-            // This is why String.fromCharCode does not work in more recent versions of Firefox
-            // E.g. pressing a '#' gives you a charCode of 163, which refers to '£' and not '#'
+            // This is why String.fromCharCode does not always work in more recent versions of Firefox
+            // E.g. pressing a '#' on a German keyboard gives you a charCode of 163, which refers to '£' and not '#'
             // The property key works fine, though. From there we can get the actual character more robustly.
             // Therefore we prefer key over keyCode whenever possible
 

--- a/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
@@ -739,8 +739,9 @@ _CPPlatformWindowWillCloseNotification = @"_CPPlatformWindowWillCloseNotificatio
                 characters = KeyCodesToUnicodeMap[_keyCode];
 
             if (!characters)
-                characters = String.fromCharCode(_keyCode).toLowerCase();
+                characters = (aDOMEvent.key && aDOMEvent.key.length == 1) ? aDOMEvent.key.toLowerCase() : String.fromCharCode(_keyCode).toLowerCase();
 
+            document.title = aDOMEvent.key + ' ' + _keyCode;
             overrideCharacters = (modifierFlags & CPShiftKeyMask || _capsLockActive) ? characters.toUpperCase() : characters;
 
             // check for caps lock state
@@ -767,7 +768,7 @@ _CPPlatformWindowWillCloseNotification = @"_CPPlatformWindowWillCloseNotificatio
                 //this lets us be consistent in all browsers and send on the keydown
                 //which means we can cancel the event early enough, but only if sendEvent needs to
             }
-            else if (CPKeyCodes.firesKeyPressEvent(_keyCode, _lastKey, aDOMEvent.shiftKey, aDOMEvent.ctrlKey, aDOMEvent.altKey))
+            else if (CPKeyCodes.firesKeyPressEvent(_keyCode, aDOMEvent.key, _lastKey, aDOMEvent.shiftKey, aDOMEvent.ctrlKey, aDOMEvent.altKey))
             {
                 // this branch is taken by events which fire keydown, keypress, and keyup.
                 // this is the only time we'll ALLOW character keys to propagate (needed for text fields)

--- a/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
@@ -738,6 +738,12 @@ _CPPlatformWindowWillCloseNotification = @"_CPPlatformWindowWillCloseNotificatio
             if (aDOMEvent.which === 0 || aDOMEvent.charCode === 0 || (aDOMEvent.which === undefined && aDOMEvent.charCode === undefined))
                 characters = KeyCodesToUnicodeMap[_keyCode];
 
+            // The problem with keyCode is that this property refers to keys on the keyboard and not to characters
+            // This is why String.fromCharCode does not work in more recent versions of Firefox
+            // E.g. pressing a '#' gives you a charCode of 163, which refers to '£' and not '#'
+            // The property key works fine, though. From there we can get the actual character more robustly.
+            // Therefore we prefer key over keyCode whenever possible
+
             if (!characters)
                 characters = (aDOMEvent.key && aDOMEvent.key.length == 1) ? aDOMEvent.key.toLowerCase() : String.fromCharCode(_keyCode).toLowerCase();
 

--- a/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
@@ -741,7 +741,6 @@ _CPPlatformWindowWillCloseNotification = @"_CPPlatformWindowWillCloseNotificatio
             if (!characters)
                 characters = (aDOMEvent.key && aDOMEvent.key.length == 1) ? aDOMEvent.key.toLowerCase() : String.fromCharCode(_keyCode).toLowerCase();
 
-            document.title = aDOMEvent.key + ' ' + _keyCode;
             overrideCharacters = (modifierFlags & CPShiftKeyMask || _capsLockActive) ? characters.toUpperCase() : characters;
 
             // check for caps lock state

--- a/AppKit/Platform/DOM/CPPlatformWindow+DOMKeys.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOMKeys.j
@@ -157,8 +157,11 @@ CPKeyCodes = {
  * @param opt_altKey Whether the alt key is held down.
  * @return Returns YES if it's a key that fires a keypress event.
  */
-CPKeyCodes.firesKeyPressEvent = function(keyCode, opt_heldKeyCode, opt_shiftKey, opt_ctrlKey, opt_altKey)
+CPKeyCodes.firesKeyPressEvent = function(keyCode, key, opt_heldKeyCode, opt_shiftKey, opt_ctrlKey, opt_altKey)
 {
+    if (key.length == 1)
+        return true;
+
     if (!CPFeatureIsCompatible(CPJavaScriptRemedialKeySupport))
         return true;
 

--- a/AppKit/Platform/DOM/CPPlatformWindow+DOMKeys.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOMKeys.j
@@ -159,7 +159,7 @@ CPKeyCodes = {
  */
 CPKeyCodes.firesKeyPressEvent = function(keyCode, key, opt_heldKeyCode, opt_shiftKey, opt_ctrlKey, opt_altKey)
 {
-    if (key.length == 1)
+    if (key && key.length == 1)
         return true;
 
     if (!CPFeatureIsCompatible(CPJavaScriptRemedialKeySupport))

--- a/AppKit/Platform/DOM/CPPlatformWindow+DOMKeys.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOMKeys.j
@@ -159,6 +159,9 @@ CPKeyCodes = {
  */
 CPKeyCodes.firesKeyPressEvent = function(keyCode, key, opt_heldKeyCode, opt_shiftKey, opt_ctrlKey, opt_altKey)
 {
+    // The property key from event is one character wide in case of 'regular' keys (as opposed e.g. to arrow keys)
+    // Regular keys all fire the keypress event
+
     if (key && key.length == 1)
         return true;
 


### PR DESCRIPTION
previously, wrong characters were emitted from keyDown: events in more recent Firefox versions. The reason is that keyCodes do not correspond to characters but rather refer to keys on the keyboard.

The bug is exposed in CPTextView that relies on keyDown: events. CPTextFields are not affected because they are based native input elements.

This patch uses the key property that corresponds to characters and not keys.
Works for me on FireFox, Safari and Chrome.

fixes #2873 