### PR TITLE
Fixed: Update Tracking areas only once when doing setFrame: on a view

### DIFF
--- a/AppKit/CPWindow/CPWindow.j
+++ b/AppKit/CPWindow/CPWindow.j
@@ -264,6 +264,8 @@ var CPWindowActionMessageKeys = [
     BOOL                                _isSheet;
     _CPWindowFrameAnimation             _frameAnimation;
     _CPWindowFrameAnimationDelegate     _frameAnimationDelegate;
+
+    BOOL                                _inhibitUpdateTrackingAreas;    // Used by the CPView when updating tracking areas
 }
 
 + (Class)_binderClassForBinding:(CPString)aBinding


### PR DESCRIPTION
This speed improvement is very notable when resizing a browser window of altering the size of
split views.
The fix uses a variable on the window to control when to update the tracking areas.
If the view is not connected to a window the tracking areas will not be updated as they will
be when added to a window.