### PR TITLE
FIX:  Glyp baseline positions in CPTextView

### DIFF
--- a/AppKit/CPTextView/CPLayoutManager.j
+++ b/AppKit/CPTextView/CPLayoutManager.j
@@ -731,12 +731,12 @@ _oncontextmenuhandler = function () { return false; };
     }
 }
 
-- (void)_setAdvancements:(CPArray)someAdvancements forGlyphRange:(CPRange)glyphRange
+- (void)_setAdvancements:(CPArray)someAdvancements forGlyphRange:(CPRange)glyphRange withLineBase:(CPNumber)lineBase
 {
     var lineFragment = _objectWithLocationInRange(_lineFragments, glyphRange.location);
 
     if (lineFragment)
-        [lineFragment setAdvancements:someAdvancements];
+        [lineFragment setAdvancements:someAdvancements withLineBase:lineBase];
 }
 
 - (void)setLocation:(CGPoint)aPoint forStartOfGlyphRange:(CPRange)glyphRange
@@ -1200,7 +1200,7 @@ var _objectsInRange = function(aList, aRange)
     return self;
 }
 
-- (void)setAdvancements:(CPArray)someAdvancements
+- (void)setAdvancements:(CPArray)someAdvancements withLineBase:(CPNumber)lineBase
 {
     var count = someAdvancements.length,
         origin = CGPointMake(_fragmentRect.origin.x + _location.x, _fragmentRect.origin.y),
@@ -1212,8 +1212,8 @@ var _objectsInRange = function(aList, aRange)
     for (var i = 0; i < count; i++)
     {
         _glyphsFrames[i] = CGRectMake(origin.x, origin.y, someAdvancements[i].width, height);
-        _glyphsFrames[i]._descent = someAdvancements[i].descent;
-        _glyphsOffsets[i] = height - someAdvancements[i].height;
+        _glyphsFrames[i]._descent = 0; //someAdvancements[i].descent;
+        _glyphsOffsets[i] = lineBase - someAdvancements[i].height;
         origin.x += someAdvancements[i].width;
     }
 }

--- a/AppKit/CPTextView/CPTypesetter.j
+++ b/AppKit/CPTextView/CPTypesetter.j
@@ -197,7 +197,7 @@ var CPSystemTypesetterFactory,
     }
 
     [_layoutManager setLocation:CGPointMake(myX, _lineBase) forStartOfGlyphRange:lineRange];
-    [_layoutManager _setAdvancements:advancements forGlyphRange:lineRange];
+    [_layoutManager _setAdvancements:advancements forGlyphRange:lineRange withLineBase:_lineBase];
 
     //fix the _lineFragments when fontsizes differ
     var l = _lineFragments.length;


### PR DESCRIPTION
In the current master, working with fonts in different sizes does not correctly displays the text in the glyps with respect to the baseline. 

Current Master:
![image](https://user-images.githubusercontent.com/20356278/71937471-b6d88300-31ac-11ea-9ea3-eb93b824c0fd.png)

After the fix:
![image](https://user-images.githubusercontent.com/20356278/71937476-bb04a080-31ac-11ea-8bee-9ef450b7acd4.png)
