### PR TITLE
fixed: _glyphsFrames and _glyphsOffsets could be used uninitialized

### DIFF
--- a/AppKit/CPTextView/CPLayoutManager.j
+++ b/AppKit/CPTextView/CPLayoutManager.j
@@ -1156,7 +1156,9 @@ var _objectsInRange = function(aList, aRange)
         _range = CPMakeRangeCopy(aRange);
         _textContainer = aContainer;
         _isInvalid = NO;
-        _runs = [[CPMutableArray alloc] init];
+        _runs = [];
+        _glyphsFrames = [];
+        _glyphsOffsets = [];
 
         for (location = aRange.location; location < CPMaxRange(aRange); location = CPMaxRange(effectiveRange))
         {


### PR DESCRIPTION
previously, CPTextView could crash under certain esoteric conditions from accessing properties of undefined.
this is fixed by this PR