### PR TITLE
FIXED: Before this PR, CPButton never declares that its label should be single line

### DIFF
--- a/AppKit/CPButton.j
+++ b/AppKit/CPButton.j
@@ -764,6 +764,7 @@ CPButtonImageOffset   = 3.0;
         [contentView setAlignment:[self currentValueForThemeAttribute:@"alignment"]];
         [contentView setVerticalAlignment:[self currentValueForThemeAttribute:@"vertical-alignment"]];
         [contentView setLineBreakMode:[self currentValueForThemeAttribute:@"line-break-mode"]];
+        [contentView setUsesSingleLineMode:YES];
         [contentView setTextShadowColor:[self currentValueForThemeAttribute:@"text-shadow-color"]];
         [contentView setTextShadowOffset:[self currentValueForThemeAttribute:@"text-shadow-offset"]];
         [contentView setImagePosition:[self currentValueForThemeAttribute:@"image-position"]];

--- a/AppKit/CPButton.j
+++ b/AppKit/CPButton.j
@@ -764,7 +764,7 @@ CPButtonImageOffset   = 3.0;
         [contentView setAlignment:[self currentValueForThemeAttribute:@"alignment"]];
         [contentView setVerticalAlignment:[self currentValueForThemeAttribute:@"vertical-alignment"]];
         [contentView setLineBreakMode:[self currentValueForThemeAttribute:@"line-break-mode"]];
-        [contentView setUsesSingleLineMode:YES];
+        [contentView _setUsesSingleLineMode:YES];
         [contentView setTextShadowColor:[self currentValueForThemeAttribute:@"text-shadow-color"]];
         [contentView setTextShadowOffset:[self currentValueForThemeAttribute:@"text-shadow-offset"]];
         [contentView setImagePosition:[self currentValueForThemeAttribute:@"image-position"]];

--- a/AppKit/_CPImageAndTextView.j
+++ b/AppKit/_CPImageAndTextView.j
@@ -66,7 +66,7 @@ var _CPimageAndTextViewFrameSizeChangedFlag         = 1 << 0,
     CPString                _text;
 
     CGSize                  _textSize;
-    BOOL                    _usesSingleLineMode @accessors(property=usesSingleLineMode);
+    BOOL                    _usesSingleLineMode @accessors;
 
     unsigned                _flags;
 

--- a/AppKit/_CPImageAndTextView.j
+++ b/AppKit/_CPImageAndTextView.j
@@ -66,7 +66,7 @@ var _CPimageAndTextViewFrameSizeChangedFlag         = 1 << 0,
     CPString                _text;
 
     CGSize                  _textSize;
-    BOOL                    _usesSingleLineMode @accessors;
+    BOOL                    _usesSingleLineMode @accessors(property=usesSingleLineMode);
 
     unsigned                _flags;
 


### PR DESCRIPTION
This PR simply uses the _usesSingleLineMode property of _CPImageAndTextView.