### PR TITLE
Fixed: JavaScriptCore (WebKit) has a limit at 65536 on number of arguments in a function.

### DIFF
--- a/Objective-J/ObjJAcornCompiler.js
+++ b/Objective-J/ObjJAcornCompiler.js
@@ -472,7 +472,7 @@ StringBuffer.prototype.isEmptySourceNode = function()
 StringBuffer.prototype.appendStringBufferString = function(stringBuffer)
 {
     // We can't do 'this.atoms.push.apply(this.atoms, stringBuffer.atoms);' as JavaScriptCore (WebKit) has a limit on number of arguments at 65536.
-    // Other browsers also has simular limits.
+    // Other browsers also have simular limits.
     var thisAtoms = this.atoms;
     var thisLength = thisAtoms.length;
     var stringBufferAtoms = stringBuffer.atoms;

--- a/Objective-J/ObjJAcornCompiler.js
+++ b/Objective-J/ObjJAcornCompiler.js
@@ -471,7 +471,18 @@ StringBuffer.prototype.isEmptySourceNode = function()
 
 StringBuffer.prototype.appendStringBufferString = function(stringBuffer)
 {
-    this.atoms.push.apply(this.atoms, stringBuffer.atoms);
+    // We can't do 'this.atoms.push.apply(this.atoms, stringBuffer.atoms);' as JavaScriptCore (WebKit) has a limit on number of arguments at 65536.
+    // Other browsers also has simular limits.
+    var thisAtoms = this.atoms;
+    var thisLength = thisAtoms.length;
+    var stringBufferAtoms = stringBuffer.atoms;
+    var stringBufferLength = stringBufferAtoms.length;
+
+    thisAtoms.length = thisLength + stringBufferLength;
+
+    for (var i = 0; i < stringBufferLength; i++) {
+        thisAtoms[thisLength + i] = stringBufferAtoms[i];
+    }
 }
 
 StringBuffer.prototype.appendStringBufferSourceNode = function(stringBuffer)


### PR DESCRIPTION
The compiler will crash for really large Objective-J files as the array with code segments will hit this limit.
The solution is to append the array item by item.

I do not find any change on performance with this new implementation.