### PR TITLE
Fixed: Loading cached theme attributes will miss previous cached value.

### DIFF
--- a/AppKit/_CPObject+Theme.j
+++ b/AppKit/_CPObject+Theme.j
@@ -205,7 +205,7 @@ var NULL_THEME = {};
 
         if (cachedAttributes)
         {
-            attributes = attributes.length ? attributes.concat(cachedAttributes) : attributes;
+            attributes = cachedAttributes.length ? attributes.concat(cachedAttributes) : attributes;
             break;
         }
 


### PR DESCRIPTION
Loading cached theme attributes will miss previous cached value if superclass is done before subclass