### PR TITLE
Fixed: Removed old unused line from a bad manual merge

### DIFF
--- a/AppKit/CPView.j
+++ b/AppKit/CPView.j
@@ -3664,7 +3664,6 @@ var CPAppearanceVibrantDark = [CPAppearance appearanceNamed:CPAppearanceNameVibr
 
 - (void)_updateTrackingAreasWithRecursion:(BOOL)shouldCallRecursively
 {
-    _inhibitUpdateTrackingAreas = YES;
     [self _updateTrackingAreasWithRecursion:shouldCallRecursively withReferencingSuperViewVisibleRect:[_superview visibleRect]];
 }
 


### PR DESCRIPTION
A line from a manual merge was left in the code. This does not alter any functionality.