### PR TITLE
New: replaceOccurrencesOfString:(CPString)target withString:(CPString…

### DIFF
--- a/Foundation/CPAttributedString.j
+++ b/Foundation/CPAttributedString.j
@@ -896,12 +896,18 @@ var CPAttributedStringStringKey     = "CPAttributedStringString",
                           options:(int)options
                             range:(CSRange)searchRange
 {
-    var foundRange;
+    var foundRange,
+    searchRangeDynamic = searchRange ? CPMakeRangeCopy(searchRange) : CPMakeRange(0, [_string length]),
+    searchRangeLengthOffset = replacement.length - target.length;
+
 
     for (var replacements = 0;
-         (foundRange = [_string rangeOfString:target options:options range:searchRange]), foundRange.location != CPNotFound;
+         (foundRange = [_string rangeOfString:target options:options range:searchRangeDynamic]), foundRange.location != CPNotFound;
          replacements++)
+    {
         [self replaceCharactersInRange:foundRange withString:replacement];
+        searchRangeDynamic.length += searchRangeLengthOffset;
+    }
 
     return replacements;
 }

--- a/Foundation/CPAttributedString.j
+++ b/Foundation/CPAttributedString.j
@@ -901,7 +901,7 @@ var CPAttributedStringStringKey     = "CPAttributedStringString",
     for (var replacements = 0;
          (foundRange = [_string rangeOfString:target options:options range:searchRange]), foundRange.location != CPNotFound;
          replacements++)
-        [attributedString replaceCharactersInRange:foundRange withString:replacement];
+        [self replaceCharactersInRange:foundRange withString:replacement];
 
     return replacements;
 }

--- a/Foundation/CPAttributedString.j
+++ b/Foundation/CPAttributedString.j
@@ -891,10 +891,10 @@ var CPAttributedStringStringKey     = "CPAttributedStringString",
     Replaces all occurrences of the target string in a given range with a replacement string. Returns the number of replacements.
  */
 
-- (int)replaceOccurrencesOfString:(CPString)target
-                       withString:(CPString)replacement
-                          options:(int)options
-                            range:(CSRange)searchRange
+- (CPUInteger)replaceOccurrencesOfString:(CPString)target
+                              withString:(CPString)replacement
+                                 options:(CPStringCompareOptions)options
+                                   range:(CSRange)searchRange
 {
     var foundRange,
     searchRangeDynamic = searchRange ? CPMakeRangeCopy(searchRange) : CPMakeRange(0, [_string length]),

--- a/Foundation/CPAttributedString.j
+++ b/Foundation/CPAttributedString.j
@@ -887,6 +887,25 @@ var CPAttributedStringStringKey     = "CPAttributedStringString",
 */
 @implementation CPMutableAttributedString : CPAttributedString
 
+/*!
+    Replaces all occurrences of the target string in a given range with a replacement string. Returns the number of replacements.
+ */
+
+- (int)replaceOccurrencesOfString:(CPString)target
+                       withString:(CPString)replacement
+                          options:(int)options
+                            range:(CSRange)searchRange
+{
+    var foundRange;
+
+    for (var replacements = 0;
+         (foundRange = [_string rangeOfString:target options:options range:searchRange]), foundRange.location != CPNotFound;
+         replacements++)
+        [attributedString replaceCharactersInRange:foundRange withString:replacement];
+
+    return replacements;
+}
+
 @end
 
 var isEqual = function(a, b)

--- a/Foundation/CPAttributedString.j
+++ b/Foundation/CPAttributedString.j
@@ -898,8 +898,7 @@ var CPAttributedStringStringKey     = "CPAttributedStringString",
 {
     var foundRange,
     searchRangeDynamic = searchRange ? CPMakeRangeCopy(searchRange) : CPMakeRange(0, [_string length]),
-    searchRangeLengthOffset = replacement.length - target.length;
-
+    searchRangeLengthOffset = [replacement length] - [target length];
 
     for (var replacements = 0;
          (foundRange = [_string rangeOfString:target options:options range:searchRangeDynamic]), foundRange.location != CPNotFound;


### PR DESCRIPTION
…)replacement options:(int)options range:(CSRange)searchRange

this implementation was missing in CPMutableAttributedString