### PR TITLE
Fix: CPKeyedArchiver method call does not match selector tested

### DIFF
--- a/Foundation/CPKeyedArchiver.j
+++ b/Foundation/CPKeyedArchiver.j
@@ -191,7 +191,7 @@ var _CPKeyedArchiverStringClass                         = Nil,
 */
 - (void)finishEncoding
 {
-    if (_delegate && _delegateSelectors & _CPKeyedArchiverDidFinishEncodingSelector)
+    if (_delegate && _delegateSelectors & _CPKeyedArchiverWillFinishEncodingSelector)
         [_delegate archiverWillFinish:self];
 
     var i = 0,
@@ -299,10 +299,10 @@ var _CPKeyedArchiverStringClass                         = Nil,
     if ([_delegate respondsToSelector:@selector(archiver:willReplaceObject:withObject:)])
         _delegateSelectors |= _CPKeyedArchiverWillReplaceObjectWithObjectSelector;
 
-    if ([_delegate respondsToSelector:@selector(archiver:didFinishEncoding:)])
+    if ([_delegate respondsToSelector:@selector(archiverDidFinish:)])
         _delegateSelectors |= _CPKeyedArchiverDidFinishEncodingSelector;
 
-    if ([_delegate respondsToSelector:@selector(archiver:willFinishEncoding:)])
+    if ([_delegate respondsToSelector:@selector(archiverWillFinish:)])
         _delegateSelectors |= _CPKeyedArchiverWillFinishEncodingSelector;
 
 }


### PR DESCRIPTION
Delegate methods described on lines 76 and 85 are not the selectors
checked on lines 305 and line 302, but are the methods actually called
on the delegate on lines 195 and 225. This fix updates the method
selectors checked on the delegate, to match those defined and called
within the CPKeyedArchiver class.

Fixes #2679