### PR TITLE
FIXED: Before this PR, the classname was not specified in the correct DOM element

### DIFF
--- a/AppKit/CPImage.j
+++ b/AppKit/CPImage.j
@@ -685,7 +685,7 @@ function CPAppKitImage(aFilename, aSize)
             aStyleNode.replaceChild(styleDescription, aStyleNode.firstChild);
         }
 
-        [aView setDOMClassName:@"CP"+[aView UID]];
+        aDOMElement.className = @"CP"+[aView UID];
     }
     else
     {


### PR DESCRIPTION
The classname for CSS theming was not specified in the correct DOM element.