### PR TITLE
FIXED: Before this PR, theme color values with alpha component weren't correctly compiled

### DIFF
--- a/AppKit/CPColor.j
+++ b/AppKit/CPColor.j
@@ -561,7 +561,11 @@ var cachedBlackColor,
 
 - (void)_initCSSStringFromComponents
 {
-    var hasAlpha = CPFeatureIsCompatible(CPCSSRGBAFeature) && _components[3] != 1.0;
+    // Fix to avoid a problem when compiling a theme (missing the alpha component as theme compiler doesn't have CSS rgba capability)
+    var hasAlpha = YES;
+#if PLATFORM(DOM)
+    hasAlpha = CPFeatureIsCompatible(CPCSSRGBAFeature) && _components[3] != 1.0;
+#endif
 
     _cssString = (hasAlpha ? "rgba(" : "rgb(") +
         parseInt(_components[0] * 255.0) + ", " +


### PR DESCRIPTION
Fixes a theme compilation problem because of lack of rgba capability of the compiler.