### PR TITLE
NEW: This PR adds a class method to BKThemeDescriptor that enables a view to inherit theme values of another view

### DIFF
--- a/AppKit/Themes/BlendKit/BKThemeDescriptor.j
+++ b/AppKit/Themes/BlendKit/BKThemeDescriptor.j
@@ -325,6 +325,15 @@ var ItemSizes               = { },
         [self registerThemeValues:themeValues forView:aView];
 }
 
++ (void)registerThemeValues:(CPArray)themeValues forView:(CPView)aView inheritFrom:(CPView)anotherView
+{
+    if (anotherView)
+        // We take all theme attributes values from anotherView
+        [aView _addThemeAttributeDictionary:[anotherView _themeAttributeDictionary]];
+
+    [self registerThemeValues:themeValues forView:aView];
+}
+
 @end
 
 function BKLabelFromIdentifier(anIdentifier)

--- a/AppKit/_CPObject+Theme.j
+++ b/AppKit/_CPObject+Theme.j
@@ -300,6 +300,22 @@ var NULL_THEME = {};
     return dictionary;
 }
 
+- (void)_addThemeAttributeDictionary:(CPDictionary)themeAttributeDictionary
+{
+    if (!themeAttributeDictionary)
+        return;
+
+    var keys = [themeAttributeDictionary allKeys];
+
+    for (var i = 0, count = [keys count], key, value; i < count; i++)
+    {
+        key = keys[i];
+        value = [themeAttributeDictionary objectForKey:key];
+
+        _themeAttributes[key] = value;
+    }
+}
+
 - (void)setValue:(id)aValue forThemeAttribute:(CPString)aName inState:(ThemeState)aState
 {
 #if DEBUG


### PR DESCRIPTION
This PR adds a class method to BKThemeDescriptor that enables a view to inherit theme values of another view.
This new method can be used in ThemeDescriptor.j