### PR TITLE
NEW: This PR makes system font themable

### DIFF
--- a/AppKit/CPControl.j
+++ b/AppKit/CPControl.j
@@ -23,11 +23,12 @@
 @import <Foundation/CPFormatter.j>
 @import <Foundation/CPTimer.j>
 
-@import "CPFont.j"
 @import "CPShadow.j"
 @import "CPText.j"
 @import "CPKeyValueBinding.j"
 @import "CPTrackingArea.j"
+
+@class CPFont
 
 @global CPApp
 
@@ -47,6 +48,9 @@
 CPRegularControlSize = 0;
 CPSmallControlSize   = 1;
 CPMiniControlSize    = 2;
+
+// To get the theme state corresponding to a control size, use CPControlSizeThemeStates[controlSize]
+CPControlSizeThemeStates = @[CPThemeStateControlSizeRegular, CPThemeStateControlSizeSmall, CPThemeStateControlSizeMini];
 
 @typedef CPLineBreakMode
 CPLineBreakByWordWrapping     = 0;
@@ -131,7 +135,7 @@ var CPControlBlackColor = [CPColor blackColor];
             @"vertical-alignment": CPTopVerticalTextAlignment,
             @"line-break-mode": CPLineBreakByClipping,
             @"text-color": [CPColor blackColor],
-            @"font": [CPFont systemFontOfSize:CPFontCurrentSystemSize],
+            @"font": [CPNull null],
             @"text-shadow-color": [CPNull null],
             @"text-shadow-offset": CGSizeMakeZero(),
             @"image-position": CPImageLeft,
@@ -195,7 +199,8 @@ var CPControlBlackColor = [CPColor blackColor];
     {
         _sendActionOn           = CPLeftMouseUpMask;
         _trackingMouseDownFlags = 0;
-        
+
+        [self setControlSize:CPThemeStateControlSizeRegular];
         [self updateTrackingAreas];
     }
 

--- a/AppKit/CPTheme.j
+++ b/AppKit/CPTheme.j
@@ -49,6 +49,8 @@ var CPThemesByName          = { },
 + (void)setDefaultTheme:(CPTheme)aTheme
 {
     CPThemeDefaultTheme = aTheme;
+
+    [CPFont initializeSystemFontFromTheme:aTheme];
 }
 
 + (CPTheme)defaultTheme


### PR DESCRIPTION
With this PR, you can now specify : 
- System font face
- System font sizes for regular, small and mini controls
- the CSS code to be injected in order to use specific fonts

For example, the following declaration is used in the ThemeDescriptors.j file of Aristo3 : 

```
+ (CPFont)themedFont
{
    var font = [CPFont systemFontOfSize:12],

    themeFontStyle = @"@font-face { font-family: 'SFNSText'; src: local('.SFNSText-Light'), url('%%/fonts/SFNSText-Light.woff') format('woff'); font-weight: 300 }\n"
                   + @"@font-face { font-family: 'SFNSText'; src: local('.SFNSText-Medium'), url('%%/fonts/SFNSText-Medium.woff') format('woff'); font-weight: 500 }\n"
                   + @"@font-face { font-family: 'SFNSDisplay'; src: local('.SFNSDisplay-Light'), url('%%/fonts/SFNSDisplay-Light.woff') format('woff'); font-weight: 300 }\n"
                   + @"@font-face { font-family: 'SFNSDisplay'; src: local('.SFNSDisplay-Medium'), url('%%/fonts/SFNSDisplay-Medium.woff') format('woff'); font-weight: 500 }\n"
                   + @"@font-face { font-family: 'SFNSText'; src: local('.SFNSText'), url('%%/fonts/SFNSText-Regular.woff') format('woff'); font-weight: 400 }\n"
                   + @"@font-face { font-family: 'SFNSText'; src: local('.SFNSText-Bold'), url('%%/fonts/SFNSText-Bold.woff') format('woff'); font-weight: 600 }\n"
                   + @"@font-face { font-family: 'SFNSDisplay'; src: local('.SFNSDisplay'), url('%%/fonts/SFNSDisplay-Regular.woff') format('woff'); font-weight: 400 }\n"
                   + @"@font-face { font-family: 'SFNSDisplay'; src: local('.SFNSDisplay-Bold'), url('%%/fonts/SFNSDisplay-Bold.woff') format('woff'); font-weight: 600 }\n"
                   + @"html, body, h1, p { text-rendering: optimizeLegibility; }\n"
                   + @"}\n";

    [self registerThemeValues:[
                               [@"system-font-face", @"SFNSText, Helvetica Neue"],
                               [@"system-font-size-regular", 13],
                               [@"system-font-size-small", 11],
                               [@"system-font-size-mini", 9],
                               [@"system-font-style", themeFontStyle]
                               ]
                      forObject:font];

    return font;
}

```
