### PR TITLE
NEW: This PR adds the ability to control CPPopoverWindow background color.

### DIFF
--- a/AppKit/_CPPopoverWindow.j
+++ b/AppKit/_CPPopoverWindow.j
@@ -25,6 +25,7 @@
 @import "CPButton.j"
 @import "CPMenu.j"
 @import "CPPanel.j"
+@import "CPAnimationContext.j"
 
 // Use forward declaration because this file is imported by CPPopover
 @class CPPopover
@@ -117,7 +118,11 @@ var _CPPopoverWindow_shouldClose_    = 1 << 4,
         _isClosing                  = NO;
         _browserAnimates            = [self browserSupportsAnimation];
         _shouldPerformAnimation     = YES;
-        _orderOutTransitionFunction = function() { [self _orderOutRecursively:YES]; };
+        _orderOutTransitionFunction = function()
+                                        {
+                                            [self _orderOutRecursively:YES];
+                                            [_windowView _restoreViewBackgroundColor];
+                                        };
         _isOpening                  = YES;
 
         [self setStyleMask:aStyleMask];


### PR DESCRIPTION
This introduces a Cappuccino specific behavior that permits to control the background color of the popover by setting a background color on the content view.

One can, using this, create "post-it" like yellow popovers : 

- Without doing anything (usual situation) : 

![before](https://user-images.githubusercontent.com/2394110/91638825-74e99f00-ea12-11ea-9810-b4334f13b0bc.png)

- After setting content view background to rgb 254, 246, 156 : 

![after](https://user-images.githubusercontent.com/2394110/91638855-977bb800-ea12-11ea-906c-d026c212e54c.png)

- Without this PR (after setting content view background) : 

![without](https://user-images.githubusercontent.com/2394110/91639199-3b666300-ea15-11ea-9380-1f28ea783bf3.png)
