### PR TITLE
NEW: This PR provides more information on an error message in CPScroller

### DIFF
--- a/AppKit/CPScroller.j
+++ b/AppKit/CPScroller.j
@@ -259,7 +259,7 @@ CPThemeStateScrollerKnobDark    = CPThemeState("scroller-knob-dark");
 - (void)setKnobProportion:(float)aProportion
 {
     if (!_IS_NUMERIC(aProportion))
-        [CPException raise:CPInvalidArgumentException reason:"aProportion must be numeric"];
+        [CPException raise:CPInvalidArgumentException reason:"aProportion must be numeric (received:"+aProportion+")"];
 
     _knobProportion = MIN(1.0, MAX(0.0001, aProportion));
 

--- a/AppKit/CPScroller.j
+++ b/AppKit/CPScroller.j
@@ -259,7 +259,7 @@ CPThemeStateScrollerKnobDark    = CPThemeState("scroller-knob-dark");
 - (void)setKnobProportion:(float)aProportion
 {
     if (!_IS_NUMERIC(aProportion))
-        [CPException raise:CPInvalidArgumentException reason:"aProportion must be numeric (received:"+aProportion+")"];
+        [CPException raise:CPInvalidArgumentException reason:"aProportion must be numeric, was: "+aProportion];
 
     _knobProportion = MIN(1.0, MAX(0.0001, aProportion));
 


### PR DESCRIPTION
Just added the bad value received.
This PR is not mandatory at all (but it's a very easy one).