### PR TITLE
FIXED: This PR fixes correct parameter type in CPViewAnimator -setAlphaValue

### DIFF
--- a/AppKit/CoreAnimation/CPViewAnimator.j
+++ b/AppKit/CoreAnimation/CPViewAnimator.j
@@ -37,7 +37,7 @@ var DEFAULT_CSS_PROPERTIES = nil,
     [self _setTargetValue:YES withKeyPath:@"CPAnimationTriggerOrderOut" setter:_cmd];
 }
 
-- (void)setAlphaValue:(CGPoint)alphaValue
+- (void)setAlphaValue:(float)alphaValue
 {
     [self _setTargetValue:alphaValue withKeyPath:@"alphaValue" setter:_cmd];
 }


### PR DESCRIPTION
```alphaValue``` is a float, not a CGPoint.
