### PR TITLE
FIXED: This PR supports modern Cocoa behavior regarding radio buttons groups.

### DIFF
--- a/AppKit/CPRadio.j
+++ b/AppKit/CPRadio.j
@@ -163,15 +163,19 @@ CPRadioImageOffset = 4.0;
 - (void)awakeFromCib
 {
     // Implementation of modern Cocoa behavior : automatic radio group
-    // Search for first CPRadio subview of my superview having an action set.
+    // Search for first CPRadio subview of my superview having the same action as me (if any).
     // If this is me, do nothing.
-    // If this is another radio button and if we have the same action, set my radio group to its, so we'll live in the same radio group.
+    // If this is another radio button, set my radio group to its, so we'll live in the same radio group.
+
+    if (![self action])
+        // I have no action set, so there can be no grouping
+        return;
 
     for (var i = 0, superviewSubviews = [[self superview] subviews], count = [superviewSubviews count], firstRadioButton; (i < count) && !firstRadioButton; i++)
-        if ([superviewSubviews[i] isKindOfClass:CPRadio] && [superviewSubviews[i] action])
+        if ([superviewSubviews[i] isKindOfClass:CPRadio] && ([superviewSubviews[i] action] === [self action]))
             firstRadioButton = superviewSubviews[i];
 
-    if ((firstRadioButton !== self) && ([self action] === [firstRadioButton action]))
+    if (firstRadioButton && (firstRadioButton !== self))
         [self setRadioGroup:[firstRadioButton radioGroup]];
 }
 

--- a/AppKit/CPRadio.j
+++ b/AppKit/CPRadio.j
@@ -171,7 +171,7 @@ CPRadioImageOffset = 4.0;
         if ([superviewSubviews[i] isKindOfClass:CPRadio] && [superviewSubviews[i] action])
             firstRadioButton = superviewSubviews[i];
 
-    if ((firstRadioButton !== self) && [self action] && ([self action] === [firstRadioButton action]))
+    if ((firstRadioButton !== self) && ([self action] === [firstRadioButton action]))
         [self setRadioGroup:[firstRadioButton radioGroup]];
 }
 

--- a/AppKit/CPRadio.j
+++ b/AppKit/CPRadio.j
@@ -67,6 +67,18 @@ CPRadioImageOffset = 4.0;
     [[button1 radioGroup] selectedRadio] returns the currently selected
     option.
 
+    UPDATE 09/2020 : Implementation of modern Cocoa behavior :
+
+    As in Cocoa, radio buttons grouping is now automatic.
+
+    To be associated in a common group (and so being mutually exclusive),
+    radio buttons must combine 2 criteria :
+
+    - same superview (enclosing view)
+    - same action
+
+    TODO: This first implementation uses "as is" CPRadioGroup. This could
+          be simplified (no more need for radio group action, for example)
 */
 @implementation CPRadio : CPButton
 {
@@ -168,6 +180,9 @@ CPRadioImageOffset = 4.0;
 
 - (void)setAction:(SEL)anAction
 {
+    if (anAction === _action)
+        return;
+
     [super setAction:anAction];
     [self _setRadioGroup];
 }
@@ -178,7 +193,7 @@ CPRadioImageOffset = 4.0;
 {
     // Implementation of modern Cocoa behavior : automatic radio group
 
-    // If I have no action set or no superview, no grouping can be done.
+    // If no action is set or no superview, no grouping can be done.
     if (![self action] || ![self superview])
     {
         // If I'm in a group (size > 1), remove me.
@@ -188,7 +203,7 @@ CPRadioImageOffset = 4.0;
         return;
     }
 
-    // OK. Search now in my superview subviews for other radio buttons having the same action as mine.
+    // Search in superview subviews for other radio buttons having the same action.
     // Take the one with the radio group having the greatest number of members.
 
     var radioGroup;
@@ -206,6 +221,12 @@ CPRadioImageOffset = 4.0;
 
     if (radioGroup)
         [self setRadioGroup:radioGroup];
+    else
+        // No other radio buttons to group with found.
+        // It may be because this radio button was in a radio group and its action was changed.
+        // If this is the case, we must reisolate it in a new radio group.
+        if ([_radioGroup size] > 1)
+            [self setRadioGroup:[CPRadioGroup new]];
 }
 
 @end

--- a/AppKit/CPRadio.j
+++ b/AppKit/CPRadio.j
@@ -163,12 +163,12 @@ CPRadioImageOffset = 4.0;
 - (void)awakeFromCib
 {
     // Implementation of modern Cocoa behavior : automatic radio group
-    // Search for first CPRadio subview of my superview.
+    // Search for first CPRadio subview of my superview having an action set.
     // If this is me, do nothing.
     // If this is another radio button and if we have the same action, set my radio group to its, so we'll live in the same radio group.
 
     for (var i = 0, superviewSubviews = [[self superview] subviews], count = [superviewSubviews count], firstRadioButton; (i < count) && !firstRadioButton; i++)
-        if ([superviewSubviews[i] isKindOfClass:CPRadio])
+        if ([superviewSubviews[i] isKindOfClass:CPRadio] && [superviewSubviews[i] action])
             firstRadioButton = superviewSubviews[i];
 
     if ((firstRadioButton !== self) && [self action] && ([self action] === [firstRadioButton action]))

--- a/AppKit/CPRadio.j
+++ b/AppKit/CPRadio.j
@@ -160,6 +160,21 @@ CPRadioImageOffset = 4.0;
         [CPApp sendAction:[_radioGroup action] to:[_radioGroup target] from:_radioGroup];
 }
 
+- (void)awakeFromCib
+{
+    // Implementation of modern Cocoa behavior : automatic radio group
+    // Search for first CPRadio subview of my superview.
+    // If this is me, do nothing.
+    // If this is another radio button and if we have the same action, set my radio group to its, so we'll live in the same radio group.
+
+    for (var i = 0, superviewSubviews = [[self superview] subviews], count = [superviewSubviews count], firstRadioButton; (i < count) && !firstRadioButton; i++)
+        if ([superviewSubviews[i] isKindOfClass:CPRadio])
+            firstRadioButton = superviewSubviews[i];
+
+    if ((firstRadioButton !== self) && [self action] && ([self action] === [firstRadioButton action]))
+        [self setRadioGroup:[firstRadioButton radioGroup]];
+}
+
 @end
 
 var CPRadioRadioGroupKey    = @"CPRadioRadioGroupKey";

--- a/Tests/AppKit/CPButtonTest.j
+++ b/Tests/AppKit/CPButtonTest.j
@@ -189,6 +189,69 @@
     [self assertTrue:wasClicked message:@"a user click on a radio button should fire the group action"];
 }
 
+- (void)testAutomaticRadioGroup
+{
+    var radioButton1 = [CPRadio radioWithTitle:@"Radio 1"],
+        radioButton2 = [CPRadio radioWithTitle:@"Radio 2"],
+        radioButton3 = [CPRadio radioWithTitle:@"Radio 3"],
+        simpleView1  = [[CPView alloc] initWithFrame:CGRectMakeZero()],
+        simpleView2  = [[CPView alloc] initWithFrame:CGRectMakeZero()];
+
+    // Initially, buttons are isolated
+    [self assertFalse:([radioButton1 radioGroup] === [radioButton2 radioGroup]) message:@"initially, buttons should be isolated"];
+
+    [simpleView1 addSubview:radioButton1];
+    [simpleView1 addSubview:radioButton2];
+
+    // As no actions are defined, buttons are still isolated
+    [self assertFalse:([radioButton1 radioGroup] === [radioButton2 radioGroup]) message:@"no actions defined, buttons should be isolated"];
+
+    [radioButton1 setAction:@selector(dummyAction1:)];
+    [radioButton2 setAction:@selector(dummyAction2:)];
+
+    // As different actions are defined, buttons are still isolatdd
+    [self assertFalse:([radioButton1 radioGroup] === [radioButton2 radioGroup]) message:@"different actions defined, buttons should be isolated"];
+
+    [radioButton2 setAction:@selector(dummyAction1:)];
+
+    // As the same action is defined, buttons must be grouped
+    [self assertTrue:([radioButton1 radioGroup] === [radioButton2 radioGroup]) message:@"same action defined, buttons should be grouped"];
+
+    [radioButton3 setAction:@selector(dummyAction1:)];
+
+    // As radioButton3 is not inserted in a view, it's isolated
+    [self assertTrue:([[radioButton3 radioGroup] size] === 1) message:@"not in a view, button should be isolated"];
+
+    [simpleView2 addSubview:radioButton3];
+
+    // As radioButton3 is in another view, it's isolated from radioButton1 & 2
+    [self assertTrue:([[radioButton3 radioGroup] size] === 1) message:@"alone in a view, button should be isolated"];
+
+    [simpleView1 addSubview:radioButton3];
+
+    // As all 3 buttons are in the same view, with the same action, they are grouped
+    [self assertTrue:([[radioButton3 radioGroup] size] === 3) message:@"after moving to the same view, buttons should be grouped"];
+
+    [radioButton3 setAction:@selector(dummyAction2:)];
+
+    // As the action of button 3 is now different, it's isolated
+    [self assertTrue:([[radioButton3 radioGroup] size] === 1) message:@"after changing the action, button 3 should be isolated"];
+
+    // And buttons 1 & 2 are still grouped
+    [self assertTrue:([radioButton1 radioGroup] === [radioButton2 radioGroup]) message:@"buttons 1 & 2 should remain grouped"];
+    [self assertTrue:([[radioButton1 radioGroup] size] === 2) message:@"radio group should contain only buttons 1 & 2"];
+}
+
+- (IBAction)dummyAction1:(id)sender
+{
+
+}
+
+- (IBAction)dummyAction2:(id)sender
+{
+
+}
+
 - (void)testTypeMasks
 {
     button = [[CPButton alloc] initWithFrame:CGRectMakeZero()];


### PR DESCRIPTION
The current Interface Builder mechanism relies on buttons having the same containing view and sharing an IBAction. Beyond those two requirements, everything is automatic.

This PR fixes #2901 