### PR TITLE
FIXED: Before this PR, CPButton's won't display their title

### DIFF
--- a/AppKit/CPControl.j
+++ b/AppKit/CPControl.j
@@ -917,7 +917,7 @@ var CPControlBlackColor = [CPColor blackColor];
 */
 - (CPFont)font
 {
-    return [self valueForThemeAttribute:@"font"];
+    return [self currentValueForThemeAttribute:@"font"] || [CPFont systemFontForControlSize:_controlSize];
 }
 
 /*!
@@ -1127,6 +1127,7 @@ var CPControlActionKey                  = @"CPControlActionKey",
         [self setControlSize:[aCoder decodeIntForKey:CPControlControlSizeKey]];
 
         [self setBaseWritingDirection:[aCoder decodeIntForKey:CPControlBaseWrittingDirectionKey]];
+        [self updateTrackingAreas];
     }
 
     return self;


### PR DESCRIPTION
With #2920, CPButton's now set their font using [self font]. The corresponding adaptation in CPControl was missing in the previous PR.