### PR TITLE
Fix version check for XcodeCapp compatibility with Big Sur

### DIFF
--- a/Tools/XcodeCapp/Jakefile
+++ b/Tools/XcodeCapp/Jakefile
@@ -23,7 +23,7 @@ task ("build", function()
                 majorVersion = parseInt(versions[0], 10),
                 minorVersion = parseInt(versions[1], 10),
                 buildVersion = parseInt(versions[2], 10);
-				
+
 			if (!((majorVersion == 11) || (majorVersion == 10 && minorVersion >= 12)))
             {
                 colorPrint("XcodeCapp requires at least macOS Sierra.", "red");

--- a/Tools/XcodeCapp/Jakefile
+++ b/Tools/XcodeCapp/Jakefile
@@ -24,7 +24,7 @@ task ("build", function()
                 minorVersion = parseInt(versions[1], 10),
                 buildVersion = parseInt(versions[2], 10);
 
-			if (!((majorVersion == 11) || (majorVersion == 10 && minorVersion >= 12)))
+        if (!((majorVersion == 11) || (majorVersion == 10 && minorVersion >= 12)))
             {
                 colorPrint("XcodeCapp requires at least macOS Sierra.", "red");
 

--- a/Tools/XcodeCapp/Jakefile
+++ b/Tools/XcodeCapp/Jakefile
@@ -23,10 +23,10 @@ task ("build", function()
                 majorVersion = parseInt(versions[0], 10),
                 minorVersion = parseInt(versions[1], 10),
                 buildVersion = parseInt(versions[2], 10);
-
-            if (majorVersion < 10 || minorVersion < 7)
+				
+			if (!((majorVersion == 11) || (majorVersion == 10 && minorVersion >= 12)))
             {
-                colorPrint("XcodeCapp can only be built on Mac OS X 10.7+. You can download the binary here: https://www.dropbox.com/sh/gxdgm356gyb9tqc/rFNyl8hcVG", "red");
+                colorPrint("XcodeCapp requires at least macOS Sierra.", "red");
 
                 p.stdin.close();
                 p.stdout.close();


### PR DESCRIPTION
Fixed - compatibility check for building XcodeCapp depends on outmoded macOS version numbering scheme.