### PR TITLE
FIXED: Before this PR, CPTabView was badly positioned 

### DIFF
--- a/Tools/nib2cib/NSTabView.j
+++ b/Tools/nib2cib/NSTabView.j
@@ -51,6 +51,9 @@
 
 - (void)awakeFromNib
 {
+    // First, let CPView do its magic
+    [super awakeFromNib];
+
     // We have to call _adjustNib2CibSize here as during NS_initWithCoder, view is not totally loaded.
     [self _adjustNib2CibSize];
 }


### PR DESCRIPTION
A call to ```[super awakeFromCib]``` was missing in nib2cib ```NSTabView.j``` (it was commented for tests in development branch).

This PR simply reintroduces this call.
