### PR TITLE
FIXED: Before this PR, outlet connection decoding was done before views are ready

### DIFF
--- a/AppKit/Cib/_CPCibObjectData.j
+++ b/AppKit/Cib/_CPCibObjectData.j
@@ -31,6 +31,7 @@
 @import "CPCibOutletConnector.j"
 @import "CPCibRuntimeAttributesConnector.j"
 @import "CPClipView.j"
+@import "_CPCibCustomObject.j"
 
 @class CPScrollView
 
@@ -163,7 +164,6 @@ var _CPCibObjectDataNamesKeysKey                = @"_CPCibObjectDataNamesKeysKey
         _classesKeys = [aCoder decodeObjectForKey:_CPCibObjectDataClassesKeysKey];
         _classesValues = [aCoder decodeObjectForKey:_CPCibObjectDataClassesValuesKey];
 
-        _connections = [aCoder decodeObjectForKey:_CPCibObjectDataConnectionsKey];
         //id              _fontManager;
 
         _framework = [aCoder decodeObjectForKey:_CPCibObjectDataFrameworkKey];
@@ -179,6 +179,8 @@ var _CPCibObjectDataNamesKeysKey                = @"_CPCibObjectDataNamesKeysKey
         _fileOwner = [aCoder decodeObjectForKey:_CPCibObjectDataFileOwnerKey];
 
         _visibleWindows = [aCoder decodeObjectForKey:_CPCibObjectDataVisibleWindowsKey];
+
+        _connections = [aCoder decodeObjectForKey:_CPCibObjectDataConnectionsKey];
     }
 
     return self;

--- a/Tools/nib2cib/NSIBObjectData.j
+++ b/Tools/nib2cib/NSIBObjectData.j
@@ -50,8 +50,6 @@
         _classesKeys = [aCoder decodeObjectForKey:@"NSClassesKeys"];
         _classesValues = [aCoder decodeObjectForKey:@"NSClassesValues"];
 
-        _connections = [aCoder decodeObjectForKey:@"NSConnections"];
-
         //_fontManager = [aCoder decodeObjectForKey:@"NSFontManager"] retain];
         _framework = [aCoder decodeObjectForKey:@"NSFramework"];
 
@@ -67,6 +65,8 @@
 
         _fileOwner = [aCoder decodeObjectForKey:@"NSRoot"];
         _visibleWindows = [aCoder decodeObjectForKey:@"NSVisibleWindows"];
+
+        _connections = [aCoder decodeObjectForKey:@"NSConnections"];
     }
 
     return self;


### PR DESCRIPTION
This PR simply moves the connections decoding at the end of the initWithCoder: process.
It does it also in the nib2cib process.