### PR TITLE
FIXED: Before this PR, imagesize would provide image size in points (that is, taking care of the image resolution) instead of pixels

### DIFF
--- a/Tools/imagesize/imagesize.m
+++ b/Tools/imagesize/imagesize.m
@@ -22,9 +22,16 @@ int getImageSize(const char* utf8Path, BOOL appendLineFeed)
 	if (!image)
 		return kErrInvalidPath;
 		
-	NSSize size = [image size];
-	
-	NSMutableString* result = [NSMutableString stringWithFormat:@"{\"width\":%g, \"height\":%g}", size.width, size.height];
+    NSArray *representations = [image representations];
+
+    if ([representations count] == 0)
+        return kErrInvalidPath;
+
+    NSImageRep *representation = representations[0];
+    NSInteger width  = [representation pixelsWide];
+    NSInteger height = [representation pixelsHigh];
+
+    NSMutableString* result = [NSMutableString stringWithFormat:@"{\"width\":%ld, \"height\":%ld}", (long)width, (long)height];
 
 	if (appendLineFeed)
 		[result appendString:@"\n"];


### PR DESCRIPTION
This PR simply uses ```NSImageRep``` ```pixelsWide``` and ```pixelsHigh``` methods to get correct sizes.

Please note that this PR only impacts CIB based applications as for code created images, size is either specified manually, either determined using the HTML IMG object ```width``` and ```height``` attributes, so in pixels size.