### PR TITLE
FIXED: Before this PR, CGContextSetShadow wasn't initializing the shadow color

### DIFF
--- a/AppKit/CoreGraphics/CGContextCanvas.j
+++ b/AppKit/CoreGraphics/CGContextCanvas.j
@@ -416,6 +416,7 @@ function CGContextSetShadow(aContext, aSize, aBlur)
     aContext.shadowOffsetX = aSize.width;
     aContext.shadowOffsetY = aSize.height;
     aContext.shadowBlur = aBlur;
+    aContext.shadowColor = [[CPColor shadowColor] cssString];
 }
 
 function CGContextSetShadowWithColor(aContext, aSize, aBlur, aColor)


### PR DESCRIPTION
As CGContextSetShadow wasn't initializing the shadow color to standard ```[CPColor shadowColor]```, the shadow color was still null, thus disabling shadowing in Canvas.

This PR simply adds the needed shadow initialization.