### PR TITLE
fixed: sharedApplication was instantiating the wrong class in subclas…

### DIFF
--- a/AppKit/CPApplication.j
+++ b/AppKit/CPApplication.j
@@ -132,7 +132,7 @@ var CPApplicationDelegate_applicationShouldTerminate_           = 1 << 0,
 + (CPApplication)sharedApplication
 {
     if (!CPApp)
-        CPApp = [[CPApplication alloc] init];
+        CPApp = [[self alloc] init];
 
     return CPApp;
 }


### PR DESCRIPTION
…ses of CPApplication

previously, CPApplication was hard-coded.
this PR makes sharedApplication instantiating the CPApp of the correct class