### PR TITLE
fixed: width of text sizing was slightly off in chrome

### DIFF
--- a/AppKit/CPSegmentedControl.j
+++ b/AppKit/CPSegmentedControl.j
@@ -802,7 +802,8 @@ CPSegmentSwitchTrackingMomentary = 2;
             label = [segment label],
             image = [segment image];
 
-        width = (label ? [label sizeWithFont:[self font]].width : 4.0) + (image ? [image size].width : 0) + contentInsetWidth;
+        // add 1 pixel to account for possible fractional pixels at right edge
+        width = (label ? [label sizeWithFont:[self font]].width + 1 : 4.0) + (image ? [image size].width : 0) + contentInsetWidth;
     }
 
     return CGRectMake(left, top, width, height);

--- a/AppKit/CPStringDrawing.j
+++ b/AppKit/CPStringDrawing.j
@@ -104,12 +104,18 @@ CPStringSizeCachingEnabled = YES;
         if (fontHeight === undefined)
             fontHeight = CPStringSizeWithFontHeightCache[cssString] = [aFont defaultLineHeightForFont];
 
-        size = CGSizeMake(CPStringSizeMeasuringContext.measureText(self).width, fontHeight);
+        var metrics = CPStringSizeMeasuringContext.measureText(self),
+            width = metrics.width;
+
+        if (metrics.actualBoundingBoxLeft !== undefined && metrics.actualBoundingBoxRight !== undefined)
+            width = metrics.actualBoundingBoxRight + metrics.actualBoundingBoxLeft;
+
+        size = CGSizeMake(FLOOR(width), fontHeight);
     }
 
     sizeCacheForFont[cacheKey] = size;
 #else
-        size = CGSizeMake(0, 0);
+    size = CGSizeMake(0, 0);
 #endif
     return CGSizeMakeCopy(size);
 }
@@ -117,7 +123,7 @@ CPStringSizeCachingEnabled = YES;
 - (CGSize)sizeWithFont:(CPFont)aFont inWidth:(float)aWidth
 {
     var size = [self _sizeWithFont:aFont inWidth:aWidth];
-    return CGSizeMake(CEIL(size.width), size.height);
+    return CGSizeMake(size.width, size.height);
 }
 
 @end

--- a/AppKit/CPStringDrawing.j
+++ b/AppKit/CPStringDrawing.j
@@ -32,7 +32,7 @@ var CPStringSizeWithFontInWidthCache = [],
     CPStringSizeWithFontHeightCache = [],
     CPStringSizeMeasuringContext;
 
-CPStringSizeCanvasHasBug = NO;
+CPCanvasStringSizingIsFunctional = NO;
 
 @implementation CPString (CPStringDrawing)
 
@@ -71,12 +71,12 @@ CPStringSizeCanvasHasBug = NO;
         var testingFont = [CPFont systemFontOfSize:12];
         var testingText = 'A A A A A A A A';
         CPStringSizeMeasuringContext.font = [testingFont cssString];
-        CPStringSizeCanvasHasBug = ROUND(CPStringSizeMeasuringContext.measureText(testingText).width) != ROUND([CPPlatformString sizeOfString:testingText withFont:testingFont forWidth:NULL].width);
+        CPCanvasStringSizingIsFunctional = ROUND(CPStringSizeMeasuringContext.measureText(testingText).width) == ROUND([CPPlatformString sizeOfString:testingText withFont:testingFont forWidth:NULL].width);
     }
 #endif
 }
 
-- (CGSize)_sizeWithFont:(CPFont)aFont inWidth:(float)aWidth
+- (CGSize)sizeWithFont:(CPFont)aFont inWidth:(float)aWidth
 {
     var size;
 
@@ -94,7 +94,7 @@ CPStringSizeCanvasHasBug = NO;
     if (size !== undefined && sizeCacheForFont.hasOwnProperty(cacheKey))
         return CGSizeMakeCopy(size);
 
-    if (CPStringSizeCanvasHasBug || !CPFeatureIsCompatible(CPHTMLCanvasFeature) || aWidth)
+    if (!CPCanvasStringSizingIsFunctional || aWidth)
         size = [CPPlatformString sizeOfString:self withFont:aFont forWidth:aWidth];
     else
     {
@@ -114,11 +114,6 @@ CPStringSizeCanvasHasBug = NO;
     size = CGSizeMake(0, 0);
 #endif
     return CGSizeMakeCopy(size);
-}
-
-- (CGSize)sizeWithFont:(CPFont)aFont inWidth:(float)aWidth
-{
-    return [self _sizeWithFont:aFont inWidth:aWidth];
 }
 
 @end

--- a/AppKit/CPStringDrawing.j
+++ b/AppKit/CPStringDrawing.j
@@ -68,6 +68,10 @@ CPCanvasStringSizingIsFunctional = NO;
         if (!CPStringSizeMeasuringContext)
             CPStringSizeMeasuringContext = CGBitmapGraphicsContextCreate();
 
+        // This is to make sure that Canvas based string sizing is functional.
+        // Currently, chrome has issues with certain strings, FF had issues in the past.
+        // Unfortunately, this test does fit in CPCompatibility.j where things are not sufficiently initialized.
+        
         var testingFont = [CPFont systemFontOfSize:12];
         var testingText = 'A A A A A A A A';
         CPStringSizeMeasuringContext.font = [testingFont cssString];

--- a/AppKit/CPStringDrawing.j
+++ b/AppKit/CPStringDrawing.j
@@ -68,8 +68,8 @@ CPCanvasStringSizingIsFunctional = NO;
         if (!CPStringSizeMeasuringContext)
             CPStringSizeMeasuringContext = CGBitmapGraphicsContextCreate();
 
-        // This is to make sure that Canvas based string sizing is functional.
-        // Currently, chrome has issues with certain strings, FF had issues in the past.
+        // This is to make sure that Canvas based string sizing is functional before we use it.
+        // Currently, Chrome has issues with certain strings, FF had issues in the past.
         // Unfortunately, this test does fit in CPCompatibility.j where things are not sufficiently initialized.
         
         var testingFont = [CPFont systemFontOfSize:12];
@@ -91,7 +91,7 @@ CPCanvasStringSizingIsFunctional = NO;
         sizeCacheForFont = CPStringSizeWithFontInWidthCache[self] = [];
 
     var cssString = [aFont cssString],
-    cacheKey = cssString + '_' + (aWidth ? aWidth : '0');
+        cacheKey = cssString + '_' + (aWidth ? aWidth : '0');
 
     size = sizeCacheForFont[cacheKey];
 

--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -1470,7 +1470,7 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
         ![self isBezeled]     &&
         (lineBreakMode === CPLineBreakByWordWrapping || lineBreakMode === CPLineBreakByCharWrapping))
     {
-        textSize = [text sizeWithFont:font inWidth:textSize.width];
+        textSize = [text sizeWithFont:font inWidth:textSize.width] + 1;
     }
     else
     {

--- a/AppKit/CPTextView/CPTypesetter.j
+++ b/AppKit/CPTextView/CPTypesetter.j
@@ -317,7 +317,7 @@ var CPSystemTypesetterFactory,
         measuringRange.length++;
 
         var currentCharCode = theString.charCodeAt(glyphIndex),  // use pure javascript methods for performance reasons
-            rangeWidth = [theString.substr(measuringRange.location, measuringRange.length) _sizeWithFont:currentFont inWidth:NULL].width + currentAnchor;
+            rangeWidth = [theString.substr(measuringRange.location, measuringRange.length) sizeWithFont:currentFont inWidth:NULL].width + currentAnchor;
 
         switch (currentCharCode)    // faster than sending actionForControlCharacterAtIndex: called for each char.
         {

--- a/AppKit/Platform/DOM/CPPlatformString.j
+++ b/AppKit/Platform/DOM/CPPlatformString.j
@@ -180,7 +180,7 @@ var DOMFixedWidthSpanElement    = nil,
     else if (CPFeatureIsCompatible(CPJavaScriptTextContentFeature))
         span.textContent = aString;
 
-    return CGSizeMake(span.clientWidth + 1, span.clientHeight);
+    return CGSizeMake(span.clientWidth, span.clientHeight);
 }
 
 + (CPDictionary)metricsOfFont:(CPFont)aFont

--- a/AppKit/_CPToolTip.j
+++ b/AppKit/_CPToolTip.j
@@ -118,6 +118,12 @@ var _CPToolTipHeight = 24.0,
         textFrameSizeSingleLine = [aText sizeWithFont:font],
         textFrameSize = [aText sizeWithFont:font inWidth:(aToolTipSize.width)];
 
+    // this small adjustement fixes
+    // tooltips wrapping issues from fractional pixels.
+    textFrameSizeSingleLine.width += 1;
+    textFrameSize.width += 1;
+
+
     // If the text fully fits within the maximum width, shrink to fit.
     if (textFrameSizeSingleLine.width < aToolTipSize.width)
     {

--- a/Tests/Manual/CPTextView/AppController.j
+++ b/Tests/Manual/CPTextView/AppController.j
@@ -60,16 +60,16 @@
     [contentView addSubview:mybutton];
 
 
-    _textView = [[CPTextView alloc] initWithFrame:CGRectMake(0, 0, 500, 500)];
+    _textView = [[CPTextView alloc] initWithFrame:CGRectMake(0, 0, 500, 200)];
     [_textView setRichText:YES];
 
-    _textView2 = [[CPTextView alloc] initWithFrame:CGRectMake(0, 0, 500, 500)];
+    _textView2 = [[CPTextView alloc] initWithFrame:CGRectMake(0, 0, 1000, 200)];
     _textView2._isRichText = NO;
     [_textView setBackgroundColor:[CPColor whiteColor]];
     [_textView2 setBackgroundColor:[CPColor whiteColor]];
 
-    var scrollView = [[CPScrollView alloc] initWithFrame:CGRectMake(20, 70, 520, 510)];
-    var scrollView2 = [[CPScrollView alloc] initWithFrame:CGRectMake(560, 70, 520, 510)];
+    var scrollView = [[CPScrollView alloc] initWithFrame:CGRectMake(20, 70, 520, 220)];
+    var scrollView2 = [[CPScrollView alloc] initWithFrame:CGRectMake(20, 550, 1020, 220)];
 
     [scrollView setDocumentView:_textView];
     [scrollView2 setDocumentView:_textView2];
@@ -125,6 +125,14 @@
                                                                                                  forKeys:[CPFontAttributeName, CPBackgroundColorAttributeName]]]];
     [theWindow orderFront:self];
     [CPMenu setMenuBarVisible:YES];
+
+    console.log([[CPFont systemFontOfSize:12] cssString])
+    console.log([[CPFont systemFontOfSize:12] cssString])
+    var context = document.createElement("canvas").getContext("2d");
+    context.font = '12px Arial, sans-serif';
+    var testingText = 'A A A A A A A A';
+    console.log(ROUND(context.measureText(testingText).width));
+    console.log(ROUND([CPPlatformString sizeOfString:testingText withFont:[CPFont systemFontOfSize:12] forWidth:NULL].width));
 }
 
 - (void) makeRTF:(id)sender

--- a/Tests/Manual/CPTextView/AppController.j
+++ b/Tests/Manual/CPTextView/AppController.j
@@ -127,7 +127,6 @@
     [CPMenu setMenuBarVisible:YES];
 
     console.log([[CPFont systemFontOfSize:12] cssString])
-    console.log([[CPFont systemFontOfSize:12] cssString])
     var context = document.createElement("canvas").getContext("2d");
     context.font = '12px Arial, sans-serif';
     var testingText = 'A A A A A A A A';


### PR DESCRIPTION
see bug https://bugs.chromium.org/p/chromium/issues/detail?id=1192834.
This bug induces white gaps after heavy editing in CPTextViews using chrome/canary/chromium.
This PR makes cappuccino test whether canvas text sizing is functional.
If not so, cappuccino falls back to dom-based sizing