### PR TITLE
FIXED: Before this PR, CPButton would always have the same label text size whatever the control size

### DIFF
--- a/AppKit/Themes/Aristo2/ThemeDescriptors.j
+++ b/AppKit/Themes/Aristo2/ThemeDescriptors.j
@@ -233,6 +233,7 @@ var themedButtonValues = nil,
 
             [@"content-inset",              CGInsetMake(0.0, 5.0, 0.0, 5.0),    [CPThemeStateControlSizeSmall, CPThemeStateBordered]],
             [@"nib2cib-adjustment-frame",   CGRectMake(-3.0, 6.0, 0.0, 0.0),    [CPThemeStateControlSizeSmall, CPThemeStateBordered]],
+            [@"font",                       [CPFont boldSystemFontOfSize:11.0], [CPThemeStateControlSizeSmall, CPThemeStateBordered]],
 
             // RoundRect CPThemeStateControlSizeMini
             [@"bezel-color",
@@ -256,6 +257,7 @@ var themedButtonValues = nil,
 
             [@"content-inset",              CGInsetMake(0.0, 2.0, 2.0, 2.0),    [CPThemeStateControlSizeMini, CPThemeStateBordered]],
             [@"nib2cib-adjustment-frame",   CGRectMake(0.0, 14.0, 0.0, 0.0),    [CPThemeStateControlSizeMini, CPThemeStateBordered]],
+            [@"font",                       [CPFont boldSystemFontOfSize:10.0], [CPThemeStateControlSizeMini, CPThemeStateBordered]],
 
             // Rounded
             [@"bezel-color",


### PR DESCRIPTION
This PR fixes #2984 

To cope with new control size management, we have to add some ```font``` attribute definitions to Aristo2.