### PR TITLE
FIXED: Before this PR, using setTextColor on a CPTextField would not take visual effect before an event

### DIFF
--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -2020,6 +2020,8 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
     }
 
     [self setValue:placeholderColor forThemeAttribute:@"text-color" inState:CPTextFieldStatePlaceholder];
+
+    [self layoutSubviews];
 }
 
 - (void)viewDidHide


### PR DESCRIPTION
This PR simply adds a call to ```layoutSubviews``` after setting the text color.

Fixes #2985 