### PR TITLE
FIXED: Before this PR, nib2cib would fail if, for some "not ready" condition, no superview is defined for a view

### DIFF
--- a/AppKit/CPView.j
+++ b/AppKit/CPView.j
@@ -1479,7 +1479,7 @@ var CPViewHighDPIDrawingEnabled = YES;
 {
     var mask = [self autoresizingMask];
 
-    if (mask === CPViewNotSizable)
+    if ((mask === CPViewNotSizable) || !_superview)
         return;
 
     var frame = _superview._frame,


### PR DESCRIPTION
This PR checks if there's a defined superview in ```resizeWithOldSuperviewSize```.

The problem can be observed when trying to nib2cib the MainMenu.xib file of the reduction in issue #2971 (ImageTest.zip).