### PR TITLE
Modernise "document.write" in «index.html» to "innerHTML"

### DIFF
--- a/Tools/capp/Resources/Templates/Application/index-debug.html
+++ b/Tools/capp/Resources/Templates/Application/index-debug.html
@@ -188,9 +188,9 @@
     <body>
         <div id="cappuccino-body">
             <div class="container">
-                <div class="content">
+                <div class="content" id="loadingDiv">
                     <script type="text/javascript">
-                        document.write(loadingHTML);
+                        document.getElementById("loadingDiv").innerHTML = loadingHTML;
                     </script>
                 </div>
             </div>

--- a/Tools/capp/Resources/Templates/Application/index.html
+++ b/Tools/capp/Resources/Templates/Application/index.html
@@ -150,9 +150,9 @@
     <body>
         <div id="cappuccino-body">
             <div class="container">
-                <div class="content">
+                <div class="content" id="loadingDiv">
                     <script type="text/javascript">
-                        document.write(loadingHTML);
+                        document.getElementById("loadingDiv").innerHTML = loadingHTML;
                     </script>
                 </div>
             </div>

--- a/Tools/capp/Resources/Templates/NibApplication/index-debug.html
+++ b/Tools/capp/Resources/Templates/NibApplication/index-debug.html
@@ -188,9 +188,9 @@
     <body>
         <div id="cappuccino-body">
             <div class="container">
-                <div class="content">
+                <div class="content" id="loadingDiv">
                     <script type="text/javascript">
-                        document.write(loadingHTML);
+                        document.getElementById("loadingDiv").innerHTML = loadingHTML;
                     </script>
                 </div>
             </div>

--- a/Tools/capp/Resources/Templates/NibApplication/index.html
+++ b/Tools/capp/Resources/Templates/NibApplication/index.html
@@ -150,9 +150,9 @@
     <body>
         <div id="cappuccino-body">
             <div class="container">
-                <div class="content">
+                <div class="content" id="loadingDiv">
                     <script type="text/javascript">
-                        document.write(loadingHTML);
+                        document.getElementById("loadingDiv").innerHTML = loadingHTML;
                     </script>
                 </div>
             </div>

--- a/Tools/capp/Resources/Templates/ThemeDescriptor/index-debug.html
+++ b/Tools/capp/Resources/Templates/ThemeDescriptor/index-debug.html
@@ -188,9 +188,9 @@
     <body>
         <div id="cappuccino-body">
             <div class="container">
-                <div class="content">
+                <div class="content" id="loadingDiv">
                     <script type="text/javascript">
-                        document.write(loadingHTML);
+                        document.getElementById("loadingDiv").innerHTML = loadingHTML;
                     </script>
                 </div>
             </div>

--- a/Tools/capp/Resources/Templates/ThemeDescriptor/index.html
+++ b/Tools/capp/Resources/Templates/ThemeDescriptor/index.html
@@ -150,9 +150,9 @@
     <body>
         <div id="cappuccino-body">
             <div class="container">
-                <div class="content">
+                <div class="content" id="loadingDiv">
                     <script type="text/javascript">
-                        document.write(loadingHTML);
+                        document.getElementById("loadingDiv").innerHTML = loadingHTML;
                     </script>
                 </div>
             </div>


### PR DESCRIPTION
Replace `document.write(loadingHTML);` (which should be avoided for speed) with equivalent `innerHTML` code. If acceptable, the other templates (Application, Framework, ThemeDescriptor) might be upgraded accordingly.