### PR TITLE
fixed: network errors had been silently ignored by CPURLConnection

### DIFF
--- a/Foundation/CPURLConnection.j
+++ b/Foundation/CPURLConnection.j
@@ -324,6 +324,14 @@ var CPURLConnectionDelegate = nil;
 
         if (statusCode === 401 && [CPURLConnectionDelegate respondsToSelector:@selector(connectionDidReceiveAuthenticationChallenge:)])
             [CPURLConnectionDelegate connectionDidReceiveAuthenticationChallenge:self];
+        else if (statusCode === 0)
+        {
+            var exception = [CPException exceptionWithName:@"Network error exception"
+                                                    reason:"An unknown network error occurred."
+                                                  userInfo:@{}];
+
+            [self _sendDelegateDidFailWithError:exception];
+        }
         else
         {
             var response;

--- a/Tests/Foundation/CPURLConnectionTest.j
+++ b/Tests/Foundation/CPURLConnectionTest.j
@@ -2,6 +2,7 @@
 
 @implementation CPURLConnectionTest : OJTestCase
 {
+    BOOL _didCallDelegateErrorMethod;
 }
 
 - (void)testParseHTTPHeaders
@@ -71,6 +72,20 @@
 
     [[conn currentRequest] setWithCredentials:YES];
     [self assert:[originalRequest withCredentials] notEqual:[currentRequest withCredentials]];
+}
+
+- (void)connection:anURLConnection didFailWithError:anError
+{
+    _didCallDelegateErrorMethod = YES;
+}
+
+- (void)testConnectionError
+{
+    _didCallDelegateErrorMethod = NO;
+
+    var req = [CPURLRequest requestWithURL:@"http://localh0st:9999/data123"], // this fictious endpoint does not exist
+        conn = [CPURLConnection connectionWithRequest:req delegate:self];     // therefore, this must trigger the delegate error notification
+    [self assertTrue:_didCallDelegateErrorMethod];
 }
 
 @end

--- a/Tests/Foundation/CPURLConnectionTest.j
+++ b/Tests/Foundation/CPURLConnectionTest.j
@@ -79,12 +79,12 @@
     _didCallDelegateErrorMethod = YES;
 }
 
-- (void)testConnectionError
+- (async void)testConnectionError
 {
     _didCallDelegateErrorMethod = NO;
 
-    var req = [CPURLRequest requestWithURL:@"http://localh0st:9999/data123"], // this fictious endpoint does not exist
-        conn = [CPURLConnection connectionWithRequest:req delegate:self];     // therefore, this must trigger the delegate error notification
+    var req = [CPURLRequest requestWithURL:@"http://localh0st:9999/data123"]; // this fictious endpoint does not exist
+    await [CPURLConnection connectionWithRequest:req delegate:self];     // FIXME: this does not work as currently connectionWithRequest does not return a Promise
     [self assertTrue:_didCallDelegateErrorMethod];
 }
 


### PR DESCRIPTION
see discussion in https://stackoverflow.com/questions/28556398/how-to-catch-neterr-connection-refused