### PR TITLE
Fixed: Bezel state ivar _bezelState must remove current state when changing to a new.

### DIFF
--- a/AppKit/CPButton.j
+++ b/AppKit/CPButton.j
@@ -973,7 +973,11 @@ CPButtonImageOffset   = 3.0;
     _bezelStyle = aBezelStyle;
 
     if (_bezelState && newState)
+    {
+        if (currentState)
+            _bezelState =_bezelState.without(currentState);
         _bezelState = _bezelState.and(newState);
+    }
     else
         _bezelState = newState || CPThemeStateNormal;
 


### PR DESCRIPTION
If the bezel state was changed and some attribute was set like an "image". The image would not be found as there were two states active and it would not match.