### PR TITLE
Include commented-out code to hide mainMenu in NibApplication template

### DIFF
--- a/Tools/capp/Resources/Templates/NibApplication/AppController.j
+++ b/Tools/capp/Resources/Templates/NibApplication/AppController.j
@@ -18,6 +18,8 @@
 - (void)applicationDidFinishLaunching:(CPNotification)aNotification
 {
     // This is called when the application is done loading.
+    // Uncomment the following line to hide the standard menu bar.
+    // [CPMenu setMenuBarVisible:NO];
 }
 
 - (void)awakeFromCib


### PR DESCRIPTION
Add commented-out code to capp gen NibApplication template.
The technique itself is easy to forget and not obvious to newcomers.
It is already included in the standard capp gen application template
and added here for completeness.