### PR TITLE
Fixed: Correct init of CPTextView when running nib2cib

### DIFF
--- a/Tools/nib2cib/NSTextView.j
+++ b/Tools/nib2cib/NSTextView.j
@@ -32,6 +32,8 @@
 {
     if (self = [super NS_initWithCoder:aCoder])
     {
+        [self _init];
+
         _textContainer = [aCoder decodeObjectForKey:@"NSTextContainer"];
 
         [self setEditable:[aTextViewSharedData isEditable]];


### PR DESCRIPTION
nib2cib can fail and crash if a CPTextView is in the .xib file as the text view is not initialized correctly