### PR TITLE
fixed: usage of eval instead of JSON.parse for parsing JSON

### DIFF
--- a/AppKit/CPColorPanel.j
+++ b/AppKit/CPColorPanel.j
@@ -483,7 +483,7 @@ var CPColorPanelSwatchesCookie = "CPColorPanelSwatchesCookie";
         ];
     }
 
-    var cookieValue = eval(cookieValue);
+    var cookieValue = JSON.parse(cookieValue);
 
     return [cookieValue arrayByApplyingBlock:function(value)
     {


### PR DESCRIPTION
using eval for parsing JSON is considered bad practice and is also slower.
addresses some of the concerns raised in #3013 