### PR TITLE
fixed: freeze when clicking during sheet animation

### DIFF
--- a/AppKit/CPWindow/CPWindow.j
+++ b/AppKit/CPWindow/CPWindow.j
@@ -1901,6 +1901,8 @@ CPTexturedBackgroundWindowMask
     // CPLeftMouseDown is needed for window moving and resizing to work.
     // CPMouseMoved is needed for rollover effects on title bar buttons.
 
+    // ignore events that happen during open / close animations
+    // not ignoring these would cause the app to freeze thereafter
     if (sheet && (_sheetContext["isClosing"] || _sheetContext["isOpening"]))
         return;
 

--- a/AppKit/CPWindow/CPWindow.j
+++ b/AppKit/CPWindow/CPWindow.j
@@ -1901,6 +1901,9 @@ CPTexturedBackgroundWindowMask
     // CPLeftMouseDown is needed for window moving and resizing to work.
     // CPMouseMoved is needed for rollover effects on title bar buttons.
 
+    if (sheet && (_sheetContext["isClosing"] || _sheetContext["isOpening"]))
+        return;
+
     if (sheet && _sheetContext["isAttached"])
     {
         switch (type)


### PR DESCRIPTION
previously, any app froze when clicking somewhere during sheet open/close animations.
these adversarial clicks are simply ignored by this PR.
fixes #3012