### PR TITLE
fixed: key event issues of handling escape in recent firefox …

### DIFF
--- a/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
@@ -694,7 +694,6 @@ _CPPlatformWindowWillCloseNotification = @"_CPPlatformWindowWillCloseNotificatio
                         (aDOMEvent.altKey ? CPAlternateKeyMask : 0) |
                         (aDOMEvent.metaKey ? CPCommandKeyMask : 0) |
                         (_capsLockActive ? CPAlphaShiftKeyMask : 0);
-debugger
 
     // With a few exceptions, all key events are blocked from propagating to
     // the browser.  Here the following exceptions are being allowed:

--- a/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
@@ -694,6 +694,7 @@ _CPPlatformWindowWillCloseNotification = @"_CPPlatformWindowWillCloseNotificatio
                         (aDOMEvent.altKey ? CPAlternateKeyMask : 0) |
                         (aDOMEvent.metaKey ? CPCommandKeyMask : 0) |
                         (_capsLockActive ? CPAlphaShiftKeyMask : 0);
+debugger
 
     // With a few exceptions, all key events are blocked from propagating to
     // the browser.  Here the following exceptions are being allowed:

--- a/AppKit/Platform/DOM/CPPlatformWindow+DOMKeys.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOMKeys.j
@@ -187,7 +187,7 @@ CPKeyCodes.firesKeyPressEvent = function(keyCode, key, opt_heldKeyCode, opt_shif
     switch (keyCode)
     {
         case CPKeyCodes.ENTER: return true;
-        case CPKeyCodes.ESC:   return !CPBrowserIsEngine(CPWebKitBrowserEngine);
+        case CPKeyCodes.ESC:   return false;
     }
 
     return CPKeyCodes.isCharacterKey(keyCode);


### PR DESCRIPTION
…versions
recently FF returns "Escape"  instead of chr(27) in the key property of keyboard events. This caused the esc key to malfunction in cappuccino on FF.

This PR fixes this by treating esc analogous to webkit. Tested on FF 94.0.2 (64-Bit) for mac.