### PR TITLE
Modernize XcodeCapp jakefile

### DIFF
--- a/Tools/XcodeCapp/Jakefile
+++ b/Tools/XcodeCapp/Jakefile
@@ -1,30 +1,70 @@
 
 require("../../common.jake");
 
-var OS = require("os"),
-    task = require("jake").task,
-    stream = require("narwhal/term").stream,
-    applicationName = "XcodeCapp.app";
+var OS                =  require("os"),
+    task              =  require("jake").task,
+    stream            =  require("narwhal/term").stream,
+    applicationName   =  "XcodeCapp.app";
 
-task ("build", function()
+
+function xcodebuild(mode, dstRoot, installPath)
 {
+    /*
+     `xcodebuild` is invoked (with mode and optional parameters)
+     to build Xcode projects from the command line.
+    
+     For our purposes, the mode parameter is  one of 'build', 'install' or 'clean'.
+     The destination for build and install artificats is governed
+     by the DSTROOT and INSTALL_PATH properties of the Xcode project (set for each target or scheme);
+     They can optionally be appended to the `xcodebuild` invocation to override
+     the project values for that invocation.
+     NOTE: DEPLOYMENT_LOCATION must be set to 'Yes' in the Xcode project settings for overrides to work.
+    
+     We use the builder pattern to assemble an invocation for each of the modes we use.
+     If dstRoot and/or installPath are null,
+     do not include those parameters in the command invocation.
+     If not included, defaults found in the Xcode project's settings will be used.
+     Parameters dstRoot and installPath must be non-empty strings or null.
+    */
+    
+    if (mode !== null)
+    {
+        mode = mode.toLowerCase();
+    }
+    else
+    {
+        colorPrint("Options for mode are 'build'||'install'||'clean'. Skipping", 'orange');
+        OS.exit(0);  
+    }
+    
+    if (mode == "clean")
+    {
+        dstRoot     =  null;
+        installPath =  null;
+    }
+
     // If sw_vers does not exist, we aren't on Mac OS X
     if (!executableExists("sw_vers"))
         OS.exit(0);
 
-    // No building on 10.6
+    /*
+     Minimum platform requirement is macOS 10.13
+     Note that internal platform numbering scheme changed after macOS 10.15
+     High Sierra selected as support cut-off because it is apparently the oldest for which GitHub Actions are available.
+     Used hardware supporting High Sierra is quite inexpensive - this may help some developers with hardware acquisition.
+    */
     try
     {
         var p = OS.popen(["sw_vers", "-productVersion"]);
 
         if (p.wait() === 0)
         {
-            var versions = p.stdout.read().split("."),
-                majorVersion = parseInt(versions[0], 10),
-                minorVersion = parseInt(versions[1], 10),
-                buildVersion = parseInt(versions[2], 10);
+            var versions     =  p.stdout.read().split("."),
+                majorVersion =  parseInt(versions[0], 10),
+                minorVersion =  parseInt(versions[1], 10),
+                buildVersion =  parseInt(versions[2], 10);
 
-        if (!((majorVersion == 11) || (majorVersion == 10 && minorVersion >= 12)))
+        if (!((majorVersion >= 11) || (majorVersion == 10 && minorVersion >= 13)))
             {
                 colorPrint("XcodeCapp requires at least macOS Sierra.", "red");
 
@@ -44,32 +84,41 @@ task ("build", function()
 
     if (executableExists("xcodebuild"))
     {
-        var args = installPath = FILE.join("/", "Applications", applicationName);
-
-        // Remove old symlink, if present.
-		//The application is now built directly into /Applications
-        if (FILE.isLink(installPath))
-            FILE.remove(installPath);
-
-		if (OS.system("xcodebuild install"))
-            colorPrint("Unable to build XcodeCapp. Skipping", "orange");
+        var commandInvocation = "xcodebuild -target XcodeCapp " + mode;
+        if (dstRoot !== null)
+        {
+            commandInvocation += " DSTROOT=" + dstRoot;
+        }
+        if (installPath !== null)
+        {
+            commandInvocation += " INSTALL_PATH=" + installPath;
+        }
+        if (OS.system(commandInvocation))
+        {
+            colorPrint("Unable to " + mode + " XcodeCapp. Skipping", "orange");
+        }
     }
     else
     {
-        print("Building " + applicationName + " requires Xcode.");
+        var capitalizedModeDescription = mode.replace(/^\w/, (firstCharacter) => firstCharacter.toUpperCase());
+        print(capitalizedModeDescription + "ing " + applicationName + " requires Xcode.");
     }
+};
+ 
+task ("build", xcodebuild("build", null, null));
+
+task ("install", function() {
+    /*
+     Install to the user's home directory.
+     `xcodebuild` uses DSTROOT as the base path when installing build products,
+     and appends INSTALL_PATH
+     `xcodebuild` recognizes and expands the POSIX $HOME setting automatically.
+    */
+    xcodebuild("install", "$HOME", "Applications");   
 });
 
-task ("clean", function()
-{
-    if (OS.system("xcodebuild clean"))
-        colorPrint("Unable to clean XcodeCapp. Skipping", "orange");
-});
+task ("clean", xcodebuild("clean", null, null));
 
-task ("clobber", function()
-{
-    if (OS.system("xcodebuild clean"))
-        colorPrint("Unable to clean XcodeCapp. Skipping", "orange");
-});
+task ("clobber", xcodebuild("clean", null, null));
 
 task ("default", ["build"]);

--- a/Tools/XcodeCapp/XcodeCapp.xcodeproj/project.pbxproj
+++ b/Tools/XcodeCapp/XcodeCapp.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		0258004A1B1E67090000EB7D /* supawhich */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = supawhich; sourceTree = "<group>"; };
 		0275390F1B227D7500F6D824 /* YRKSpinningProgressIndicator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YRKSpinningProgressIndicator.h; sourceTree = "<group>"; };
 		027539101B227D7500F6D824 /* YRKSpinningProgressIndicator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YRKSpinningProgressIndicator.m; sourceTree = "<group>"; };
+		4147D36D27ECE7AA00E92AD4 /* Jakefile */ = {isa = PBXFileReference; explicitFileType = sourcecode.javascript; path = Jakefile; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.javascript; };
 		680621171B015BF400CB24CD /* XCCCappuccinoProjectControllerDataView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XCCCappuccinoProjectControllerDataView.h; sourceTree = "<group>"; };
 		680621181B015BF400CB24CD /* XCCCappuccinoProjectControllerDataView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XCCCappuccinoProjectControllerDataView.m; sourceTree = "<group>"; };
 		6815BBE61AFBE6B00030D8BB /* XCCCappuccinoProjectController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XCCCappuccinoProjectController.h; sourceTree = "<group>"; };
@@ -188,6 +189,7 @@
 			children = (
 				6841F2741AF98F6F00CFE60E /* CoreServices.framework */,
 				6841F23D1AF98CE600CFE60E /* XcodeCapp */,
+				4147D36D27ECE7AA00E92AD4 /* Jakefile */,
 				6841F23C1AF98CE600CFE60E /* Products */,
 			);
 			sourceTree = "<group>";
@@ -425,6 +427,7 @@
 			baseConfigurationReference = 6841F27A1AF990C300CFE60E /* Debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -444,7 +447,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEPLOYMENT_LOCATION = YES;
-				DSTROOT = /;
+				DSTROOT = "/tmp/$(PROJECT_NAME).dst";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -462,10 +465,10 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				INSTALL_PATH = $USER_APPS_DIR;
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				INSTALL_PATH = "$(USER_APPS_DIR)";
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = YES;
-				ONLY_ACTIVE_ARCH = YES;
+				ONLY_ACTIVE_ARCH = NO;
 				SDKROOT = macosx;
 			};
 			name = Debug;
@@ -475,6 +478,7 @@
 			baseConfigurationReference = 6841F27B1AF990C300CFE60E /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -494,7 +498,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEPLOYMENT_LOCATION = YES;
-				DSTROOT = /;
+				DSTROOT = "/tmp/$(PROJECT_NAME).dst";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -505,9 +509,10 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				INSTALL_PATH = $USER_APPS_DIR;
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				INSTALL_PATH = "$(USER_APPS_DIR)";
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				ONLY_ACTIVE_ARCH = NO;
 				SDKROOT = macosx;
 			};
 			name = Release;
@@ -518,12 +523,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
-				DSTROOT = /;
+				DSTROOT = build;
 				INFOPLIST_FILE = XcodeCapp/Info.plist;
-				INSTALL_PATH = "$(USER_APPS_DIR)";
+				INSTALL_PATH = Applications;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
-				PRODUCT_BUNDLE_IDENTIFIER = org.cappuccino.xcodecapp;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				ONLY_ACTIVE_ARCH = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.cappuccino.xcodecapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -534,12 +540,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
-				DSTROOT = /;
+				DSTROOT = build;
 				INFOPLIST_FILE = XcodeCapp/Info.plist;
-				INSTALL_PATH = "$(USER_APPS_DIR)";
+				INSTALL_PATH = Applications;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
-				PRODUCT_BUNDLE_IDENTIFIER = org.cappuccino.xcodecapp;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				ONLY_ACTIVE_ARCH = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.cappuccino.xcodecapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/Tools/XcodeCapp/XcodeCapp.xcodeproj/project.pbxproj
+++ b/Tools/XcodeCapp/XcodeCapp.xcodeproj/project.pbxproj
@@ -520,7 +520,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DSTROOT = /;
 				INFOPLIST_FILE = XcodeCapp/Info.plist;
-				INSTALL_PATH = "$(LOCAL_APPS_DIR)";
+				INSTALL_PATH = "$(USER_APPS_DIR)";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_BUNDLE_IDENTIFIER = org.cappuccino.xcodecapp;
@@ -536,7 +536,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DSTROOT = /;
 				INFOPLIST_FILE = XcodeCapp/Info.plist;
-				INSTALL_PATH = "$(LOCAL_APPS_DIR)";
+				INSTALL_PATH = "$(USER_APPS_DIR)";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_BUNDLE_IDENTIFIER = org.cappuccino.xcodecapp;

--- a/Tools/XcodeCapp/XcodeCapp/XCCPPXOperation.m
+++ b/Tools/XcodeCapp/XcodeCapp/XCCPPXOperation.m
@@ -93,7 +93,7 @@ NSString * const XCCPBXOperationDidEndNotification = @"XCCPbxCreationDidEndNotif
         
         if (shouldLaunchTask)
         {
-            self->task = [self->taskLauncher taskWithCommand:@"python" arguments:arguments];
+            self->task = [self->taskLauncher taskWithCommand:@"python3" arguments:arguments];
 
             NSDictionary *result = [self->taskLauncher runTask:self->task returnType:kTaskReturnTypeStdError];
             

--- a/Tools/XcodeCapp/XcodeCapp/XCCTaskLauncher.m
+++ b/Tools/XcodeCapp/XcodeCapp/XCCTaskLauncher.m
@@ -40,7 +40,7 @@
         self.environment[@"NARWHAL_ENGINE"] = @"jsc";
         self.environment[@"CAPP_NOSUDO"]    = @"1";
         
-        self.executables = @[@"python", @"objj", @"nib2cib",@"objj2objcskeleton", @"capp_lint", @"touch"];
+        self.executables = @[@"python3", @"objj", @"nib2cib",@"objj2objcskeleton", @"capp_lint", @"touch"];
 
         self.isValid = [self _checkExecutables];
     }


### PR DESCRIPTION
* Properly check for macOS versions which use a major version > 10.
* Clean up minimum/target platform versions - minimum version should now be 10.13 everywhere.
* Implement separate build and install phases.
* Build to Cappuccino source folder
* Install to ~/Applications folder (to avoid problems with elevated permissions in /Applications)
* Ensure Xcode's modern build system is used for all schemes and targets (legacy build system is deprecated and may be removed without further notices)