### PR TITLE
fixed: å and Å did not work well on scandinavian keyboards in CPTextView

### DIFF
--- a/AppKit/CPTextView/CPTextView.j
+++ b/AppKit/CPTextView/CPTextView.j
@@ -1051,7 +1051,7 @@ Sets the selection to a range of characters in response to user action.
 
     [[_window platformWindow] _propagateCurrentDOMEvent:YES];  // for the _CPNativeInputManager (necessary at least on FF and chrome)
 
-    if (![_CPNativeInputManager isNativeInputFieldActive])
+    if (![_CPNativeInputManager isNativeInputFieldActive] && ![_CPNativeInputManager isDeadKey:event])
         [self interpretKeyEvents:[event]];
 
     [_caret setPermanentlyVisible:YES];
@@ -2636,7 +2636,14 @@ var _CPCopyPlaceholder = '-';
 {
     return _CPNativeInputFieldActive;
 }
++ (void)isDeadKey:(CPEvent)event
+{
+#if PLATFORM(DOM)
+    return event._DOMEvent && event._DOMEvent.key == 'Dead';
+#endif
 
+    return NO;
+}
 + (void)cancelCurrentNativeInputSession
 {
 

--- a/AppKit/CPTextView/CPTextView.j
+++ b/AppKit/CPTextView/CPTextView.j
@@ -1051,7 +1051,7 @@ Sets the selection to a range of characters in response to user action.
 
     [[_window platformWindow] _propagateCurrentDOMEvent:YES];  // for the _CPNativeInputManager (necessary at least on FF and chrome)
 
-    if (![_CPNativeInputManager isNativeInputFieldActive] && [event charactersIgnoringModifiers].charCodeAt(0) != 229) // filter out 229 because this would be inserted in chrome on each deadkey
+    if (![_CPNativeInputManager isNativeInputFieldActive])
         [self interpretKeyEvents:[event]];
 
     [_caret setPermanentlyVisible:YES];
@@ -2710,14 +2710,6 @@ var _CPCopyPlaceholder = '-';
             return false; // prevent the default behaviour
 
         var charCode = _CPNativeInputField.innerHTML.charCodeAt(0);
-
-        // å and Å need to be filtered out in keyDown: due to chrome inserting 229 on a deadkey
-        if (charCode == 229 || charCode == 197)
-        {
-            [currentFirstResponder insertText:_CPNativeInputField.innerHTML];
-            _CPNativeInputField.innerHTML = '';
-            return;
-        }
 
         // chrome-trigger: keypressed is omitted for deadkeys
         if (!_CPNativeInputFieldActive && _CPNativeInputFieldKeyPressedCalled == NO && _CPNativeInputField.innerHTML.length && _CPNativeInputField.innerHTML != _CPCopyPlaceholder && _CPNativeInputField.innerHTML.length < 3)

--- a/AppKit/CPTextView/CPTextView.j
+++ b/AppKit/CPTextView/CPTextView.j
@@ -2639,7 +2639,7 @@ var _CPCopyPlaceholder = '-';
 + (void)isDeadKey:(CPEvent)event
 {
 #if PLATFORM(DOM)
-    return event._DOMEvent && event._DOMEvent.key == 'Dead';
+    return event._DOMEvent && (event._DOMEvent.key == 'Dead' || event._DOMEvent.key == 'Process');
 #endif
 
     return NO;


### PR DESCRIPTION
previously, å and Å had been awkwardly filtered in keyDown: and reinserted via the deadkey handler. this caused a sluggish typing experience for our Skandinavian friends.

this filtering is cleaned up by this PR.
deadkey-diacritics still work.

tested on chrome, safari and FF, although only on mac.
fixes #3030