### PR TITLE
CPView.j, fix typo: _ephereralSubviews → _ephemeralSubviews

### DIFF
--- a/AppKit/CPView.j
+++ b/AppKit/CPView.j
@@ -232,7 +232,7 @@ var CPViewHighDPIDrawingEnabled = YES;
     JSObject            _ephemeralSubviews;
 
     JSObject            _ephemeralSubviewsForNames;
-    CPSet               _ephereralSubviews;
+    CPSet               _ephemeralSubviews;
 
     // Key View Support
     CPView              _nextKeyView;


### PR DESCRIPTION
This typo occurs only once, line #3462 references the correct spelling.