### PR TITLE
fixed: poor user experience when entering dates that are too high for…

### DIFF
--- a/AppKit/CPDatePicker/_CPDatePickerElementTextField.j
+++ b/AppKit/CPDatePicker/_CPDatePickerElementTextField.j
@@ -387,7 +387,7 @@ CPAMPMDateType = 6;
 
             // if we enter a day that is too high for the current month
             // we need to increase the month by one
-            // if we do not do this, the user input woul be silently reset
+            // if we do not do this, the user input would be silently reset
             // very poor user experience
 
             if (parseInt(anObjectValue, 10) > [dateValue _daysInMonth])

--- a/AppKit/CPDatePicker/_CPDatePickerElementTextField.j
+++ b/AppKit/CPDatePicker/_CPDatePickerElementTextField.j
@@ -385,6 +385,18 @@ CPAMPMDateType = 6;
                 return;
             }
 
+            // if we enter a day that is too high for the current month
+            // we need to increase the month by one
+            // if we do not do this, the user input woul be silently reset
+            // very poor user experience
+
+            if (parseInt(anObjectValue, 10) > [dateValue _daysInMonth])
+            {
+                [_datePickerElementView._textFieldMonth setIntValue:(dateValue.getMonth() + 2)];
+                [super setObjectValue:objectValue];
+                return;
+            }
+
             [super setObjectValue:objectValue];
             break;
 


### PR DESCRIPTION
… the current month.
E.g. if you enter 30 in Februrary (30/02), "30" will be silently reset to 01/02 after tabbing over to the month field.
This patch makes sure that 30 is retained in the day field.
To achieve this, the month is bumped by one, so 30/02 would automatically get to 30/03 after tabbing over the month field.