### PR TITLE
new: blendedColorWithFraction:(CGFloat)fraction ofColor:(CPColor)color

### DIFF
--- a/AppKit/CPColor.j
+++ b/AppKit/CPColor.j
@@ -650,6 +650,29 @@ var cachedBlackColor,
 }
 
 /*!
+    Creates a new color object with  values beeing a weighted sum of the current color object and the specified color .
+
+    @param fraction beeing a float between 0 and 1
+    @param color other color for blending
+
+    @return a new color object
+*/
+- (CPColor)blendedColorWithFraction:(CGFloat)fraction ofColor:(CPColor)color
+{
+    var red = [_components[0], color._components[0]],
+        green = [_components[1], color._components[1]],
+        blue = [_components[2], color._components[2]],
+        alpha = [_components[3], color._components[3]];
+
+    var blendedRed = red[0] + fraction * (red[1] - red[0]);
+    var blendedGreen = green[0] + fraction * (green[1] - green[0]);
+    var blendedBlue = blue[0] + fraction * (blue[1] - blue[0]);
+    var blendedAlpha = alpha[0] + fraction * (alpha[1] - alpha[0]);
+
+    return [CPColor colorWithCalibratedRed:blendedRed green:blendedGreen blue:blendedBlue alpha:blendedAlpha];
+}
+
+/*!
     Returns a new color with the same RGB as the receiver but a new alpha component.
 
     @param anAlphaComponent the alpha component for the new color


### PR DESCRIPTION
this adds a missing method from the cocoa spec from here: https://developer.apple.com/documentation/appkit/nscolor/1524689-blendedcolorwithfraction