### PR TITLE
Allow building XcodeCapp under any version greater than Sierra

### DIFF
--- a/Tools/XcodeCapp/Jakefile
+++ b/Tools/XcodeCapp/Jakefile
@@ -24,7 +24,7 @@ task ("build", function()
                 minorVersion = parseInt(versions[1], 10),
                 buildVersion = parseInt(versions[2], 10);
 
-        if (!((majorVersion == 11) || (majorVersion == 10 && minorVersion >= 12)))
+        if (!((majorVersion >= 11) || (majorVersion == 10 && minorVersion >= 12)))
             {
                 colorPrint("XcodeCapp requires at least macOS Sierra.", "red");
 


### PR DESCRIPTION
Individual new OS releases had support added individually until now.