### PR TITLE
Improve XcodeCapp ‘About’ window and version number reporting

### DIFF
--- a/Tools/XcodeCapp/XcodeCapp/AppDelegate.h
+++ b/Tools/XcodeCapp/XcodeCapp/AppDelegate.h
@@ -28,6 +28,7 @@
 @property IBOutlet  XCCMainController       *mainWindowController;
 @property NSOperationQueue                  *mainOperationQueue;
 @property NSString                          *version;
+@property NSString                          *copyright;
 
 - (IBAction)openAbout:(id)aSender;
 - (IBAction)openPreferences:(id)aSender;

--- a/Tools/XcodeCapp/XcodeCapp/AppDelegate.m
+++ b/Tools/XcodeCapp/XcodeCapp/AppDelegate.m
@@ -99,6 +99,9 @@
 
     self.version = [NSBundle mainBundle].infoDictionary[@"CFBundleShortVersionString"];
 
+    NSString *copyrightString = [NSBundle mainBundle].infoDictionary[@"NSHumanReadableCopyright"];
+    self.copyright = [NSString stringWithFormat:@"%@\nAll rights reserved", copyrightString];
+
     [self _initUserDefaults];
     [self _initOperationQueue];
     [self _initStatusItem];

--- a/Tools/XcodeCapp/XcodeCapp/Base.lproj/MainMenu.xib
+++ b/Tools/XcodeCapp/XcodeCapp/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23077.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23077.2"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -350,42 +350,42 @@
                     </menu>
                 </menuItem>
             </items>
+            <point key="canvasLocation" x="-225" y="-276"/>
         </menu>
         <window title="XcodeCapp" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="main-window" animationBehavior="default" id="QvC-M9-y7g">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenPrimary="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="224" y="158" width="863" height="634"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>
             <value key="minSize" type="size" width="800" height="600"/>
             <view key="contentView" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="863" height="634"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <splitView autosaveName="main-splitView" dividerStyle="thin" vertical="YES" id="tld-4e-icT">
+                    <splitView fixedFrame="YES" autosaveName="main-splitView" dividerStyle="thin" vertical="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tld-4e-icT">
                         <rect key="frame" x="0.0" y="0.0" width="863" height="634"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <customView id="EWg-n1-sFa">
+                            <customView fixedFrame="YES" id="EWg-n1-sFa">
                                 <rect key="frame" x="0.0" y="0.0" width="263" height="634"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <subviews>
-                                    <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="72" horizontalPageScroll="10" verticalLineScroll="72" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="UZ4-kJ-krj">
+                                    <scrollView fixedFrame="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="72" horizontalPageScroll="10" verticalLineScroll="72" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UZ4-kJ-krj">
                                         <rect key="frame" x="0.0" y="0.0" width="263" height="634"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" drawsBackground="NO" id="Zlj-Y5-TaS">
                                             <rect key="frame" x="0.0" y="0.0" width="263" height="634"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
-                                                <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="72" rowSizeStyle="automatic" viewBased="YES" id="Mss-Tu-7kR">
+                                                <tableView appearanceType="vibrantLight" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="72" rowSizeStyle="automatic" viewBased="YES" id="Mss-Tu-7kR">
                                                     <rect key="frame" x="0.0" y="0.0" width="263" height="634"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <color key="backgroundColor" name="windowBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                     <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                                     <tableColumns>
-                                                        <tableColumn identifier="MainCell" editable="NO" width="263" minWidth="40" maxWidth="1000" id="UKo-y4-Q5Q">
+                                                        <tableColumn identifier="MainCell" editable="NO" width="231" minWidth="40" maxWidth="1000" id="UKo-y4-Q5Q">
                                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                                                <font key="font" metaFont="smallSystem"/>
                                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                             </tableHeaderCell>
@@ -397,11 +397,11 @@
                                                             <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                             <prototypeCellViews>
                                                                 <tableCellView identifier="MainCell" id="QnM-Kd-OyB" customClass="XCCCappuccinoProjectControllerDataView">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="263" height="72"/>
+                                                                    <rect key="frame" x="10" y="0.0" width="243" height="72"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                     <subviews>
-                                                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsExpansionToolTips="YES" id="nss-wl-6TY">
-                                                                            <rect key="frame" x="17" y="49" width="223" height="17"/>
+                                                                        <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nss-wl-6TY">
+                                                                            <rect key="frame" x="17" y="49" width="203" height="17"/>
                                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                                             <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" title="Table View Cell" id="HCp-It-Jhp">
                                                                                 <font key="font" metaFont="system"/>
@@ -409,7 +409,7 @@
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                        <box autoresizesSubviews="NO" boxType="custom" borderType="line" borderWidth="0.0" cornerRadius="5" title="Box" titlePosition="noTitle" id="kpw-qm-NQG">
+                                                                        <box autoresizesSubviews="NO" fixedFrame="YES" boxType="custom" borderType="line" borderWidth="0.0" cornerRadius="100" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="kpw-qm-NQG">
                                                                             <rect key="frame" x="5" y="52" width="10" height="10"/>
                                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             <view key="contentView" id="S9K-TP-K5A">
@@ -419,12 +419,12 @@
                                                                             <color key="borderColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                                             <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                                                         </box>
-                                                                        <box verticalHuggingPriority="750" boxType="separator" id="MsY-oY-iIn">
-                                                                            <rect key="frame" x="-12" y="-2" width="279" height="5"/>
+                                                                        <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="MsY-oY-iIn">
+                                                                            <rect key="frame" x="-12" y="-2" width="259" height="5"/>
                                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                                                         </box>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="PN4-Zx-XTz">
-                                                                            <rect key="frame" x="17" y="36" width="223" height="11"/>
+                                                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PN4-Zx-XTz">
+                                                                            <rect key="frame" x="17" y="36" width="203" height="11"/>
                                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                                             <textFieldCell key="cell" controlSize="mini" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" title="Label" id="gK0-ds-ocu">
                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -432,11 +432,11 @@
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                        <customView id="j8y-lz-3wP">
-                                                                            <rect key="frame" x="26" y="9" width="213" height="16"/>
+                                                                        <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="j8y-lz-3wP">
+                                                                            <rect key="frame" x="15" y="9" width="213" height="16"/>
                                                                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             <subviews>
-                                                                                <button toolTip="Open In Xcode" verticalHuggingPriority="750" id="0Kk-a1-H2b">
+                                                                                <button toolTip="Open In Xcode" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0Kk-a1-H2b">
                                                                                     <rect key="frame" x="144" y="0.0" width="33" height="16"/>
                                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                                                                                     <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="open-in-xcode" imagePosition="overlaps" alignment="center" controlSize="small" imageScaling="proportionallyDown" inset="2" id="21c-Zh-TSt">
@@ -444,7 +444,7 @@
                                                                                         <font key="font" metaFont="smallSystem"/>
                                                                                     </buttonCell>
                                                                                 </button>
-                                                                                <button toolTip="Switch listening mode" verticalHuggingPriority="750" id="PoH-Du-Pas">
+                                                                                <button toolTip="Switch listening mode" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PoH-Du-Pas">
                                                                                     <rect key="frame" x="0.0" y="0.0" width="33" height="16"/>
                                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                                                                                     <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="run" imagePosition="overlaps" alignment="center" controlSize="small" imageScaling="proportionallyDown" inset="2" id="WLR-K6-Jof">
@@ -452,7 +452,7 @@
                                                                                         <font key="font" metaFont="smallSystem"/>
                                                                                     </buttonCell>
                                                                                 </button>
-                                                                                <button toolTip="Reset the project" verticalHuggingPriority="750" id="7pJ-O0-Sk5">
+                                                                                <button toolTip="Reset the project" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7pJ-O0-Sk5">
                                                                                     <rect key="frame" x="180" y="0.0" width="33" height="16"/>
                                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                                                                                     <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="resync" imagePosition="overlaps" alignment="center" controlSize="small" imageScaling="proportionallyDown" inset="2" id="0lw-E5-col">
@@ -460,7 +460,7 @@
                                                                                         <font key="font" metaFont="smallSystem"/>
                                                                                     </buttonCell>
                                                                                 </button>
-                                                                                <button toolTip="Open in Finder" verticalHuggingPriority="750" id="vsI-jy-i4m">
+                                                                                <button toolTip="Open in Finder" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vsI-jy-i4m">
                                                                                     <rect key="frame" x="36" y="0.0" width="33" height="16"/>
                                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                                                                                     <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="open-in-finder" imagePosition="overlaps" alignment="center" controlSize="small" imageScaling="proportionallyDown" inset="2" id="wlx-b2-lHy">
@@ -468,7 +468,7 @@
                                                                                         <font key="font" metaFont="smallSystem"/>
                                                                                     </buttonCell>
                                                                                 </button>
-                                                                                <button toolTip="Edit in Code Editor" verticalHuggingPriority="750" id="rTo-y9-fQU">
+                                                                                <button toolTip="Edit in Code Editor" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rTo-y9-fQU">
                                                                                     <rect key="frame" x="72" y="0.0" width="33" height="16"/>
                                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                                                                                     <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="open-in-editor" imagePosition="overlaps" alignment="center" controlSize="small" imageScaling="proportionallyDown" inset="2" id="VDo-2A-vaS">
@@ -476,7 +476,7 @@
                                                                                         <font key="font" metaFont="smallSystem"/>
                                                                                     </buttonCell>
                                                                                 </button>
-                                                                                <button toolTip="Open Terminal in Project" verticalHuggingPriority="750" id="dz5-I3-w2h">
+                                                                                <button toolTip="Open Terminal in Project" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dz5-I3-w2h">
                                                                                     <rect key="frame" x="108" y="0.0" width="33" height="16"/>
                                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                                                                                     <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="open-in-terminal" imagePosition="overlaps" alignment="center" controlSize="small" imageScaling="proportionallyDown" inset="2" id="Mwt-yg-Jeo">
@@ -486,8 +486,8 @@
                                                                                 </button>
                                                                             </subviews>
                                                                         </customView>
-                                                                        <customView id="kNu-ud-1j8" customClass="YRKSpinningProgressIndicator">
-                                                                            <rect key="frame" x="244" y="28" width="16" height="16"/>
+                                                                        <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kNu-ud-1j8" customClass="YRKSpinningProgressIndicator">
+                                                                            <rect key="frame" x="224" y="28" width="16" height="16"/>
                                                                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                                                                             <userDefinedRuntimeAttributes>
                                                                                 <userDefinedRuntimeAttribute type="number" keyPath="maxValue">
@@ -521,23 +521,23 @@
                                             </subviews>
                                             <nil key="backgroundColor"/>
                                         </clipView>
-                                        <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="GIE-ju-XbD">
+                                        <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="GIE-ju-XbD">
                                             <rect key="frame" x="1" y="119" width="223" height="15"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
-                                        <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="pb5-AF-zGg">
+                                        <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="pb5-AF-zGg">
                                             <rect key="frame" x="224" y="17" width="15" height="102"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                     </scrollView>
-                                    <box autoresizesSubviews="NO" boxType="custom" borderType="line" title="Box" titlePosition="noTitle" transparent="YES" id="atN-bp-ONR">
+                                    <box autoresizesSubviews="NO" fixedFrame="YES" boxType="custom" borderType="line" title="Box" titlePosition="noTitle" transparent="YES" translatesAutoresizingMaskIntoConstraints="NO" id="atN-bp-ONR">
                                         <rect key="frame" x="0.0" y="0.0" width="263" height="32"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                         <view key="contentView" id="lgd-3C-ZcF">
                                             <rect key="frame" x="1" y="1" width="261" height="30"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
-                                                <button verticalHuggingPriority="750" id="7QO-xa-9rT">
+                                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7QO-xa-9rT">
                                                     <rect key="frame" x="0.0" y="-2" width="35" height="32"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                     <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="NSAddTemplate" imagePosition="overlaps" alignment="center" imageScaling="proportionallyDown" inset="2" id="ari-l9-Qyx">
@@ -548,7 +548,7 @@
                                                         <action selector="addProject:" target="923-ke-ovW" id="WcS-qH-gsc"/>
                                                     </connections>
                                                 </button>
-                                                <button verticalHuggingPriority="750" id="5qE-h2-muz">
+                                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5qE-h2-muz">
                                                     <rect key="frame" x="34" y="-2" width="35" height="32"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                     <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" imageScaling="proportionallyDown" inset="2" id="Wwg-4A-3Ad">
@@ -566,49 +566,49 @@
                                                 </button>
                                             </subviews>
                                         </view>
-                                        <color key="borderColor" name="gridColor" catalog="System" colorSpace="catalog"/>
-                                        <color key="fillColor" name="windowBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        <color key="borderColor" red="1" green="1" blue="1" alpha="0.41999999999999998" colorSpace="calibratedRGB"/>
+                                        <color key="fillColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                     </box>
                                 </subviews>
                             </customView>
-                            <customView id="87a-A4-dGN">
+                            <customView fixedFrame="YES" id="87a-A4-dGN">
                                 <rect key="frame" x="264" y="0.0" width="599" height="634"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <subviews>
-                                    <customView id="uJC-CC-9au">
+                                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uJC-CC-9au">
                                         <rect key="frame" x="0.0" y="0.0" width="599" height="634"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <subviews>
-                                            <box autoresizesSubviews="NO" boxType="custom" borderType="line" borderWidth="0.0" title="Box" titlePosition="noTitle" id="SrB-rO-09w">
+                                            <box autoresizesSubviews="NO" fixedFrame="YES" boxType="custom" borderType="line" borderWidth="0.0" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="SrB-rO-09w">
                                                 <rect key="frame" x="0.0" y="588" width="615" height="46"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                 <view key="contentView" id="98G-pQ-oIM">
                                                     <rect key="frame" x="0.0" y="0.0" width="615" height="46"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
-                                                        <box verticalHuggingPriority="750" boxType="separator" id="QMT-Ui-fxI">
+                                                        <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="QMT-Ui-fxI">
                                                             <rect key="frame" x="-1" y="-3" width="613" height="5"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                                         </box>
-                                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" id="krM-95-waf">
+                                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="krM-95-waf">
                                                             <rect key="frame" x="14" y="24" width="580" height="17"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" focusRingType="none" title="Project Name" id="ylH-C3-MHM">
                                                                 <font key="font" metaFont="system"/>
-                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                             </textFieldCell>
                                                             <connections>
                                                                 <binding destination="923-ke-ovW" name="value" keyPath="self.currentCappuccinoProjectController.cappuccinoProject.nickname" id="Teo-iY-bEl"/>
                                                             </connections>
                                                         </textField>
-                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="0c3-NS-t4n">
+                                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0c3-NS-t4n">
                                                             <rect key="frame" x="14" y="8" width="580" height="14"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" title="Project Path" id="NvI-dv-Vcf">
                                                                 <font key="font" metaFont="smallSystem"/>
-                                                                <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="textColor" red="0.76319916294850176" green="0.76061204714189667" blue="0.76578627875510685" alpha="1" colorSpace="calibratedRGB"/>
+                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                             </textFieldCell>
                                                             <connections>
                                                                 <binding destination="923-ke-ovW" name="value" keyPath="self.currentCappuccinoProjectController.cappuccinoProject.projectPath" id="IT9-Ja-icI"/>
@@ -616,17 +616,17 @@
                                                         </textField>
                                                     </subviews>
                                                 </view>
-                                                <color key="borderColor" name="gridColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="fillColor" name="windowBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="borderColor" red="0.96862745098039216" green="0.50588235294117645" blue="0.16470588235294117" alpha="1" colorSpace="calibratedRGB"/>
+                                                <color key="fillColor" red="0.34509803921568627" green="0.34509803921568627" blue="0.34509803921568627" alpha="1" colorSpace="calibratedRGB"/>
                                             </box>
-                                            <box autoresizesSubviews="NO" boxType="custom" borderType="line" borderWidth="0.0" title="Box" id="ic3-Xg-i5j">
+                                            <box autoresizesSubviews="NO" fixedFrame="YES" boxType="custom" borderType="line" borderWidth="0.0" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="ic3-Xg-i5j">
                                                 <rect key="frame" x="0.0" y="562" width="599" height="26"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                 <view key="contentView" id="Tuy-VW-JIc">
                                                     <rect key="frame" x="0.0" y="0.0" width="599" height="26"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
-                                                        <button verticalHuggingPriority="750" id="sNm-EJ-c40">
+                                                        <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sNm-EJ-c40">
                                                             <rect key="frame" x="18" y="2" width="147" height="22"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                             <buttonCell key="cell" type="square" title="Settings" bezelStyle="shadowlessSquare" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyDown" inset="2" id="Fel-8z-zmY">
@@ -642,7 +642,7 @@
                                                                 <action selector="updateSelectedTab:" target="923-ke-ovW" id="WXV-zO-X4G"/>
                                                             </connections>
                                                         </button>
-                                                        <button verticalHuggingPriority="750" id="E4i-Ez-bfl">
+                                                        <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="E4i-Ez-bfl">
                                                             <rect key="frame" x="227" y="2" width="147" height="22"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                             <buttonCell key="cell" type="square" title="Errors &amp; Warnings" bezelStyle="shadowlessSquare" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyDown" inset="2" id="x1c-0h-XNs">
@@ -658,7 +658,7 @@
                                                                 <action selector="updateSelectedTab:" target="923-ke-ovW" id="YlA-uX-wtA"/>
                                                             </connections>
                                                         </button>
-                                                        <button verticalHuggingPriority="750" id="UCo-MK-pOT">
+                                                        <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UCo-MK-pOT">
                                                             <rect key="frame" x="432" y="2" width="147" height="22"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                             <buttonCell key="cell" type="square" title="Operations" bezelStyle="shadowlessSquare" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyDown" inset="2" id="ZxW-hd-KKo">
@@ -674,16 +674,16 @@
                                                                 <action selector="updateSelectedTab:" target="923-ke-ovW" id="V56-Vq-dcX"/>
                                                             </connections>
                                                         </button>
-                                                        <box verticalHuggingPriority="750" boxType="separator" id="0Lp-Tm-YXi">
+                                                        <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="0Lp-Tm-YXi">
                                                             <rect key="frame" x="0.0" y="-2" width="599" height="5"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                                         </box>
                                                     </subviews>
                                                 </view>
-                                                <color key="borderColor" name="gridColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="fillColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="borderColor" red="0.93725490196078431" green="0.93725490196078431" blue="0.93725490196078431" alpha="1" colorSpace="calibratedRGB"/>
+                                                <color key="fillColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                             </box>
-                                            <tabView drawsBackground="NO" type="noTabsNoBorder" id="00d-fn-q41">
+                                            <tabView fixedFrame="YES" drawsBackground="NO" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="00d-fn-q41">
                                                 <rect key="frame" x="0.0" y="0.0" width="599" height="562"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -713,39 +713,30 @@
         </window>
         <window title="About" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="EMp-Db-uhU" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
-            <rect key="contentRect" x="196" y="240" width="296" height="191"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <rect key="contentRect" x="196" y="240" width="324" height="200"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>
             <view key="contentView" id="dj4-iP-S2b">
-                <rect key="frame" x="0.0" y="0.0" width="296" height="191"/>
+                <rect key="frame" x="0.0" y="0.0" width="324" height="200"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="3j4-r5-Ybe">
-                        <rect key="frame" x="74" y="64" width="149" height="17"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3j4-r5-Ybe">
+                        <rect key="frame" x="88" y="73" width="149" height="17"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="XcodeCapp" id="qvL-bN-A9R">
                             <font key="font" metaFont="systemBold" size="15"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField verticalHuggingPriority="750" id="IH1-cn-Xc9">
-                        <rect key="frame" x="18" y="20" width="260" height="14"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Copyright © 2012-2018 Cappuccino Project." id="8lT-Ky-ecV">
-                            <font key="font" metaFont="smallSystem"/>
-                            <color key="textColor" white="0.5" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
-                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                    </textField>
-                    <imageView id="Q2t-aL-TDg">
-                        <rect key="frame" x="107" y="89" width="82" height="82"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <imageView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Q2t-aL-TDg">
+                        <rect key="frame" x="121" y="98" width="82" height="82"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="logo" id="zF2-py-kAi"/>
                     </imageView>
-                    <textField verticalHuggingPriority="750" id="vIx-Hh-v8Z">
-                        <rect key="frame" x="108" y="42" width="81" height="14"/>
+                    <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vIx-Hh-v8Z">
+                        <rect key="frame" x="18" y="51" width="288" height="14"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Version 4.0.1" id="WUW-Ut-m7V">
+                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Value from Info.plist displayed using bindings" id="WUW-Ut-m7V">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -754,21 +745,33 @@
                             <binding destination="Voe-Tx-rLC" name="value" keyPath="self.version" id="Nfs-HY-nea"/>
                         </connections>
                     </textField>
+                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IH1-cn-Xc9">
+                        <rect key="frame" x="18" y="0.0" width="292" height="43"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" controlSize="small" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="Set in Info.plist, displayed using bindings" id="8lT-Ky-ecV">
+                            <font key="font" metaFont="smallSystem"/>
+                            <color key="textColor" white="0.5" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                        <connections>
+                            <binding destination="Voe-Tx-rLC" name="value" keyPath="self.copyright" id="cHX-2a-APu"/>
+                        </connections>
+                    </textField>
                 </subviews>
             </view>
-            <point key="canvasLocation" x="-218" y="94.5"/>
+            <point key="canvasLocation" x="-304" y="-20"/>
         </window>
         <userDefaultsController representsSharedInstance="YES" id="GHK-nR-IEq" userLabel="User Defaults Controller"/>
         <window title="XcodeCapp Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="xcc-prefs" animationBehavior="default" id="ekp-cc-W2F">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES"/>
             <rect key="contentRect" x="534" y="231" width="357" height="132"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>
             <view key="contentView" id="79d-AB-fk4">
                 <rect key="frame" x="0.0" y="0.0" width="357" height="132"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <button toolTip="If this is checked, when a Cappuccino project is opened, the project’s Xcode support project will be opened automatically" id="QGE-Iy-i46">
+                    <button toolTip="If this is checked, when a Cappuccino project is opened, the project’s Xcode support project will be opened automatically" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QGE-Iy-i46">
                         <rect key="frame" x="18" y="96" width="321" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Automatically open Projects in Xcode" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="VNE-DB-5fX">
@@ -784,7 +787,7 @@
                             </binding>
                         </connections>
                     </button>
-                    <textField verticalHuggingPriority="750" id="Llm-fD-60A">
+                    <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Llm-fD-60A">
                         <rect key="frame" x="18" y="70" width="186" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Maximum parallel operations:" id="feI-Ow-URM">
@@ -793,7 +796,7 @@
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <popUpButton verticalHuggingPriority="750" id="9up-BP-tRE">
+                    <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9up-BP-tRE">
                         <rect key="frame" x="229" y="65" width="111" height="26"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <popUpButtonCell key="cell" type="push" title="20" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="UjK-Ie-IaQ" id="niA-cT-acm">
@@ -814,7 +817,7 @@
                             <binding destination="GHK-nR-IEq" name="selectedValue" keyPath="values.XCCUserDefaultsMaxNumberOfConcurrentOperations" id="gpI-YW-A6a"/>
                         </connections>
                     </popUpButton>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="axH-wD-X4l">
+                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="axH-wD-X4l">
                         <rect key="frame" x="18" y="20" width="321" height="42"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" id="NZb-FO-ea5">
@@ -826,7 +829,7 @@
                     </textField>
                 </subviews>
             </view>
-            <point key="canvasLocation" x="-156.5" y="-126"/>
+            <point key="canvasLocation" x="136" y="-20"/>
         </window>
         <box boxType="custom" borderType="line" borderWidth="0.0" title="Box" titlePosition="noTitle" id="fYW-ua-i1m">
             <rect key="frame" x="0.0" y="0.0" width="271" height="313"/>
@@ -835,30 +838,30 @@
                 <rect key="frame" x="0.0" y="0.0" width="271" height="313"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
-                    <customView id="vKu-AP-6l9">
+                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vKu-AP-6l9">
                         <rect key="frame" x="16" y="16" width="239" height="281"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                         <subviews>
-                            <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" id="9iO-X5-hpo">
+                            <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9iO-X5-hpo">
                                 <rect key="frame" x="26" y="75" width="186" height="186"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="logo" id="1zG-V8-6bF"/>
                             </imageView>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="lpR-ul-R4k">
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lpR-ul-R4k">
                                 <rect key="frame" x="40" y="42" width="158" height="25"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="XcodeCapp" id="Oar-AW-2i5">
                                     <font key="font" metaFont="system" size="18"/>
-                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField verticalHuggingPriority="750" id="fUL-eL-YkQ">
+                            <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fUL-eL-YkQ">
                                 <rect key="frame" x="18" y="20" width="203" height="14"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Version 4.0" id="unR-NY-aap">
                                     <font key="font" metaFont="smallSystem"/>
-                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="textColor" white="0.31343064259999998" alpha="1" colorSpace="calibratedWhite"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                                 <connections>
@@ -869,9 +872,9 @@
                     </customView>
                 </subviews>
             </view>
-            <color key="borderColor" name="gridColor" catalog="System" colorSpace="catalog"/>
-            <color key="fillColor" name="windowBackgroundColor" catalog="System" colorSpace="catalog"/>
-            <point key="canvasLocation" x="630" y="-361"/>
+            <color key="borderColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+            <color key="fillColor" red="0.98039221759999995" green="0.98039221759999995" blue="0.98039221759999995" alpha="1" colorSpace="deviceRGB"/>
+            <point key="canvasLocation" x="310.5" y="-302.5"/>
         </box>
         <box boxType="custom" borderType="line" borderWidth="0.0" title="Box" titlePosition="noTitle" id="stz-Vu-tYo" customClass="XCCWelcomeView">
             <rect key="frame" x="0.0" y="0.0" width="464" height="401"/>
@@ -880,23 +883,23 @@
                 <rect key="frame" x="0.0" y="0.0" width="464" height="401"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
-                    <customView id="3EK-jb-wmc">
+                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3EK-jb-wmc">
                         <rect key="frame" x="15" y="16" width="434" height="369"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                         <subviews>
-                            <box verticalHuggingPriority="750" boxType="separator" id="FVR-yM-GAZ">
+                            <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="FVR-yM-GAZ">
                                 <rect key="frame" x="40" y="116" width="354" height="5"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                             </box>
-                            <box autoresizesSubviews="NO" boxType="custom" borderType="line" cornerRadius="28" title="Box" titlePosition="noTitle" id="Tbj-mM-87j">
-                                <rect key="frame" x="189" y="28" width="56" height="56"/>
+                            <box autoresizesSubviews="NO" fixedFrame="YES" boxType="custom" borderType="line" cornerRadius="100" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="Tbj-mM-87j">
+                                <rect key="frame" x="189" y="28" width="57" height="57"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                 <view key="contentView" id="aoX-nH-ofv">
-                                    <rect key="frame" x="1" y="1" width="54" height="54"/>
+                                    <rect key="frame" x="1" y="1" width="55" height="55"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <button focusRingType="none" id="wQo-c7-sD7">
-                                            <rect key="frame" x="14" y="14" width="27" height="26"/>
+                                        <button focusRingType="none" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wQo-c7-sD7">
+                                            <rect key="frame" x="14" y="15" width="27" height="26"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" focusRingType="none" imageScaling="proportionallyDown" inset="2" id="o7j-4e-NNJ">
                                                 <behavior key="behavior" lightByContents="YES"/>
@@ -906,16 +909,16 @@
                                                 <action selector="addProject:" target="923-ke-ovW" id="YGQ-yu-Glg"/>
                                             </connections>
                                         </button>
-                                        <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" bezeled="NO" indeterminate="YES" style="spinning" id="vPH-Iq-Ray">
-                                            <rect key="frame" x="11" y="11" width="32" height="32"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                        </progressIndicator>
                                     </subviews>
                                 </view>
-                                <color key="borderColor" red="0.97254901959999995" green="0.50196078430000002" blue="0.15686274510000001" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
-                                <color key="fillColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                <color key="borderColor" red="0.97254901960784312" green="0.50196078431372548" blue="0.15686274509803921" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="fillColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                             </box>
-                            <button focusRingType="none" id="wdl-kS-DYD">
+                            <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" maxValue="100" bezeled="NO" indeterminate="YES" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="vPH-Iq-Ray">
+                                <rect key="frame" x="201" y="40" width="32" height="32"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                            </progressIndicator>
+                            <button focusRingType="none" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wdl-kS-DYD">
                                 <rect key="frame" x="124" y="150" width="186" height="186"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="logo" imagePosition="only" alignment="center" focusRingType="none" imageScaling="proportionallyDown" inset="2" id="OC7-Ci-3pt">
@@ -930,8 +933,8 @@
                     </customView>
                 </subviews>
             </view>
-            <color key="borderColor" name="gridColor" catalog="System" colorSpace="catalog"/>
-            <color key="fillColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+            <color key="borderColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+            <color key="fillColor" red="0.98039221759999995" green="0.98039221759999995" blue="0.98039221759999995" alpha="1" colorSpace="deviceRGB"/>
             <connections>
                 <outlet property="boxImport" destination="Tbj-mM-87j" id="Nly-uI-l8C"/>
                 <outlet property="loadingIndicator" destination="vPH-Iq-Ray" id="qiU-X4-gPI"/>
@@ -971,8 +974,8 @@
         </menu>
     </objects>
     <resources>
-        <image name="NSAddTemplate" width="11" height="11"/>
-        <image name="NSRemoveTemplate" width="11" height="11"/>
+        <image name="NSAddTemplate" width="18" height="16"/>
+        <image name="NSRemoveTemplate" width="18" height="4"/>
         <image name="logo" width="512" height="512"/>
         <image name="open-in-editor" width="16" height="16"/>
         <image name="open-in-finder" width="16" height="16"/>

--- a/Tools/XcodeCapp/XcodeCapp/Info.plist
+++ b/Tools/XcodeCapp/XcodeCapp/Info.plist
@@ -34,7 +34,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>Version 4.0.1</string>
+	<string>Version 4.0.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
@@ -44,7 +44,7 @@
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2012-2018 Cappuccino Project. All rights reserved.</string>
+	<string>Copyright © 2012-2024 Cappuccino Project</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
Ahead of more substantial changes to XcodeCapp:

Use copyright string from Info.plist
(was previously hard-coded in About window, despite also being set in Info.plist).

Create copyright property on AppDelegate.

Append 'All rights reserved' in code, remove from Info.plist value (make line breaking in About window easier to manage, ease localization, ease automated checking of copyright dates.)

Display copyright notice using bindings.

Resize copyright field to prevent truncated text.

Set resize masks for all window fields - not currently set.

Resize window to golden ratio for improved visual presentation.