### PR TITLE
Re-enable installation of capp_lint

### DIFF
--- a/Tools/capp_lint/capp_lint
+++ b/Tools/capp_lint/capp_lint
@@ -27,6 +27,8 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+# Note: Python2 must be installed to run this
+
 from __future__ import with_statement
 from optparse import OptionParser
 from string import Template

--- a/Tools/capp_lint/install.sh
+++ b/Tools/capp_lint/install.sh
@@ -2,11 +2,7 @@
 
 chmod +x capp_lint
 
-if [[ ! -d /usr/local/narwhal/bin ]]; then
-    mkdir -p /usr/local/narwhal/bin
-fi
-
-cp capp_lint /usr/local/narwhal/bin
+cp capp_lint /usr/local/bin
 
 if [[ ! -d /usr/local/share/man/man1 ]]; then
     mkdir -p /usr/local/share/man/man1


### PR DESCRIPTION
Requires Python 2, but this is true for XcodeCapp also. Installs to /usr/bin/local, but must be manually installed using install script in source directory.