### PR TITLE
fixied: bindings for case  'only stop at tick marks'

### DIFF
--- a/AppKit/CPSlider.j
+++ b/AppKit/CPSlider.j
@@ -312,6 +312,9 @@ var AFFINITY = 5;
     if (!trackRect || CGRectIsEmpty(trackRect))
         trackRect = bounds;
 
+    [self closestTickMarkValueToValue: [self doubleValue]]; // we only need the side effect …
+    _currentTickMarkSegment = _closestTickMarkIndex; // … when "Only stop on tick marks" selected
+
     if (_isCircular)
     {
         var angle  = 3 * PI_2 - (1.0 - [self doubleValue] - _minValue) / (_maxValue - _minValue) * PI2,

--- a/AppKit/CPSlider.j
+++ b/AppKit/CPSlider.j
@@ -312,7 +312,7 @@ var AFFINITY = 5;
     if (!trackRect || CGRectIsEmpty(trackRect))
         trackRect = bounds;
 
-    [self closestTickMarkValueToValue: [self doubleValue]]; // we only need the side effect …
+    [self closestTickMarkValueToValue:[self doubleValue]]; // we only need the side effect …
     _currentTickMarkSegment = _closestTickMarkIndex; // … when "Only stop on tick marks" selected
 
     if (_isCircular)

--- a/AppKit/CPSlider.j
+++ b/AppKit/CPSlider.j
@@ -312,8 +312,11 @@ var AFFINITY = 5;
     if (!trackRect || CGRectIsEmpty(trackRect))
         trackRect = bounds;
 
-    [self closestTickMarkValueToValue:[self doubleValue]]; // we only need the side effect …
-    _currentTickMarkSegment = _closestTickMarkIndex; // … when "Only stop on tick marks" selected
+    if (_allowsTickMarkValuesOnly)
+    {
+        [self closestTickMarkValueToValue:[self doubleValue]]; // we only need the side effect …
+        _currentTickMarkSegment = _closestTickMarkIndex;
+    }
 
     if (_isCircular)
     {


### PR DESCRIPTION
This fixes bindings to also work when 'only stop at tick marks' is selected; formerly the code would crash silently with `setObjectValue`.