### PR TITLE
Change rendering mode for menubar inactive icon from ‘Render As’ to ‘Template Image’

### DIFF
--- a/Tools/XcodeCapp/XcodeCapp/Images.xcassets/status-icon-inactive.imageset/Contents.json
+++ b/Tools/XcodeCapp/XcodeCapp/Images.xcassets/status-icon-inactive.imageset/Contents.json
@@ -1,14 +1,14 @@
 {
   "images" : [
     {
+      "filename" : "status-icon-inactive.png",
       "idiom" : "universal",
-      "scale" : "1x",
-      "filename" : "status-icon-inactive.png"
+      "scale" : "1x"
     },
     {
+      "filename" : "status-icon-inactive@2x.png",
       "idiom" : "universal",
-      "scale" : "2x",
-      "filename" : "status-icon-inactive@2x.png"
+      "scale" : "2x"
     },
     {
       "idiom" : "universal",
@@ -16,7 +16,10 @@
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
Allows macOS to automatically manage blending mode and color of menubar icon.

Modern macOS renders the menubar with translucency, making icons with some fixed colors difficult to see with some wallpapers.
This was particularly pronounced with ‘status-icon-inactive’. 

Changing render mode to ‘Template Image’ allows the OS to adjust icon color and blending mode dynamically — to suit current combination of Light/Dark mode and wallpaper color.