### PR TITLE
fixed: CPObjectController returns 'null marker' instead of nil

### DIFF
--- a/AppKit/CPObjectController.j
+++ b/AppKit/CPObjectController.j
@@ -808,7 +808,8 @@ var CPObjectControllerContentKey                        = @"CPObjectControllerCo
         var value = [self _controllerMarkerForValues:values];
         [_cachedValues setObject:value forKey:theKeyPath];
 
-        return value;
+        // Apple's implementation returns nil instead of CPNullMarker
+        return value === CPNullMarker ? nil : value;
     }
     else
         return values;

--- a/Tests/AppKit/CPObjectControllerTest.j
+++ b/Tests/AppKit/CPObjectControllerTest.j
@@ -1,0 +1,21 @@
+@import <AppKit/AppKit.j>
+
+@implementation CPObjectControllerTest : OJTestCase
+{
+}
+
+- (void)setUp
+{
+}
+
+- (void)testObjectControllerSelectionWithNil
+{
+    var controller = [[CPObjectController alloc] init];
+    [controller setContent:@{@"name": @"Martin"}];
+    [self assert:@"Martin" equals:[[controller selection] valueForKeyPath:@"name"] message:@"name equals 'Martin'"];
+    [self assert:nil equals:[[controller selection] valueForKeyPath:@"lastName"] message:@"name equals 'nil'"];
+    [self assert:@"Martin" equals:[controller valueForKeyPath:@"selection.name"] message:@"selection.name equals 'Martin'"];
+    [self assert:nil equals:[controller valueForKeyPath:@"selection.lastName"] message:@"selection.name equals 'nil'"];
+}
+
+@end


### PR DESCRIPTION
fixes #1987