### PR TITLE
new: Prevent _CPMenuWindow from becoming key window

### DIFF
--- a/AppKit/CPMenu/_CPMenuWindow.j
+++ b/AppKit/CPMenu/_CPMenuWindow.j
@@ -431,6 +431,13 @@ _CPMenuWindowAttachedMenuBackgroundStyle    = 2;
     return [_menuView itemIndexAtPoint:[_menuView convertPoint:aPoint fromView:nil]];
 }
 
+// Fix for context menus preventing events from reaching the first responder
+
+- (BOOL)canBecomeKeyWindow
+{
+    return NO;
+}
+
 @end
 
 #pragma mark -


### PR DESCRIPTION
When a context menu or popup menu is opened, it creates a `_CPMenuWindow`. Previously, this window would become the key window, causing the main document window to resign key status. This broke the responder chain for the main window (preventing it from receiving key events) and caused issues with dismissing the menu when clicking outside.

This commit overrides `canBecomeKeyWindow` in `_CPMenuWindow` to return `NO`, ensuring that menu windows never steal key focus from the application.

Fixes #581