### PR TITLE
Fixed: CPMenu items appearing on the wrong side of the menu bar

### DIFF
--- a/AppKit/CPMenu/CPMenu.j
+++ b/AppKit/CPMenu/CPMenu.j
@@ -269,7 +269,8 @@ var _CPMenuBarVisible               = NO,
     if (self)
     {
         _title = aTitle;
-        _items = [];
+        // Use CPMutableArray instead of raw JS array for consistency with removeAllItems
+        _items = [CPMutableArray array]; 
 
         _autoenablesItems = YES;
         _showsStateColumn = YES;
@@ -374,6 +375,10 @@ var _CPMenuBarVisible               = NO,
     [self willChangeValueForKey:@"items"];
     _items = [CPMutableArray array];
     [self didChangeValueForKey:@"items"];
+    
+    // Ensure the main menu updates if cleared
+    if (self === [CPApp mainMenu] && _CPMenuBarSharedWindow)
+        [_CPMenuBarSharedWindow setMenu:self];
 }
 
 /*!
@@ -1223,6 +1228,11 @@ var _CPMenuBarVisible               = NO,
         postNotificationName:CPMenuDidAddItemNotification
                       object:self
                     userInfo:@{ @"CPMenuItemIndex": anIndex }];
+
+    // FIX #1222: If this is the main menu, force the shared menu bar window to refresh its layout.
+    // This ensures new items are positioned correctly (e.g. not pushed to the far right by previous layout states).
+    if (self === [CPApp mainMenu] && _CPMenuBarSharedWindow)
+        [_CPMenuBarSharedWindow setMenu:self];
 }
 
 - (void)removeObjectFromItemsAtIndex:(CPUInteger)anIndex
@@ -1238,6 +1248,10 @@ var _CPMenuBarVisible               = NO,
         postNotificationName:CPMenuDidRemoveItemNotification
                       object:self
                     userInfo:@{ @"CPMenuItemIndex": anIndex }];
+    
+    // FIX #1222: Ensure the shared menu bar updates layout when items are removed.
+    if (self === [CPApp mainMenu] && _CPMenuBarSharedWindow)
+        [_CPMenuBarSharedWindow setMenu:self];
 }
 
 @end
@@ -1331,4 +1345,3 @@ var CPMenuTitleKey              = @"CPMenuTitleKey",
 
 @import "_CPMenuBarWindow.j"
 @import "_CPMenuWindow.j"
-


### PR DESCRIPTION
When items were added to the main menu programmatically using addItem: or insertItem:, they were often visually placed on the far right of the menu bar due to a lack of layout invalidation in the shared menu bar window.

This change ensures that _CPMenuBarSharedWindow refreshes its menu content whenever items are inserted or removed from the main menu, forcing a correct re-layout of the menu items. Additionally, _items is now explicitly initialized as a CPMutableArray.

Fixes #1222