### PR TITLE
fixed: CPOutlineView should be its own tableView delegate and datasource

### DIFF
--- a/AppKit/CPOutlineView.j
+++ b/AppKit/CPOutlineView.j
@@ -252,7 +252,7 @@ var CPOutlineViewCoalesceSelectionNotificationStateOff  = 0,
 
     Theme states for custom data views are documented in CPTableView.
 */
-@implementation CPOutlineView : CPTableView <CPTableViewDataSource, CPTableViewDelegate>
+@implementation CPOutlineView : CPTableView
 {
     id <CPOutlineViewDataSource>    _outlineViewDataSource;
     id <CPOutlineViewDelegate>      _outlineViewDelegate;


### PR DESCRIPTION
Previously, CPOutlineView used private proxy objects (_CPOutlineViewTableViewDelegate and _CPOutlineViewTableViewDataSource) to act as the delegate and data source for the underlying CPTableView. This caused [outlineView delegate] to return the internal proxy object instead of the outline view itself, which is unexpected behavior and deviates from Cocoa.

This commit refactors CPOutlineView to:
- Remove the _CPOutlineViewTableViewDelegate and _CPOutlineViewTableViewDataSource proxy classes.
- Adopt the CPTableViewDelegate and CPTableViewDataSource protocols directly on CPOutlineView.
- Set [super setDelegate:self] and [super setDataSource:self] during initialization.
- Move the logic for routing table view messages to the outline view's delegate/datasource directly into CPOutlineView.

Fixes #437