### PR TITLE
Fixed: [CPView addSubview:] was ignoring bounds origin for DOM positioning

### DIFF
--- a/AppKit/CPView.j
+++ b/AppKit/CPView.j
@@ -662,6 +662,11 @@ var CPViewHighDPIDrawingEnabled = YES;
 #endif
     }
 
+#if PLATFORM(DOM)
+    var origin = aSubview._frame.origin;
+    CPDOMDisplayServerSetStyleLeftTop(aSubview._DOMElement, _boundsTransform, origin.x, origin.y);
+#endif
+
     [aSubview setNextResponder:self];
     [aSubview _scaleSizeUnitSquareToSize:[self _hierarchyScaleSize]];
 


### PR DESCRIPTION
When a CPView has a non-zero bounds origin (set via setBoundsOrigin:),
it uses a _boundsTransform to map coordinates. Previously, adding a
subview did not take this transform into account during the initial
DOM element placement, causing the subview to appear in the wrong
position until a subsequent frame change occurred.

This change adds a call to CPDOMDisplayServerSetStyleLeftTop in
_insertSubview:atIndex: to ensure the subview's DOM element is
positioned correctly relative to the superview's bounds immediately.

Fixes #2081