### PR TITLE
fixed: CPDocument sends windowWillClose: message twice

### DIFF
--- a/AppKit/CPDocument.j
+++ b/AppKit/CPDocument.j
@@ -871,10 +871,13 @@ var CPDocumentUntitledCount = 0;
 {
     var theDelegate = context.delegate;
 
-    if (aDocument === self && shouldClose)
+    // Only close the document explicitly if there is NO delegate to handle the action.
+    // If a delegate exists (e.g., the CPWindow), it is responsible for performing the close
+    // upon receiving the callback below. Calling [self close] here would cause a double-close.
+    if (aDocument === self && shouldClose && theDelegate == nil)
         [self close];
 
-    else if (theDelegate != null)
+    if (theDelegate)
         theDelegate.isa.objj_msgSend3(theDelegate, context.selector, aDocument, shouldClose, context.context);
 }
 


### PR DESCRIPTION
When `_document:shouldClose:context:` is called with `shouldClose` set to YES, the document calls `[self close]`. Previously, the code would unconditionally call the delegate afterwards.

Since `[self close]` initiates the closing of attached window controllers and windows, invoking the delegate immediately after caused the closing logic (and `windowWillClose:`) to trigger a second time.

This change places the delegate callback inside an `else` block, ensuring it is not called if the document has already initiated the close sequence.

Fixes #1871