### PR TITLE
Fixed: CPRuleEditor rows did not resize after being shrunken

### DIFF
--- a/AppKit/CPRuleEditor/CPRuleEditor.j
+++ b/AppKit/CPRuleEditor/CPRuleEditor.j
@@ -1774,7 +1774,12 @@ TODO: implement
 
 - (_CPRuleEditorViewSliceRow)_createNewSliceWithFrame:(CGRect)frame ruleEditorView:(CPRuleEditor)editor
 {
-    return [[_CPRuleEditorViewSliceRow alloc] initWithFrame:frame ruleEditorView:editor];
+    var slice = [[_CPRuleEditorViewSliceRow alloc] initWithFrame:frame ruleEditorView:editor];
+    
+    // Ensure the slice resizes with the editor
+    [slice setAutoresizingMask:CPViewWidthSizable];
+    
+    return slice;
 }
 
 - (void)_reconfigureSubviewsAnimate:(BOOL)animate


### PR DESCRIPTION
The individual row slices in CPRuleEditor were missing the CPViewWidthSizable 
autoresizing mask. This caused the right-hand side views (like text fields) 
to remain stuck at their minimum size after the window was shrunk and then 
expanded again.

This commit adds the CPViewWidthSizable mask to newly created slices in 
_createNewSliceWithFrame:ruleEditorView:.

Fixes #1985