### PR TITLE
Fixed: Toolbar items show now visual feedback when clicked

### DIFF
--- a/AppKit/CPToolbar.j
+++ b/AppKit/CPToolbar.j
@@ -1014,6 +1014,7 @@ var LABEL_MARGIN    = 2.0;
 
     CPImageView     _imageView;
     CPView          _view;
+    CPView          _highlightView;
 
     CPTextField     _labelField;
 
@@ -1243,6 +1244,18 @@ var LABEL_MARGIN    = 2.0;
 
         if (alternateImage)
             [_imageView setImage:alternateImage];
+        else
+        {
+            if (!_highlightView)
+            {
+                _highlightView = [[CPView alloc] initWithFrame:[_imageView bounds]];
+                [_highlightView setBackgroundColor:[CPColor blackColor]];
+                [_highlightView setAlphaValue:0.3];
+                [_highlightView setAutoresizingMask:CPViewWidthSizable | CPViewHeightSizable];
+            }
+
+            [_imageView addSubview:_highlightView];
+        }
 
         [_labelField setTextShadowOffset:CGSizeMakeZero()];
     }
@@ -1252,6 +1265,8 @@ var LABEL_MARGIN    = 2.0;
 
         if (image)
             [_imageView setImage:image];
+
+        [_highlightView removeFromSuperview];
 
         [_labelField setTextShadowOffset:CGSizeMake(0.0, 1.0)];
     }


### PR DESCRIPTION
Previously, toolbar items that did not have a specific 'alternateImage' set would show no visual change when clicked. This patch updates `_CPToolbarItemView` to apply a semi-transparent black overlay to the image during the highlighted state if no alternate image exists, mimicking standard Cocoa behavior.

Fixes #1967