### PR TITLE
Cpmenu top level item sticky selection fix

### DIFF
--- a/AppKit/CPMenu/_CPMenuBarWindow.j
+++ b/AppKit/CPMenu/_CPMenuBarWindow.j
@@ -473,7 +473,7 @@
 
     // If the mouse is within the menu bar bounds but not over an item
     // (e.g. dragging far left or right), force the menu to unhighlight.
-    if (CGRectContainsPoint([self bounds], aPoint))
+    if (CGRectContainsPoint([[self contentView] bounds], aPoint))
         [_menu _highlightItemAtIndex:CPNotFound];
 
     return CPNotFound;


### PR DESCRIPTION
Previously, dragging the mouse horizontally along the main menu bar into an area without items (e.g., far left or right) would leave the last hovered menu item highlighted and its submenu open.

This patch modifies `itemIndexAtPoint:` in `_CPMenuBarWindow.j`. It now detects if the mouse is within the menu bar's content view bounds but matches no specific item. In this case, it explicitly clears the menu highlight (`CPNotFound`), ensuring the submenu closes immediately.