### PR TITLE
fixed: prevent timezone shift from reverting month navigation in _CPD…

### DIFF
--- a/AppKit/CPDatePicker/_CPDatePickerCalendar.j
+++ b/AppKit/CPDatePicker/_CPDatePickerCalendar.j
@@ -251,7 +251,15 @@
 
 - (void)_displayNextMonth
 {
-     [self setDateValue:[_monthView nextMonth]];
+    // Copy the date so we don't modify the view's state directly
+    var nextDate = [[_monthView nextMonth] copy];
+    
+    // Set to the middle of the month (15th).
+    // This prevents [setDateValue:]'s timezone adjustment from 
+    // shifting the date back into the previous month (e.g., Nov 1 -> Oct 31).
+    nextDate.setDate(15);
+    
+    [self setDateValue:nextDate];
 }
 
 - (void)_displayPreviousMonth


### PR DESCRIPTION
…atePickerCalendar

Ensure month navigation uses the 15th of the month rather than the 1st. This prevents time zone adjustments in setDateValue: from rolling the date back into the previous month, which caused the calendar to stay stuck on the current month.