### PR TITLE
CPTableView: Replace Canvas drawing with CSS to fix Firefox crash

### DIFF
--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -3298,22 +3298,11 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
         _draggedColumnIsSelected = [self isColumnSelected:columnIndex];
 
     var columnLeft = CGRectGetMinX(columnRect),
-        offset = CGPointMake(columnLeft, CGRectGetMinY(visibleRect)),
-        // FIX: Check if we should force the "white text" look (Selected + Focused)
-        shouldForceActiveState = [self isColumnSelected:columnIndex] && [self _isFocused];
+        offset = CGPointMake(columnLeft, CGRectGetMinY(visibleRect));
 
     [self _enumerateViewsInRows:_exposedRows columns:[CPIndexSet indexSetWithIndex:columnIndex] usingBlock:function(dataView, row, column, stop)
     {
         [self _addDraggedDataView:dataView toView:columnClipView forColumn:column row:row offset:offset];
-
-        // FIX: Force theme states because these views are about to lose their context
-        // (either by moving to a non-key DragWindow or by being removed from _dataViewsForRows tracking)
-        if (shouldForceActiveState)
-        {
-            [dataView setThemeState:CPThemeStateFirstResponder];
-            [dataView setThemeState:CPThemeStateKeyWindow];
-        }
-
         delete (_dataViewsForRows[row][tableColumnUID]);
     }];
 


### PR DESCRIPTION
This commit addresses a critical issue where large tables in Firefox caused an "Uncaught DOMException: CanvasRenderingContext2D.translate" error due to canvas coordinate limits.

Changes:
- Removed `_CPTableDrawView` and associated Canvas drawing logic (grid, background, highlight).
- Implemented `_updateRowStyleForView` to apply styles directly via CSS on the DOM elements.
- Grid lines are now rendered using CSS borders.
- Backgrounds and selection highlights are now rendered using CSS background-colors.
- Updated `_preparedViewAtColumn` to apply styles immediately upon view creation/recycling.

This switch from Canvas to CSS eliminates the coordinate translation error and significantly improves rendering performance for tables with high row counts.