### PR TITLE
fixed: menu key support conflicting with browser native menu keys

### DIFF
--- a/AppKit/CPMenu/CPMenu.j
+++ b/AppKit/CPMenu/CPMenu.j
@@ -1080,7 +1080,11 @@ var _CPMenuBarVisible               = NO,
 
 #if PLATFORM(DOM)
                 // we are done with this event in cappuccino space. do not let the browser do something weird additionally (e.g. command-o).
-                _CPDOMEventStop(anEvent._DOMEvent);
+                // but we must not stop copy/paste events as these can only be handled by the browser at this time even if they are in our menu
+                // (until we move to CPTextView as the fieleditor)
+
+                if (characters != "c" && characters != "x" && characters != "v")
+                    _CPDOMEventStop(anEvent._DOMEvent);
 #endif
             }
             else


### PR DESCRIPTION
this PR stops native event propagation when a menu key was successfully handled. this prevents the browser to perform another unrelated surprising action from his own menu keys.

fixes #1964