### PR TITLE
Fixed: CPWindow setContentView: overlapping the toolbar

### DIFF
--- a/AppKit/CPWindow/CPWindow.j
+++ b/AppKit/CPWindow/CPWindow.j
@@ -1266,6 +1266,10 @@ CPTexturedBackgroundWindowMask
     [_contentView setAutoresizingMask:CPViewWidthSizable | CPViewHeightSizable];
     [_windowView addSubview:_contentView];
 
+    // The window view manages the exact layout of the content view (e.g. offsetting for the toolbar).
+    if ([_windowView respondsToSelector:@selector(tile)])
+        [_windowView tile];
+
     /*
         If the initial first responder has been set to something other than
         the window, set it to the window because it will no longer be valid.


### PR DESCRIPTION
When `setContentView:` is called, it calculates the new view's frame using
`contentRectForFrameRect:`. However, this static calculation doesn't 
account for dynamic elements like toolbars, causing the new content view 
to be placed at the top of the window (origin 0,0) and overlapping the 
toolbar.

To fix this, we now explicitly tell the `_windowView` to update its 
layout by calling `tile` (if implemented) right after the new content 
view is added. This allows the specific window view subclass (e.g., 
`_CPStandardWindowView`) to correctly calculate the dynamic bounds and 
inset the content view below the toolbar, avoiding heavier workarounds 
like `_noteToolbarChanged`.

Fixes #783