### PR TITLE
Fixed: multiple didFailToFormatString delegate calls in CPTextField (#1546)

### DIFF
--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -336,7 +336,8 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
                                            characters:nil
                           charactersIgnoringModifiers:nil
                                             isARepeat:NO
-                                              keyCode:nil];
+                                              keyCode:nil
+                                          isActionKey:NO];
 
             [CPTextFieldInputOwner keyUp:cappEvent];
 


### PR DESCRIPTION
When a text field containing an invalid value loses focus due to a user click, a cascade of focus change attempts occurs almost simultaneously (via `CPWindow` hit testing, explicit `mouseDown:` overrides, and the browser's native DOM `blur`). This previously caused the `control:didFailToFormatString:errorDescription:` delegate method to be erroneously called up to 3 times for a single interaction.

This commit fixes the issue by caching the result of the delegate call and associating it with `[CPApp currentEvent]`. If the exact same user event triggers repeated validation failures for the same string on the same text field, the cached result is returned, preventing the delegate from being spammed.

Fixes #1546