### PR TITLE
Fixed: timing of CPControlTextDidBeginEditingNotification (#1941)

### DIFF
--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -1131,6 +1131,12 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
     if (![self isEnabled] || !([self isEditable] || [self isSelectable]))
         return;
 
+    if ([self isEditable] && !_isEditing)
+    {
+        _isEditing = YES;
+        [self textDidBeginEditing:[CPNotification notificationWithName:CPControlTextDidBeginEditingNotification object:self userInfo:nil]];
+    }
+
     // CPTextField uses an HTML input element to take the input so we need to
     // propagate the dom event so the element is updated. This has to be done
     // before interpretKeyEvents: though so individual commands have a chance

--- a/AppKit/CPTokenField.j
+++ b/AppKit/CPTokenField.j
@@ -453,8 +453,8 @@ CPTokenFieldDeleteButtonType     = 1;
     {
         [_tokenScrollView documentView]._DOMElement.appendChild(element);
 
-        //post CPControlTextDidBeginEditingNotification
-        [self textDidBeginEditing:[CPNotification notificationWithName:CPControlTextDidBeginEditingNotification object:self userInfo:nil]];
+        // Removed so CPTokenField doesn't fire the notification the moment it becomes the first responder, but instead defers to the first keystroke, just like Cocoa (see keyDown: in CPTextField).
+        // [self textDidBeginEditing:[CPNotification notificationWithName:CPControlTextDidBeginEditingNotification object:self userInfo:nil]];
 
         [[CPRunLoop mainRunLoop] performBlock:function()
         {

--- a/AppKit/CPTokenField.j
+++ b/AppKit/CPTokenField.j
@@ -349,6 +349,12 @@ CPTokenFieldDeleteButtonType     = 1;
     if (theBinding)
         [theBinding reverseSetValueFor:@"objectValue"];
 
+    if (!_isEditing)
+    {
+        _isEditing = YES;
+        [self textDidBeginEditing:[CPNotification notificationWithName:CPControlTextDidBeginEditingNotification object:self userInfo:nil]];
+    }
+
     [self textDidChange:[CPNotification notificationWithName:CPControlTextDidChangeNotification object:self userInfo:nil]];
 
     _shouldNotifyTarget = YES;
@@ -497,6 +503,8 @@ CPTokenFieldDeleteButtonType     = 1;
     [self _setObserveWindowKeyNotifications:NO];
 
     [self _resignFirstKeyResponder];
+
+    _isEditing = NO;
 
     if (_shouldNotifyTarget)
     {
@@ -1031,6 +1039,16 @@ CPTokenFieldDeleteButtonType     = 1;
 #if PLATFORM(DOM)
     CPTokenFieldTextDidChangeValue = [self stringValue];
 #endif
+
+    // Has to be enabled, and it also has to be editable or selectable.
+    if (![self isEnabled] || !([self isEditable] || [self isSelectable]))
+        return;
+
+    if ([self isEditable] && !_isEditing)
+    {
+        _isEditing = YES;
+        [self textDidBeginEditing:[CPNotification notificationWithName:CPControlTextDidBeginEditingNotification object:self userInfo:nil]];
+    }
 
     // Leave the default _propagateCurrentDOMEvent setting in place. This might be YES or NO depending
     // on if something that could be a browser shortcut was pressed or not, such as Cmd-R to reload.


### PR DESCRIPTION
In Cocoa, `NSControlTextDidBeginEditingNotification` is sent on the first `keyDown` event after a field gains focus. Previously, Cappuccino incorrectly sent this notification on `keyUp` in `CPTextField` and immediately upon becoming the key responder in `CPTokenField`.

This commit aligns Cappuccino's behavior with Cocoa by:
* Updating `keyDown:` in `CPTextField` to detect the start of an editing session and immediately broadcast `CPControlTextDidBeginEditingNotification` on the first keystroke.
* Removing the premature notification call from `_becomeFirstKeyResponder` in `CPTokenField`, allowing it to naturally inherit the corrected `keyDown:` behavior from `CPTextField`.

Fixes #1941