### PR TITLE
fixed: CPTokenField autocomplete when placed in a CPToolbar

### DIFF
--- a/AppKit/CPTokenField.j
+++ b/AppKit/CPTokenField.j
@@ -551,7 +551,7 @@ CPTokenFieldDeleteButtonType     = 1;
         CPTokenFieldCachedDragFunction = nil;
 
         document.body.ondrag = CPTokenFieldCachedDragFunction;
-        document.body.onselectstart = CPTokenFieldCachedSelectStartFunction
+        document.body.onselectstart = CPTokenFieldCachedSelectStartFunction;
     }
 
 #endif

--- a/AppKit/CPToolbar.j
+++ b/AppKit/CPToolbar.j
@@ -1021,6 +1021,22 @@ var LABEL_MARGIN    = 2.0;
     BOOL            _FIXME_isHUD;
 }
 
+- (BOOL)acceptsFirstResponder
+{
+    if (_view && [_view acceptsFirstResponder])
+        return YES;
+
+     return NO;
+}
+
+- (BOOL)becomeFirstResponder
+{
+    if (_view && [_view acceptsFirstResponder])
+        return [[self window] makeFirstResponder:_view];
+
+    return [super becomeFirstResponder];
+}
+
 - (id)initWithToolbarItem:(CPToolbarItem)aToolbarItem toolbar:(CPToolbar)aToolbar
 {
     self = [super init];


### PR DESCRIPTION
When a CPTokenField or CPComboBox is placed inside a CPToolbar, interacting 
with the autocomplete menu would cause the field to lose focus and 
prematurely dismiss the menu.

This occurred because `_CPToolbarItemView` was hardcoded to return `NO` for 
`acceptsFirstResponder` in an attempt to prevent focus hijacking. However, 
this unintentionally broke the responder chain for its custom child views 
during focus resolution. 

This patch updates `_CPToolbarItemView` to conditionally return `YES` to 
`acceptsFirstResponder` if its custom inner `_view` accepts it, and safely 
routes `becomeFirstResponder` directly to that view.

Fixes #1520