### PR TITLE
new: clear CPPredicateEditor rows when objectValue is set to nil

### DIFF
--- a/AppKit/CPRuleEditor/CPPredicateEditor.j
+++ b/AppKit/CPRuleEditor/CPPredicateEditor.j
@@ -269,6 +269,8 @@
     _currentAnimation = nil;
     _sendAction = NO;
 
+    var rows = [];
+
     if (predicate != nil)
     {
         if ((_nestingMode == CPRuleEditorNestingModeSimple || _nestingMode == CPRuleEditorNestingModeCompound)
@@ -276,9 +278,12 @@
             predicate = [[CPCompoundPredicate alloc] initWithType:[self _compoundPredicateTypeForRootRows] subpredicates:[CPArray arrayWithObject:predicate]];
 
         var row = [self _rowObjectFromPredicate:predicate];
+        
         if (row != nil)
-            [_boundArrayOwner setValue:[CPArray arrayWithObject:row] forKey:_boundArrayKeyPath];
+            [rows addObject:row];
     }
+
+    [_boundArrayOwner setValue:rows forKey:_boundArrayKeyPath];
 
     [self setAnimation:animation];
 }


### PR DESCRIPTION
Previously, `_reflectPredicate:` would skip updating `_boundArrayOwner` 
if the provided predicate was nil, leaving the existing rows visible on 
screen. By initializing an empty rows array and unconditionally updating 
the bound array owner, the editor now correctly drops all rows when 
`setObjectValue:nil` is called.

Closes #1281
