### PR TITLE
Fixed: incorrect CPWebView sizing after animation

### DIFF
--- a/AppKit/CPWebView.j
+++ b/AppKit/CPWebView.j
@@ -278,7 +278,11 @@ CPWebViewAppKitScrollMaxPollCount                  = 3;
 
     if (_effectiveScrollMode === CPWebViewScrollAppKit)
     {
-        var visibleRect = [_frameView visibleRect];
+        // Use `[_scrollView documentVisibleRect]` instead of `[_frameView visibleRect]`.
+        // `visibleRect` accounts for window clipping, which collapses to 0x0 if the view is 
+        // animated off-screen, resulting in an incorrectly shrunken web layout.
+        var visibleRect = [_scrollView documentVisibleRect];
+        
         [_frameView setFrameSize:CGSizeMake(CGRectGetMaxX(visibleRect), CGRectGetMaxY(visibleRect))];
 
         // try to get the document size so we can correctly set the frame


### PR DESCRIPTION
When a CPWebView is animated off-screen, its layout incorrectly shrinks 
and fails to recover. This occurs because `_resizeWebFrame` relies on 
`[_frameView visibleRect]` to temporarily collapse the frame and calculate 
the inner DOM size. Because `visibleRect` factors in window clipping, 
animating the view outside the window bounds causes the rect to evaluate 
to {0, 0, 0, 0}. This forces the iframe into a 0x0 footprint, corrupting 
the layout when it returns on-screen.

Replacing `[_frameView visibleRect]` with `[_scrollView documentVisibleRect]` 
fixes the issue. `documentVisibleRect` correctly calculates the internal 
viewport size of the scroll view, completely ignoring external window 
clipping.

Fixes #1893