### PR TITLE
Fixed: CPTableView bug where removing a column breaks internal state

### DIFF
--- a/AppKit/CPTableView.j
+++ b/AppKit/CPTableView.j
@@ -3486,13 +3486,73 @@ Your delegate can implement this method to avoid subclassing the tableview to ad
                 [removeIndexes addIndex:columnIdx];
         }
 
-        var rowIndexes = [CPIndexSet indexSetWithIndexesInRange:CPMakeRange(0, [self numberOfRows])];
-        [self _unloadDataViewsInRows:rowIndexes columns:removeIndexes];
+        if ([removeIndexes count] > 0)
+        {
+            var rowIndexes = [CPIndexSet indexSetWithIndexesInRange:CPMakeRange(0, [self numberOfRows])];
+            [self _unloadDataViewsInRows:rowIndexes columns:removeIndexes];
 
-        [_tableColumns removeObjectsAtIndexes:removeIndexes];
+            [_tableColumns removeObjectsAtIndexes:removeIndexes];
 
-        _dirtyTableColumnRangeIndex = 0;
-        [self _recalculateTableColumnRanges];
+            _dirtyTableColumnRangeIndex = 0;
+            [self _recalculateTableColumnRanges];
+
+            // Shift cached index sets downwards to account for the removed columns
+            var shiftIndexSet = function(indexSet)
+            {
+                var newSet = [CPIndexSet indexSet];
+                [indexSet enumerateIndexesUsingBlock:function(idx, stop)
+                {
+                    if (![removeIndexes containsIndex:idx])
+                    {
+                        var shift = 0,
+                            remIdx = [removeIndexes firstIndex];
+
+                        while (remIdx !== CPNotFound && remIdx < idx)
+                        {
+                            shift++;
+                            remIdx = [removeIndexes indexGreaterThanIndex:remIdx];
+                        }
+
+                        [newSet addIndex:idx - shift];
+                    }
+                }];
+                return newSet;
+            };
+
+            _exposedColumns = shiftIndexSet(_exposedColumns);
+            _selectedColumnIndexes = shiftIndexSet(_selectedColumnIndexes);
+
+            // Shift individual index variables
+            var shiftIndex = function(idx)
+            {
+                if (idx === CPNotFound || idx === -1)
+                    return idx;
+                
+                if ([removeIndexes containsIndex:idx])
+                    return CPNotFound;
+                
+                var shift = 0,
+                    remIdx = [removeIndexes firstIndex];
+
+                while (remIdx !== CPNotFound && remIdx < idx)
+                {
+                    shift++;
+                    remIdx = [removeIndexes indexGreaterThanIndex:remIdx];
+                }
+
+                return idx - shift;
+            };
+
+            _editingColumn = shiftIndex(_editingColumn);
+            
+            _draggedColumnIndex = shiftIndex(_draggedColumnIndex);
+            if (_draggedColumnIndex === CPNotFound)
+                _draggedColumnIndex = -1;
+                
+            _clickedColumn = shiftIndex(_clickedColumn);
+            if (_clickedColumn === CPNotFound)
+                _clickedColumn = -1;
+        }
 
         [_differedColumnDataToRemove removeAllObjects];
         _needsDifferedTableColumnRemove = NO;

--- a/Tests/Manual/TableTest/OldTest/AppController.j
+++ b/Tests/Manual/TableTest/OldTest/AppController.j
@@ -164,10 +164,20 @@ tableTestDragType = @"CPTableViewTestDragType";
 
 - (void)removeColumn:(id)sender
 {
-   // if ([[tableView tableColumns] containsObject:randomColumn])
-        [tableView removeTableColumn:randomColumn];
-    //else
-      //  [tableView addTableColumn:randomColumn];
+    var columns = [tableView tableColumns];
+    
+    // Check if we still have columns left to remove
+    if (columns && [columns count] > 0)
+    {
+        var columnToRemove = [columns lastObject];
+        [tableView removeTableColumn:columnToRemove];
+        
+        CPLog.debug(@"Removed column with identifier: " + [columnToRemove identifier]);
+    }
+    else
+    {
+        CPLog.debug(@"No more columns to remove!");
+    }
 }
 
 - (void)addColumn:(id)sender


### PR DESCRIPTION
Updates the deferred column removal logic to dynamically shift all cached column indices (like _exposedColumns and _selectedColumnIndexes) down by the number of removed columns preceding them. Resets tracked interaction indices (_clickedColumn, _editingColumn) if the target column was removed.

fixes #638