### PR TITLE
CPLayoutManager: Fix O(N^2) layout bottleneck when loading large text documents

### DIFF
--- a/AppKit/CPTextView/CPLayoutManager.j
+++ b/AppKit/CPTextView/CPLayoutManager.j
@@ -305,13 +305,17 @@ _oncontextmenuhandler = function () { return false; };
 
 - (BOOL)_rescuingInvalidFragmentsWasPossibleForGlyphRange:(CPRange)aRange
 {
-    var l = _lineFragments.length,
-        location = aRange.location,
-        found = NO,
-        targetLine = 0;
+    // 1. EARLY EXIT: If there are no fragments to rescue (e.g. setting new text), do nothing.
+    if (!_lineFragmentsForRescue || _lineFragmentsForRescue.length === 0)
+        return NO;
 
-   // try to find the first linefragment of the desired range
-    for (; targetLine < l; targetLine++)
+    var l = _lineFragments.length,
+            location = aRange.location,
+            found = NO,
+            targetLine = l - 1; // Start from the END of the array
+
+    // 2. REVERSE SEARCH: The fragment we want is almost always at the end.
+    for (; targetLine >= 0; targetLine--)
     {
         if (CPLocationInRange(location, _lineFragments[targetLine]._range))
         {
@@ -333,9 +337,6 @@ _oncontextmenuhandler = function () { return false; };
         oldLength = CPMaxRange([_lineFragmentsForRescue lastObject]._range),
         newLength = [[_textStorage string].length],
         removalSkip = 1;
-
-  //  if (ABS(newLength - oldLength) > 1)
-  //      return NO;
 
     if (![oldLineFragment isVisuallyIdenticalToFragment:newLineFragment])
     {


### PR DESCRIPTION
When laying out text, `CPSimpleTypesetter` calls `_flushRange` for every 
line, which in turn calls `_rescuingInvalidFragmentsWasPossibleForGlyphRange:` 
to see if existing DOM elements can be recycled.

Previously, this function used a forward linear search starting at index 0 
to find the matching line fragment. Because `_flushRange` appends new lines 
to the end of the `_lineFragments` array, this resulted in an O(N^2) operation. 
For documents with thousands of lines, this caused millions of unnecessary 
loop iterations, locking up the main thread for several seconds.

This commit changes the search to iterate backwards from the end of the array. 
Since the target fragment is almost always the most recently added item, the 
search now completes in O(1) time. 

Additionally added an early exit guard to skip the logic entirely if there 
are no fragments to rescue.