### PR TITLE
fixed: ensure custom fonts are respected in all states, styles, and CIBs

### DIFF
--- a/AppKit/CPTextField.j
+++ b/AppKit/CPTextField.j
@@ -2004,6 +2004,41 @@ CPTextFieldStatePlaceholder = CPThemeState("placeholder");
         [self _setCSSStyleForInputElement];
 }
 
+#pragma mark Overrides
+
+/*!
+    Sets the font of the receiver.
+
+    @param aFont - A CPFont object.
+*/
+- (void)setFont:(CPFont)aFont
+{
+    if ([self currentValueForThemeAttribute:@"font"] === aFont)
+        return;
+
+    // Apply the font to the default/normal state
+    [self setValue:aFont forThemeAttribute:@"font"];
+    
+    // Apply to standard editing and border states
+    [self setValue:aFont forThemeAttribute:@"font" inState:CPThemeStateEditing];
+    [self setValue:aFont forThemeAttribute:@"font" inState:CPThemeStateBezeled];
+    [self setValue:aFont forThemeAttribute:@"font" inState:CPThemeStateBordered];
+    [self setValue:aFont forThemeAttribute:@"font" inState:CPTextFieldStateRounded];
+    [self setValue:aFont forThemeAttribute:@"font" inState:[CPTextFieldStateRounded, CPThemeStateEditing]];
+    
+    // Apply across all standard control size states
+    [self setValue:aFont forThemeAttribute:@"font" inState:CPThemeStateControlSizeRegular];
+    [self setValue:aFont forThemeAttribute:@"font" inState:CPThemeStateControlSizeSmall];
+    [self setValue:aFont forThemeAttribute:@"font" inState:CPThemeStateControlSizeMini];
+
+    // Apply to table data view states (ensuring Interface Builder-style lists respect the font)
+    [self setValue:aFont forThemeAttribute:@"font" inState:CPThemeStateTableDataView];
+    [self setValue:aFont forThemeAttribute:@"font" inState:[CPThemeStateTableDataView, CPThemeStateSelectedDataView]];
+    [self setValue:aFont forThemeAttribute:@"font" inState:[CPThemeStateTableDataView, CPThemeStateSelectedDataView, CPThemeStateFirstResponder, CPThemeStateKeyWindow]];
+
+    [self layoutSubviews];
+}
+
 - (void)takeValueFromKeyPath:(CPString)aKeyPath ofObjects:(CPArray)objects
 {
     var count = objects.length,


### PR DESCRIPTION
Override -setFont: in CPTextField to apply custom fonts across all theme states (such as editing, bezeled, bordered, rounded, and table data view states). 

This resolves two issues:
1. Programmatic custom font configurations are now maintained during transitions to and from non-bezeled states.
2. Custom font settings configured in Interface Builder (CIB/NIB) are now consistently applied and respected at runtime.

Fixes #3195