### PR TITLE
new: Clear the cached visible rect so it gets recalculated after size…

### DIFF
--- a/AppKit/CPTextView/CPTextView.j
+++ b/AppKit/CPTextView/CPTextView.j
@@ -2069,8 +2069,16 @@ Sets the selection to a range of characters in response to user action.
     [self setFrameSize:[self frameSize]];
 }
 
+- (void)setBoundsSize:(CGSize)aSize
+{
+    _exposedRect = nil; // Clear the cached visible rect when bounds change
+    [super setBoundsSize:aSize];
+}
+
 - (void)setFrameSize:(CGSize)aSize
 {
+    _exposedRect = nil; // Clear the cached visible rect so it gets recalculated at the new size
+
     var desiredSize = CGSizeCreateCopy(aSize);
 
     if (_isHorizontallyResizable || _isVerticallyResizable)


### PR DESCRIPTION
This PR fixes a rendering bug where multi-line text in a CPTextView is visually truncated after the view is dynamically resized. Although the entire text remains present in the backing store (and can be copied), only the first line is painted visually because the layout rendering boundary is not updated to match the new size.

The visible boundary of a CPTextView is tracked via a cached rect named _exposedRect. When a text view is not housed inside a CPClipView (such as in custom layout cells or message bubble views), _exposedRect falls back to the view's initial bounds on first access.

When the text view is subsequently resized (e.g., via -sizeToFit and -setFrameSize:), this cached rect is not invalidated. During layout rendering, _CPLineFragment compares line coordinates against the stale _exposedRect. Consequently, any lines wrapping below the initial height are flagged as out of bounds, preventing their corresponding DOM elements from being generated and rendered.

Added logic to invalidate _exposedRect (setting it to nil) within -setFrameSize: and -setBoundsSize: so that the visible boundary is recalculated accurately during the next layout and rendering pass.