### PR TITLE
new: Add XIB serialization support for CPSplitViewController and CPStackView

### DIFF
--- a/Tools/nib2cib/NSSplitViewController.j
+++ b/Tools/nib2cib/NSSplitViewController.j
@@ -1,0 +1,104 @@
+/*
+ * NSSplitViewController.j
+ * nib2cib
+ *
+ * Created by Daniel Boehringer.
+ * Copyright 2025 The Cappuccino Project.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+@import <AppKit/CPSplitViewController.j>
+
+
+@implementation CPSplitViewController (NSCoding)
+
+- (id)NS_initWithCoder:(CPCoder)aCoder
+{
+    if (self = [super NS_initWithCoder:aCoder])
+    {
+        _splitViewItems = [CPMutableArray array];
+        _minimumThicknessForInlineSidebars = 20.0;
+
+        if ([aCoder containsValueForKey:@"NSSplitView"])
+            _splitView = [aCoder decodeObjectForKey:@"NSSplitView"];
+        else if ([[self view] isKindOfClass:[CPSplitView class]])
+            _splitView = [self view];
+
+        if (_splitView)
+            [_splitView setDelegate:self];
+
+        if ([aCoder containsValueForKey:@"NSSplitViewItems"])
+        {
+            var items = [aCoder decodeObjectForKey:@"NSSplitViewItems"];
+            for (var i = 0; i < [items count]; i++)
+            {
+                [self addSplitViewItem:items[i]];
+            }
+        }
+    }
+
+    return self;
+}
+
+@end
+
+@implementation NSSplitViewController : CPSplitViewController
+{
+}
+
+- (id)initWithCoder:(CPCoder)aCoder
+{
+    return [self NS_initWithCoder:aCoder];
+}
+
+- (Class)classForKeyedArchiver
+{
+    return [CPSplitViewController class];
+}
+
+@end
+
+
+@implementation CPSplitViewItem (NSCoding)
+
+- (id)NS_initWithCoder:(CPCoder)aCoder
+{
+    if (self = [super init])
+    {
+        _viewController = [aCoder decodeObjectForKey:@"NSViewController"];
+        _isCollapsed = [aCoder decodeBoolForKey:@"NSCollapsed"];
+    }
+
+    return self;
+}
+
+@end
+
+@implementation NSSplitViewItem : CPSplitViewItem
+{
+}
+
+- (id)initWithCoder:(CPCoder)aCoder
+{
+    return [self NS_initWithCoder:aCoder];
+}
+
+- (Class)classForKeyedArchiver
+{
+    return [CPSplitViewItem class];
+}
+
+@end

--- a/Tools/nib2cib/NSSplitViewController.j
+++ b/Tools/nib2cib/NSSplitViewController.j
@@ -3,7 +3,7 @@
  * nib2cib
  *
  * Created by Daniel Boehringer.
- * Copyright 2025 The Cappuccino Project.
+ * Copyright 2026 The Cappuccino Project.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/Tools/nib2cib/NSStackView.j
+++ b/Tools/nib2cib/NSStackView.j
@@ -3,7 +3,7 @@
  * nib2cib
  *
  * Created by Daniel Boehringer.
- * Copyright 2025 The Cappuccino Project.
+ * Copyright 2026 The Cappuccino Project.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/Tools/nib2cib/NSStackView.j
+++ b/Tools/nib2cib/NSStackView.j
@@ -1,0 +1,86 @@
+/*
+ * NSStackView.j
+ * nib2cib
+ *
+ * Created by Daniel Boehringer.
+ * Copyright 2025 The Cappuccino Project.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+@import <AppKit/CPStackView.j>
+
+
+@implementation CPStackView (NSCoding)
+
+- (id)NS_initWithCoder:(CPCoder)aCoder
+{
+    if (self = [super NS_initWithCoder:aCoder])
+    {
+        _orientation = [aCoder containsValueForKey:@"NSOrientation"] ? [aCoder decodeIntForKey:@"NSOrientation"] : CPUserInterfaceLayoutOrientationHorizontal;
+        _alignment = [aCoder containsValueForKey:@"NSAlignment"] ? [aCoder decodeIntForKey:@"NSAlignment"] : CPLayoutAttributeCenterY;
+        _spacing = [aCoder containsValueForKey:@"NSSpacing"] ? [aCoder decodeFloatForKey:@"NSSpacing"] : 8.0;
+
+        var top = [aCoder containsValueForKey:@"NSEdgeInsetsTop"] ? [aCoder decodeFloatForKey:@"NSEdgeInsetsTop"] : 0.0,
+            left = [aCoder containsValueForKey:@"NSEdgeInsetsLeft"] ? [aCoder decodeFloatForKey:@"NSEdgeInsetsLeft"] : 0.0,
+            bottom = [aCoder containsValueForKey:@"NSEdgeInsetsBottom"] ? [aCoder decodeFloatForKey:@"NSEdgeInsetsBottom"] : 0.0,
+            right = [aCoder containsValueForKey:@"NSEdgeInsetsRight"] ? [aCoder decodeFloatForKey:@"NSEdgeInsetsRight"] : 0.0;
+        _edgeInsets = CPEdgeInsetsMake(top, left, bottom, right);
+
+        _detachesHiddenViews = [aCoder containsValueForKey:@"NSDetachesHiddenViews"] ? [aCoder decodeBoolForKey:@"NSDetachesHiddenViews"] : YES;
+
+        _viewsLeading = [[CPMutableArray alloc] init];
+        _viewsCenter = [[CPMutableArray alloc] init];
+        _viewsTrailing = [[CPMutableArray alloc] init];
+        _arrangedSubviews = [[CPMutableArray alloc] init];
+
+        _customSpacings = [[CPMapTable alloc] init];
+        _visibilityPriorities = [[CPMapTable alloc] init];
+
+        var arrangedSubviews = nil;
+        if ([aCoder containsValueForKey:@"NSArrangedSubviews"])
+            arrangedSubviews = [aCoder decodeObjectForKey:@"NSArrangedSubviews"];
+        else if ([aCoder containsValueForKey:@"NSViews"])
+            arrangedSubviews = [aCoder decodeObjectForKey:@"NSViews"];
+
+        if (arrangedSubviews)
+        {
+            for (var i = 0; i < [arrangedSubviews count]; i++)
+            {
+                [self addArrangedSubview:arrangedSubviews[i]];
+            }
+        }
+    }
+
+    return self;
+}
+
+@end
+
+@implementation NSStackView : CPStackView
+{
+}
+
+- (id)initWithCoder:(CPCoder)aCoder
+{
+    return [self NS_initWithCoder:aCoder];
+}
+
+- (Class)classForKeyedArchiver
+{
+    return [CPStackView class];
+}
+
+@end


### PR DESCRIPTION
Implement NSCoding support for CPSplitViewController, 
CPSplitViewItem, and CPStackView. This resolves runtime deserialization 
failures when unarchiving XIB files that utilize these components.

- Create `NSSplitViewController.j` to decode standard `NSSplitViewController` 
  and `NSSplitViewItem` keys, mapping them back to their native CP equivalents.
- Create `NSStackView.j` to decode standard `NSStackView` attributes (such 
  as orientation, alignment, spacing, edge insets, and arranged subviews).
- Separate the decoding logic and the NS-to-CP class mapping from the core 
  framework implementation files, keeping them clean and self-contained.

This aligns with the framework-integrated serialization model of the 
updated nib2cib toolchain.

fixes #3231