### PR TITLE
new: heightTracksTextView support in CPTextContainer + rtf fixes

### DIFF
--- a/AppKit/CPTextView/CPTextContainer.j
+++ b/AppKit/CPTextView/CPTextContainer.j
@@ -148,27 +148,58 @@ CPLineMovesUp = 4;
 
 - (void)setWidthTracksTextView:(BOOL)flag
 {
-    _widthTracksTextView = flag;
-    [_textView setPostsFrameChangedNotifications:flag];
+    if (_widthTracksTextView === flag)
+        return;
 
-    if (flag && _textView)
-    {
-        [[CPNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(textViewFrameChanged:)
-                                                     name:CPViewFrameDidChangeNotification
-                                                   object:_textView];
-    }
-    else
+    _widthTracksTextView = flag;
+    [self _updateFrameObserver];
+}
+
+// Controls whether the receiver adjusts the height of its bounding rectangle when its text view is resized.
+- (BOOL)heightTracksTextView
+{
+    return _heightTracksTextView;
+}
+
+- (void)setHeightTracksTextView:(BOOL)flag
+{
+    if (_heightTracksTextView === flag)
+        return;
+
+    _heightTracksTextView = flag;
+    [self _updateFrameObserver];
+}
+
+- (void)_updateFrameObserver
+{
+    if (_textView)
     {
         [[CPNotificationCenter defaultCenter] removeObserver:self
                                                         name:CPViewFrameDidChangeNotification
                                                       object:_textView];
+
+        var flag = _widthTracksTextView || _heightTracksTextView;
+        [_textView setPostsFrameChangedNotifications:flag];
+
+        if (flag)
+        {
+            [[CPNotificationCenter defaultCenter] addObserver:self
+                                                     selector:@selector(textViewFrameChanged:)
+                                                         name:CPViewFrameDidChangeNotification
+                                                       object:_textView];
+        }
     }
 }
 
 - (void)textViewFrameChanged:(CPNotification)aNotification
 {
-    var newSize = CGSizeMake([_textView frame].size.width, _size.height);
+    var newSize = CGSizeMake(_size.width, _size.height);
+
+    if (_widthTracksTextView)
+        newSize.width = [_textView frame].size.width;
+
+    if (_heightTracksTextView)
+        newSize.height = [_textView frame].size.height;
 
     [self setContainerSize:newSize];
 }
@@ -177,7 +208,9 @@ CPLineMovesUp = 4;
 {
     if (_textView)
     {
-        [self setWidthTracksTextView:NO];   // We only support width
+        [[CPNotificationCenter defaultCenter] removeObserver:self
+                                                        name:CPViewFrameDidChangeNotification
+                                                      object:_textView];
         [_textView setTextContainer:nil];
     }
 
@@ -185,7 +218,7 @@ CPLineMovesUp = 4;
 
     if (_textView)
     {
-        [self setWidthTracksTextView:_widthTracksTextView];   // We only support width
+        [self _updateFrameObserver];
         [_textView setTextContainer:self];
     }
 

--- a/AppKit/CPTextView/_CPRTFParser.j
+++ b/AppKit/CPTextView/_CPRTFParser.j
@@ -979,7 +979,11 @@ var kRgsymRtf = {
                 else
                 {
                     _freename += tmp;
-                   [self _appendPlainString:tmp];
+                    // Only append literal spaces to the document if we are in the active body state
+                    if (_curState == 0)
+                    {
+                        [self _appendPlainString:tmp];
+                    }
                 }
 
                 break;
@@ -1025,7 +1029,8 @@ var kRgsymRtf = {
 
                 if (_hexreturn)
                 {
-                    if (ch.length > 0)
+                    // Only append decoded characters if we are in the active body state
+                    if (ch.length > 0 && _curState === 0)
                     {
                         var byteVal = parseInt(ch, 16);
                         var unicodeVal = byteVal;

--- a/AppKit/CPTextView/_CPRTFParser.j
+++ b/AppKit/CPTextView/_CPRTFParser.j
@@ -797,10 +797,15 @@ var kRgsymRtf = {
                  [self _flushCurrentRun];
                  var fontIndex = parseInt(param) - 1;
 
-                 if (_currentRun && fontIndex >= 0)
-                     _currentRun.fgColour = _colorArray[fontIndex];
+                 if (_currentRun)
+                 {
+                     if (fontIndex >= 0 && fontIndex < _colorArray.length)
+                         _currentRun.fgColour = _colorArray[fontIndex];
+                     else
+                         _currentRun.fgColour = nil;
+                 }
 
-                break;
+                 break;
 
             case "cb":  // change background color
             case "highlight":

--- a/AppKit/CPTextView/_CPRTFParser.j
+++ b/AppKit/CPTextView/_CPRTFParser.j
@@ -334,6 +334,7 @@ var kRgsymRtf = {
     CPArray             _fontArray;
     CPString            _freename;
     BOOL                _parsingFontTable;
+    BOOL                _keywordIsControlWord;
 
     // Table parsing state
     BOOL                _inTableActive;
@@ -353,6 +354,7 @@ var kRgsymRtf = {
         _states             = [];
         _currentParseIndex  = 0;
         _hexreturn          = NO;
+        _keywordIsControlWord = NO;
         _result             = [CPAttributedString new];
         _colorArray         = [];
         _fontArray          = ['Arial'];   // FIXME: should be name of system font
@@ -889,7 +891,12 @@ var kRgsymRtf = {
     ch = rtf.charAt(_currentParseIndex);
 
     if (!/[a-zA-Z]/.test(ch))
+    {
+        _keywordIsControlWord = NO;
         return [self _translateKeyword:ch parameter:nil fParameter:fParam];
+    }
+
+    _keywordIsControlWord = YES;
 
     while (new RegExp("[a-zA-Z]").test(ch))
     {
@@ -978,6 +985,7 @@ var kRgsymRtf = {
                 break;
 
             case "{":
+                lastchar = 0;
                 if (_waitingForNextRow)
                     [self _flushTableIfAny];
 
@@ -986,6 +994,7 @@ var kRgsymRtf = {
                 break;
 
             case "}":
+                lastchar = 0;
                 if (_waitingForNextRow)
                     [self _flushTableIfAny];
 
@@ -1009,7 +1018,7 @@ var kRgsymRtf = {
                 _freename = '';
                 ch = [self _parseKeyword:rtf length:len];
 
-                if (!_hexreturn && ch.length == 0)
+                if (!_hexreturn && _keywordIsControlWord)
                     lastchar = 1;
                 else
                     lastchar = 0;
@@ -1040,6 +1049,7 @@ var kRgsymRtf = {
             case 0x0a:
             case '\n':
             case '\r':
+                lastchar = 0;
                 break;
 
             default:

--- a/AppKit/CPTextView/_CPRTFProducer.j
+++ b/AppKit/CPTextView/_CPRTFProducer.j
@@ -542,6 +542,17 @@ function _points2twips(a) { return (a) * 20.0; }
                         cellText = "";
                     }
                     
+                    // Safely extract text representation from CPAttributedString / CPTextStorage if present
+                    if (cellText && typeof cellText === "object") {
+                        if (typeof cellText.string === "function") {
+                            cellText = [cellText string];
+                        } else if (cellText._string !== undefined) {
+                            cellText = cellText._string;
+                        } else if (cellText.string !== undefined) {
+                            cellText = cellText.string;
+                        }
+                    }
+
                     cellText = String(cellText);
                     cellText = cellText.replace(/\\/g, '\\\\');
                     cellText = cellText.replace(/{/g, '\\{');
@@ -715,7 +726,7 @@ function _points2twips(a) { return (a) * 20.0; }
         var nobraces;
 
         if ([headerString length])
-            nobraces = [CPString stringWithFormat:@"%@ %@}", headerString, substring];
+            nobraces = [CPString stringWithFormat:@"%@ %@", headerString, substring];
         else
             nobraces = substring;
 


### PR DESCRIPTION
Introduced a unified _updateFrameObserver helper method to manage registration for CPViewFrameDidChangeNotification. This ensures that the text container listens to the text view's frame changes if either widthTracksTextView or heightTracksTextView is enabled, and correctly removes the observer only when both are disabled.

Updated textViewFrameChanged: to dynamically adjust either width, height, or both depending on the active tracking properties.

Adjusted setTextView: to safely unregister from the old text view and register with the new one without overriding the user-configured tracking properties.