### PR TITLE
Fixed: baseline alignment in _CPLineFragment to prevent overlapping text descenders

### DIFF
--- a/AppKit/CPTextView/CPLayoutManager.j
+++ b/AppKit/CPTextView/CPLayoutManager.j
@@ -965,16 +965,11 @@ _oncontextmenuhandler = function () { return false; };
                         if (frame)
                         {
                             var correctedRect = CGRectCreateCopy(frame);
-                            correctedRect.size.height -= frame._descent;
-                            correctedRect.origin.y -= frame._descent;
 
                             if (!rect)
                                 rect = CGRectCreateCopy(correctedRect);
                             else
                                 rect = CGRectUnion(rect, correctedRect);
-
-                            if (_isNewlineCharacter([[_textStorage string] characterAtIndex:MAX(0, CPMaxRange(selectedCharRange) - 1)]))
-                                 rect.size.width = containerSize.width - rect.origin.x;
                         }
                     }
                 }
@@ -1348,7 +1343,10 @@ var _objectsInRange = function(aList, aRange)
     {
         _glyphsFrames[i] = CGRectMake(origin.x, origin.y, someAdvancements[i].width, height);
         _glyphsFrames[i]._descent = someAdvancements[i].descent;
-        _glyphsOffsets[i] = height - someAdvancements[i].height;
+        
+        // Align the run's baseline with the common line baseline (_location.y)
+        _glyphsOffsets[i] = _location.y - someAdvancements[i].height;
+        
         origin.x += someAdvancements[i].width;
     }
 }

--- a/AppKit/CPTextView/CPTextView.j
+++ b/AppKit/CPTextView/CPTextView.j
@@ -2333,30 +2333,28 @@ Sets the selection to a range of characters in response to user action.
     if (_selectionRange.location == numberOfGlyphs && _isNewlineCharacter([[_textStorage string] characterAtIndex:_selectionRange.location - 1]))
         return CGRectCreateCopy([_layoutManager extraLineFragmentRect]);
 
-    var caretRect = [_layoutManager boundingRectForGlyphRange:CPMakeRange(_selectionRange.location, 1) inTextContainer:_textContainer];
+        var caretRect = [_layoutManager boundingRectForGlyphRange:CPMakeRange(_selectionRange.location, 1) inTextContainer:_textContainer];
 
-    var loc = (_selectionRange.location == numberOfGlyphs) ? _selectionRange.location - 1 : _selectionRange.location,
-        caretOffset = [_layoutManager _characterOffsetAtLocation:loc],
-        oldYPosition = CGRectGetMaxY(caretRect),
-        caretDescend = [_layoutManager _descentAtLocation:loc];
+        var loc = (_selectionRange.location == numberOfGlyphs) ? _selectionRange.location - 1 : _selectionRange.location,
+            caretOffset = [_layoutManager _characterOffsetAtLocation:loc],
+            font = [_textStorage attribute:CPFontAttributeName atIndex:loc effectiveRange:nil] || [self font];
 
-    if (caretOffset > 0)
-    {
-        caretRect.origin.y += caretOffset;
-        caretRect.size.height = oldYPosition - caretRect.origin.y;
-    }
+        if (caretOffset > 0)
+        {
+            caretRect.origin.y += caretOffset;
+        }
 
-    if (caretDescend < 0)
-        caretRect.size.height -= caretDescend;
+        // Set the caret height to match the size of the active font
+        caretRect.size.height = [font size];
 
-    if (_selectionRange.location == numberOfGlyphs)
-        caretRect.origin.x += caretRect.size.width;
+        if (_selectionRange.location == numberOfGlyphs)
+            caretRect.origin.x += caretRect.size.width;
 
     caretRect.origin.x += _textContainerOrigin.x;
     caretRect.origin.y += _textContainerOrigin.y;
 
     caretRect.size.width = MAX(1.0, caretRect.size.width);
-    caretRect.size.height = MAX(1.0, caretRect.size.height);
+    caretRect.size.height = MAX(1.0, caretRect.size.height) + 2;
 
     return caretRect;
 }

--- a/AppKit/CPTextView/CPTextView.j
+++ b/AppKit/CPTextView/CPTextView.j
@@ -2333,22 +2333,22 @@ Sets the selection to a range of characters in response to user action.
     if (_selectionRange.location == numberOfGlyphs && _isNewlineCharacter([[_textStorage string] characterAtIndex:_selectionRange.location - 1]))
         return CGRectCreateCopy([_layoutManager extraLineFragmentRect]);
 
-        var caretRect = [_layoutManager boundingRectForGlyphRange:CPMakeRange(_selectionRange.location, 1) inTextContainer:_textContainer];
+    var caretRect = [_layoutManager boundingRectForGlyphRange:CPMakeRange(_selectionRange.location, 1) inTextContainer:_textContainer];
 
-        var loc = (_selectionRange.location == numberOfGlyphs) ? _selectionRange.location - 1 : _selectionRange.location,
-            caretOffset = [_layoutManager _characterOffsetAtLocation:loc],
-            font = [_textStorage attribute:CPFontAttributeName atIndex:loc effectiveRange:nil] || [self font];
+    var loc = (_selectionRange.location == numberOfGlyphs) ? _selectionRange.location - 1 : _selectionRange.location,
+        caretOffset = [_layoutManager _characterOffsetAtLocation:loc],
+        font = [_textStorage attribute:CPFontAttributeName atIndex:loc effectiveRange:nil] || [self font];
 
-        if (caretOffset > 0)
-        {
-            caretRect.origin.y += caretOffset;
-        }
+    if (caretOffset > 0)
+    {
+        caretRect.origin.y += caretOffset;
+    }
 
-        // Set the caret height to match the size of the active font
-        caretRect.size.height = [font size];
+    // Set the caret height to match the size of the active font
+    caretRect.size.height = [font size];
 
-        if (_selectionRange.location == numberOfGlyphs)
-            caretRect.origin.x += caretRect.size.width;
+    if (_selectionRange.location == numberOfGlyphs)
+        caretRect.origin.x += caretRect.size.width;
 
     caretRect.origin.x += _textContainerOrigin.x;
     caretRect.origin.y += _textContainerOrigin.y;


### PR DESCRIPTION
### Description
This pull request addresses an issue in the text layout system where descenders from larger text runs (such as "p", "g", or "y") overlap with characters in the line directly below.

#### Cause
In `CPLayoutManager.j`, the `_CPLineFragment` method `setAdvancements:` calculates glyph vertical offsets relative to the line's total height (`_usedRect.size.height`) rather than the line's calculated baseline (`_location.y`). Because of this, text runs are positioned too far down within the line fragment, causing descenders to bleed past the fragment's bottom boundary.

#### Solution
The vertical offset calculation in `setAdvancements:` has been updated to use `_location.y` instead of `height`:

```javascript
_glyphsOffsets[i] = _location.y - someAdvancements[i].height;
```

This change aligns all text runs on a line to the common baseline (`_lineBase`). It ensures that the space below the baseline is allocated for descenders within the line fragment, keeping them within their proper boundary and preventing overlapping.

#### Testing
* Tested with mixed font sizes on adjacent lines.
* Verified that baseline alignment remains consistent across different font heights and descenders no longer overlap with the line below.