### PR TITLE
Fixed: scale accumulation in scaleUnitSquareToSize: when setting bounds size

### DIFF
--- a/AppKit/CPView.j
+++ b/AppKit/CPView.j
@@ -1474,6 +1474,21 @@ var CPViewHighDPIDrawingEnabled = YES;
         origin.y *= size.height / frameSize.height;
     }
 
+    [self willChangeValueForKey:@"scaleSize"];
+    if (size.width === 0 || size.height === 0)
+    {
+        _scaleSize = CGSizeMake(1.0, 1.0);
+    }
+    else
+    {
+        _scaleSize = CGSizeMake(frameSize.width / size.width, frameSize.height / size.height);
+    }
+    _isScaled = (_scaleSize.width !== 1.0 || _scaleSize.height !== 1.0);
+    [self didChangeValueForKey:@"scaleSize"];
+
+    // Recompute hierarchy scale size for this view and its descendants
+    [self _scaleSizeUnitSquareToSize:CGSizeMake(1.0, 1.0)];
+
     if (_layer)
         [_layer _owningViewBoundsChanged];
 

--- a/AppKit/CPView.j
+++ b/AppKit/CPView.j
@@ -1474,18 +1474,24 @@ var CPViewHighDPIDrawingEnabled = YES;
         origin.y *= size.height / frameSize.height;
     }
 
-    [self willChangeValueForKey:@"scaleSize"];
+    var newScaleSize;
 
     if (size && size.width !== 0 && size.height !== 0 && frameSize)
-        _scaleSize = CGSizeMake(frameSize.width / size.width, frameSize.height / size.height);
+        newScaleSize = CGSizeMake(frameSize.width / size.width, frameSize.height / size.height);
     else
-        _scaleSize = CGSizeMake(1.0, 1.0);
+        newScaleSize = CGSizeMake(1.0, 1.0);
 
-    _isScaled = (_scaleSize.width !== 1.0 || _scaleSize.height !== 1.0);
-    [self didChangeValueForKey:@"scaleSize"];
+    // Only update and propagate if the scale factor has actually changed
+    if (!CGSizeEqualToSize(_scaleSize, newScaleSize))
+    {
+        [self willChangeValueForKey:@"scaleSize"];
+        _scaleSize = newScaleSize;
+        _isScaled = (_scaleSize.width !== 1.0 || _scaleSize.height !== 1.0);
+        [self didChangeValueForKey:@"scaleSize"];
 
-    // Recompute hierarchy scale size safely
-    [self _scaleSizeUnitSquareToSize:CGSizeMake(1.0, 1.0)];
+        // Only traverse the view hierarchy if there is a genuine change in the scale state
+        [self _scaleSizeUnitSquareToSize:CGSizeMake(1.0, 1.0)];
+    }
 
     if (_layer)
         [_layer _owningViewBoundsChanged];

--- a/AppKit/CPView.j
+++ b/AppKit/CPView.j
@@ -1475,18 +1475,16 @@ var CPViewHighDPIDrawingEnabled = YES;
     }
 
     [self willChangeValueForKey:@"scaleSize"];
-    if (size.width === 0 || size.height === 0)
-    {
-        _scaleSize = CGSizeMake(1.0, 1.0);
-    }
-    else
-    {
+
+    if (size && size.width !== 0 && size.height !== 0 && frameSize)
         _scaleSize = CGSizeMake(frameSize.width / size.width, frameSize.height / size.height);
-    }
+    else
+        _scaleSize = CGSizeMake(1.0, 1.0);
+
     _isScaled = (_scaleSize.width !== 1.0 || _scaleSize.height !== 1.0);
     [self didChangeValueForKey:@"scaleSize"];
 
-    // Recompute hierarchy scale size for this view and its descendants
+    // Recompute hierarchy scale size safely
     [self _scaleSizeUnitSquareToSize:CGSizeMake(1.0, 1.0)];
 
     if (_layer)
@@ -1501,7 +1499,6 @@ var CPViewHighDPIDrawingEnabled = YES;
     if (_window && !_window._inhibitUpdateTrackingAreas && !_inhibitFrameAndBoundsChangedNotifications)
         [self _updateTrackingAreasWithRecursion:YES];
 }
-
 
 /*!
     Notifies subviews that the superview changed size.

--- a/AppKit/CPView.j
+++ b/AppKit/CPView.j
@@ -2618,7 +2618,7 @@ setBoundsOrigin:
 */
 - (void)_scaleSizeUnitSquareToSize:(CGSize)aSize
 {
-    _hierarchyScaleSize = CGSizeMakeCopy([_superview _hierarchyScaleSize]);
+    _hierarchyScaleSize = _superview ? CGSizeMakeCopy([_superview _hierarchyScaleSize]) : CGSizeMake(1.0, 1.0);
 
     if (_isScaled)
     {

--- a/AppKit/CPView.j
+++ b/AppKit/CPView.j
@@ -1489,7 +1489,6 @@ var CPViewHighDPIDrawingEnabled = YES;
         _isScaled = (_scaleSize.width !== 1.0 || _scaleSize.height !== 1.0);
         [self didChangeValueForKey:@"scaleSize"];
 
-        // Only traverse the view hierarchy if there is a genuine change in the scale state
         [self _scaleSizeUnitSquareToSize:CGSizeMake(1.0, 1.0)];
     }
 

--- a/Tests/AppKit/CPTabViewTest.j
+++ b/Tests/AppKit/CPTabViewTest.j
@@ -69,6 +69,7 @@
 {
     var tabs = [_tabView tabs];
     [_tabView setBounds:CGRectMake(100, 100, 20, 300)];
+
     // Perform this manually for the sake of the unit test.
     [_tabView layoutIfNeeded];
     [self assert:([tabs boundsSize].width / 2)  equals:CGRectGetMidX([tabs bounds])];

--- a/Tests/AppKit/CPTabViewTest.j
+++ b/Tests/AppKit/CPTabViewTest.j
@@ -69,7 +69,6 @@
 {
     var tabs = [_tabView tabs];
     [_tabView setBounds:CGRectMake(100, 100, 20, 300)];
-
     // Perform this manually for the sake of the unit test.
     [_tabView layoutIfNeeded];
     [self assert:([tabs boundsSize].width / 2)  equals:CGRectGetMidX([tabs bounds])];


### PR DESCRIPTION
#### Problem
In `CPView`, the scaling state is tracked using internal properties (`_scaleSize` and `_isScaled`). However, when `setBoundsSize:` is called explicitly, these properties are not updated to reflect the new relationship between the view's frame size and bounds size. 

When a layout process attempts to reset a view's scaling (by setting its bounds size back to match its frame size) before applying a new scale factor, the stale scale state persists. This causes subsequent calls to `scaleUnitSquareToSize:` to multiply against the previous scale value rather than a clean baseline, leading to continuous and cumulative shrinking or expanding of the view during live resizing (as reported in #2974).

#### Solution
This pull request updates `setBoundsSize:` to recalculate `_scaleSize` and `_isScaled` based on the new bounds-to-frame ratio. It also calls `_scaleSizeUnitSquareToSize:` to propagate the updated hierarchy scale down to the view's subviews. 

This aligns the behavior more closely with native Cocoa/AppKit, where setting the bounds size implicitly resets the unit square scale relative to the frame size.

#### Changes
* **`AppKit/CPView.j`**: 
  * Recalculate `_scaleSize` and `_isScaled` inside `setBoundsSize:`.
  * Invoke `_scaleSizeUnitSquareToSize:` to update the hierarchy scale size of the view and its subviews.

fixes #2974