### PR TITLE
Remove duplicate CPIndexSet -isEqual

### DIFF
--- a/Foundation/CPIndexSet.j
+++ b/Foundation/CPIndexSet.j
@@ -176,13 +176,6 @@
     return YES;
 }
 
-- (BOOL)isEqual:(id)anObject
-{
-    return  self === anObject ||
-            [anObject isKindOfClass:[self class]] &&
-            [self isEqualToIndexSet:anObject];
-}
-
 /*!
     Returns \c YES if the index set contains the specified index.
     @param anIndex the index to check for in the set


### PR DESCRIPTION
Originally added in error, not realizing another author had just applied and committed the same fix.

Javascript-based tooling unable to catch this.