### PR TITLE
fixed: CPRuleEditor: crash when dragging nested compound rows

### DIFF
--- a/AppKit/CPRuleEditor/CPRuleEditor.j
+++ b/AppKit/CPRuleEditor/CPRuleEditor.j
@@ -2342,33 +2342,41 @@ TODO: implement
 
 - (BOOL)performDragOperation:(id /*< CPDraggingInfo >*/)info
 {
-    var aboveInsertIndexCount = 0,
-        object,
-        removeIndex;
+    var object;
 
     var rowObjects = [_rowCache valueForKey:@"rowObject"],
         index = [_draggingRows lastIndex];
 
-    var parentRowIndex = [self parentRowForRow:index], // first index of draggingrows
+    var firstDraggingIndex = [_draggingRows firstIndex],
+        parentRowIndex = [self parentRowForRow:firstDraggingIndex],
         parentRowObject = (parentRowIndex === -1) ? _boundArrayOwner : [[self _rowCacheForIndex:parentRowIndex] rowObject],
         insertIndex = _subviewIndexOfDropLine;
 
     while (index !== CPNotFound)
     {
-        if (index >= insertIndex)
+        // Identify if this row's parent is also inside the dragging set.
+        // If it is, we skip it because it will move automatically with its parent.
+        var parentOfCurrent = [self parentRowForRow:index];
+        if (parentOfCurrent !== -1 && [_draggingRows containsIndex:parentOfCurrent])
         {
-            removeIndex = index + aboveInsertIndexCount;
-            aboveInsertIndexCount += 1;
-        }
-        else
-        {
-            removeIndex = index;
-            insertIndex -= 1;
+            index = [_draggingRows indexLessThanIndex:index];
+            continue;
         }
 
-        object = [rowObjects objectAtIndex:removeIndex];
-        [self removeRowAtIndex:removeIndex];
-        [[self _subrowObjectsOfObject:parentRowObject] insertObject:object atIndex:insertIndex - parentRowIndex - 1];
+        object = [rowObjects objectAtIndex:index];
+        
+        // Find the current live index of the object inside the editor
+        var cache = [self _searchCacheForRowObject:object];
+        var liveIndex = [_rowCache indexOfObjectIdenticalTo:cache];
+
+        if (liveIndex !== CPNotFound)
+        {
+            if (liveIndex < insertIndex)
+                insertIndex -= 1;
+
+            [self removeRowAtIndex:liveIndex];
+            [[self _subrowObjectsOfObject:parentRowObject] insertObject:object atIndex:insertIndex - parentRowIndex - 1];
+        }
 
         index = [_draggingRows indexLessThanIndex:index];
     }
@@ -2377,6 +2385,7 @@ TODO: implement
     _draggingRows = nil;
     return YES;
 }
+
 
 - (CPIndexSet)_draggingTypes
 {


### PR DESCRIPTION
Fixes an issue where dragging a compound (group heading) row upwards
results in an "Uncaught CPInvalidArgumentException: Range out of bounds"
exception.

Root Cause:
When dragging a compound row, both the heading row and its nested child
rows are included in the `_draggingRows` set. The previous implementation
attempted to process and re-insert every single dragging row (including
children) individually. When dragging upwards, this caused the child
row's target insertion index calculation (`insertIndex - parentRowIndex - 1`)
to yield a negative number, triggering an index-out-of-bounds error.

Changes:
- Modified `performDragOperation:` to skip processing nested child rows 
  if their parent row is also present in the dragging set. The children 
  now naturally relocate with their parent compound row.
- Updated the target parent calculation to consistently derive from the 
  topmost (first) dragging row.
- Replaced the manual index shifting logic (`aboveInsertIndexCount`) with 
  a dynamic lookup of each row's live index in `_rowCache` to ensure 
  safe and accurate array mutations.