### PR TITLE
Refactor CABackingStore: Eliminate preprocessor directives and legacy…

### DIFF
--- a/AppKit/CoreAnimation/CABackingStore.j
+++ b/AppKit/CoreAnimation/CABackingStore.j
@@ -21,54 +21,38 @@
  */
 
 @import "CGGeometry.j"
-@import "CPCompatibility.j"
+// REMOVED: @import "CPCompatibility.j" - Obsolete legacy compatibility layer removed.
 
-#define PIXEL(pixels) pixels + "px";
-
+// REMOVED: #define PIXEL(pixels) macro - Eliminated in favour of native inline string concatenation.
 
 function CABackingStoreGetContext(aBackingStore)
 {
-    return aBackingStore.context;
-};
-
-if (CPFeatureIsCompatible(CPHTMLCanvasFeature))
-{
-
-CABackingStoreCreate = function()
-{
-    var DOMElement = document.createElement("canvas");
-
-    DOMElement.style.position = "absolute";
-
-    // FIXME: Consolidate drawImage to support this.
-    return { context:DOMElement.getContext("2d"), buffer:DOMElement, _image:DOMElement };
-};
-
-CABackingStoreSetSize = function(aBackingStore, aSize)
-{
-    var buffer = aBackingStore.buffer;
-
-    buffer.width = aSize.width;
-    buffer.height = aSize.height;
-    buffer.style.width = PIXEL(aSize.width);
-    buffer.style.height = PIXEL(aSize.height);
-};
-
+	return aBackingStore.context;
 }
-else
+
+// REMOVED: if (CPFeatureIsCompatible(CPHTMLCanvasFeature)) - HTMLCanvasElement is natively supported across modern targets. Legacy fallback block completely removed.
+function CABackingStoreCreate()
 {
+	// MODERNIZED: Replaced legacy 'var' with block-scoped 'const' for immutable DOM reference.
+	const DOMElement = document.createElement("canvas");
 
-CABackingStoreCreate = function()
-{
-    var context = CGBitmapGraphicsContextCreate();
+	DOMElement.style.position = "absolute";
 
-    context.buffer = "";
-
-    return { context:context };
-};
-
-CABackingStoreSetSize = function(aBackingStore, aSize)
-{
-};
-
+	// FIXME: Consolidate drawImage to support this.
+	return { context:DOMElement.getContext("2d"), buffer:DOMElement, _image:DOMElement };
 }
+
+function CABackingStoreSetSize(aBackingStore, aSize)
+{
+	// MODERNIZED: Replaced legacy 'var' with block-scoped 'const'.
+	const buffer = aBackingStore.buffer;
+
+	buffer.width = aSize.width;
+	buffer.height = aSize.height;
+
+	// MODERNIZED: Replaced macro expansion with native inline evaluation.
+	buffer.style.width = aSize.width + "px";
+	buffer.style.height = aSize.height + "px";
+}
+
+// REMOVED: Legacy else block utilizing CGBitmapGraphicsContextCreate due to guaranteed canvas support.


### PR DESCRIPTION
… compatibility

* Remove PIXEL macro and replace with native inline string concatenation.
* Remove CPHTMLCanvasFeature branching and obsolete CGBitmapGraphicsContextCreate fallback.
* Convert var declarations to block-scoped const.
* Standardize global function assignments to explicit C-style declarations.
* Remove unused CPCompatibility.j import.