### PR TITLE
Refactor METHOD_CALL_STRING macro to Javascript function

### DIFF
--- a/Foundation/CPException.j
+++ b/Foundation/CPException.j
@@ -248,8 +248,13 @@ if (Error.prototype._userInfo !== null)
 
 [CPException initialize];
 
-#define METHOD_CALL_STRING()\
-    ((class_isMetaClass(anObject.isa) ? "+" : "-") + "[" + [anObject className] + " " + aSelector + "]: ")
+// MARK: - Exception Utilities
+
+function _CPMethodCallString(anObject, aSelector)
+{
+	var prefix = class_isMetaClass(anObject.isa) ? "+" : "-";
+	return prefix + "[" + [anObject className] + " " + aSelector + "]: ";
+}
 
 function _CPRaiseInvalidAbstractInvocation(anObject, aSelector)
 {


### PR DESCRIPTION
Replace the unhygienic METHOD_CALL_STRING() C pre-processor macro in CPException.j with a standard JavaScript helper function, _CPMethodCallString().

Add a `// MARK: - Exception Utilities` navigation landmark.

This removes a legacy text-substitution dependency, enabling single-pass AST generation for the platform-native compilation pipeline.