### PR TITLE
replace unload event listener with pagehide

### DIFF
--- a/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
@@ -481,7 +481,7 @@ _CPPlatformWindowWillCloseNotification = @"_CPPlatformWindowWillCloseNotificatio
         _DOMWindow.addEventListener("blur", onBlurEventCallback, NO);
         _DOMWindow.addEventListener("focus", onFocusEventCallback, NO);
 
-        _DOMWindow.addEventListener("unload", function()
+        _DOMWindow.addEventListener("pagehide", function()
         {
             _DOMWindow.removeEventListener("unload", arguments.callee, NO);
 


### PR DESCRIPTION
- **Replace `unload` event listener with `pagehide`**: Modern browsers (Chrome 115+) deprecate `unload` and enforce a Permissions Policy that logs `[Violation] Permissions policy violation: unload is not allowed in this document`. Updating to `pagehide` satisfies the policy while maintaining proper window cleanup and bfcache compatibility.
