### PR TITLE
Add test for @accessors(copy)

### DIFF
--- a/Tests/Objective-J/CopyAccessorTest.j
+++ b/Tests/Objective-J/CopyAccessorTest.j
@@ -1,0 +1,48 @@
+@import <Foundation/Foundation.j>
+
+@implementation CopyAccessorTestClass : CPObject
+{
+    CPMutableArray ivar @accessors(copy);
+}
+
+@end
+
+@implementation CopyAccessorTest : OJTestCase
+{
+    CopyAccessorTestClass testClass;
+}
+
+- (void)setUp
+{
+    testClass = [[CopyAccessorTestClass alloc] init];
+}
+
+- (void)testCopyAccessorStoresDistinctObject
+{
+    var original = [@"a", @"b"];
+
+    [testClass setIvar:original];
+
+    [self assertFalse:[testClass ivar] === original];
+}
+
+- (void)testCopyAccessorIsUnaffectedByLaterMutation
+{
+    var original = [@"a", @"b"];
+
+    [testClass setIvar:original];
+    [original addObject:@"c"];
+
+    [self assert:2 equals:[[testClass ivar] count]];
+}
+
+- (void)testCopyAccessorPreservesContentAtAssignment
+{
+    var original = [@"a", @"b"];
+
+    [testClass setIvar:original];
+
+    [self assert:original equals:[testClass ivar]];
+}
+
+@end


### PR DESCRIPTION
@accessors(copy) had no test in ./Tests.
The compiler's copy-accessor setter behaviour was unverified.

Add CopyAccessorTest.j to Tests/Objective-J. It asserts three properties of the generated setter:
- the stored value is not identical to the assigned object
- the stored value is unaffected by later mutation of the original
- the stored value is equal in content to the original at assignment

This is added both as a matter of good coverage for the existing toolchain and so that new tooling has a reference for a piece of foundational behaviour.