### PR TITLE
fixed: import missing dependencies and declare layout orientation typedef in CPStackView

### DIFF
--- a/AppKit/CPStackView.j
+++ b/AppKit/CPStackView.j
@@ -20,7 +20,16 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+@import <Foundation/CPGeometry.j>
+@import <Foundation/CPMapTable.j>
+
+@import "CPLayoutConstraint.j"
 @import "CPView.j"
+
+// Layout Orientation
+@typedef CPUserInterfaceLayoutOrientation
+    CPUserInterfaceLayoutOrientationHorizontal  = 0;
+    CPUserInterfaceLayoutOrientationVertical    = 1;
 
 // Gravity Areas
 @typedef CPStackViewGravity


### PR DESCRIPTION
Fixes missing type and symbol compiler warnings when compiling CPStackView.j:
- Add `@import <Foundation/CPGeometry.j>` for CPEdgeInsets functions and types
- Add `@import <Foundation/CPMapTable.j>` for CPMapTable
- Add `@import "CPLayoutConstraint.j"` for CPLayoutAttribute enum constants
- Add `@typedef CPUserInterfaceLayoutOrientation` enum declaration

Fixes #3271