### PR TITLE
Remove CPScrollView build warning

### DIFF
--- a/AppKit/CPTextView/CPRulerView.j
+++ b/AppKit/CPTextView/CPRulerView.j
@@ -36,6 +36,7 @@ CPRulerOrientationHorizontal = 0,
 CPRulerOrientationVertical = 1
 
 @class CPRulerView;
+@class CPScrollView;
 
 
 // MARK: - CPRulerMarker (Interactive Handles with Dynamic Alignment Icons)


### PR DESCRIPTION
CPRulerView.j did not import CPScrollView.
A direct import would create a cycle, since CPScrollView.j already imports CPRulerView.j. Added a forward declaration instead.