### PR TITLE
Fix build warnings in _CPTableTextAttachment

### DIFF
--- a/AppKit/CPTextView/_CPTableTextAttachment.j
+++ b/AppKit/CPTextView/_CPTableTextAttachment.j
@@ -19,7 +19,8 @@
  */
 
 @import "CPView.j"
-@import "CPTextView.j"
+@class CPTextView;
+@class CPTextContainer;
 @import "CPTextField.j"
 @import <Foundation/CPAttributedString.j>
 


### PR DESCRIPTION
Replaced the CPTextView.j import with forward declarations for CPTextView and CPTextContainer (the latter previously reached via the removed import).

The previous import graph created a circular dependency (_CPTableTextAttachment.j -> CPTextView.j -> _CPRTFParser.j / _CPRTFProducer.j -> _CPTableTextAttachment.j).

This caused the legacy compiler to emit a class registration warning during clean builds, as the class was unregistered at the time of resolution. Incremental builds masked this warning via cached symbol tables.

Using forward declarations breaks the cycle and ensures warning-free clean and incremental builds.