### PR TITLE
Add missing CPTextTab forward declaration in CPRulerView

### DIFF
--- a/AppKit/CPTextView/CPRulerView.j
+++ b/AppKit/CPTextView/CPRulerView.j
@@ -37,6 +37,7 @@ CPRulerOrientationVertical = 1
 
 @class CPRulerView;
 @class CPScrollView;
+@class CPTextTab;
 
 
 // MARK: - CPRulerMarker (Interactive Handles with Dynamic Alignment Icons)


### PR DESCRIPTION
CPRulerView.j referenced CPTextTab (isKindOfClass: and alloc/init) without a declaration.

Added @class CPTextTab; to resolve the symbol reference. A forward declaration was utilized rather than importing CPParagraphStyle.j to minimize dependency coupling, despite the absence of a circular import risk.

Resolves build warning.