### PR TITLE
Address CPRulerOrientation build warning

### DIFF
--- a/AppKit/CPTextView/CPRulerView.j
+++ b/AppKit/CPTextView/CPRulerView.j
@@ -29,11 +29,11 @@
 @import "CPMenuItem.j"
 
 // Orientations matching AppKit standards
-// typedef enum CPRulerOrientation
-CPHorizontalRuler = 0,
-CPVerticalRuler = 1,
-CPRulerOrientationHorizontal = 0,
-CPRulerOrientationVertical = 1
+@typedef CPRulerOrientation
+CPHorizontalRuler = 0;
+CPVerticalRuler = 1;
+CPRulerOrientationHorizontal = 0;
+CPRulerOrientationVertical = 1;
 
 @class CPRulerView;
 @class CPScrollView;


### PR DESCRIPTION
CPRulerView.j declared CPRulerOrientation's constants directly, with only a comment claiming it was a typedef.

No @typedef directive existed, so the type was unknown wherever used as an ivar or parameter type.

Added the missing @typedef CPRulerOrientation, matching the pattern already used for CPTextAlignment in CPText.j.