### PR TITLE
Remove CPTabStopType build warning

### DIFF
--- a/AppKit/CPTextView/CPParagraphStyle.j
+++ b/AppKit/CPTextView/CPParagraphStyle.j
@@ -26,7 +26,7 @@
 
 CPParagraphStyleAttributeName = @"CPParagraphStyleAttributeName";
 
-// Define missing global tab stop type constants
+@typedef CPTabStopType
 CPLeftTabStopType = 0;
 CPRightTabStopType = 1;
 CPCenterTabStopType = 2;


### PR DESCRIPTION
CPParagraphStyle.j defined CPTabStopType's four constants directly, with a comment noting they were "missing" but no @typedef for the type itself.

_CPRTFParser.j uses CPTabStopType as an ivar type and imports CPParagraphStyle.j directly, so the fix belongs in the defining file.

Added the missing @typedef CPTabStopType, same pattern as CPRulerOrientation.