### PR TITLE
Clear _CPFontPanelPreviewView build warning

### DIFF
--- a/AppKit/CPTextView/CPFontPanel.j
+++ b/AppKit/CPTextView/CPFontPanel.j
@@ -36,6 +36,7 @@
 @class CPLayoutManager
 @class CPTextContainer
 @class CPFontManager
+@class _CPFontPanelPreviewView
 
 /*
     Collection indexes


### PR DESCRIPTION
CPFontPanel.j used _CPFontPanelPreviewView as an ivar type and instantiated it before its own @implementation, later in the same file, with no forward declaration. Added @class _CPFontPanelPreviewView, alongside the file's existing forward declarations.

This removes all build warnings.