### PR TITLE
fix: replace legacy `unload` event listener cleanup with `pagehide`

### DIFF
--- a/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
+++ b/AppKit/Platform/DOM/CPPlatformWindow+DOM.j
@@ -483,7 +483,7 @@ _CPPlatformWindowWillCloseNotification = @"_CPPlatformWindowWillCloseNotificatio
 
         _DOMWindow.addEventListener("pagehide", function()
         {
-            _DOMWindow.removeEventListener("unload", arguments.callee, NO);
+            _DOMWindow.removeEventListener("pagehide", arguments.callee, NO);
 
             [self blurEvent:nil];
             [self _notifyPlatformWindowWillClose];


### PR DESCRIPTION
Fixes a modern browser warning/violation triggered by the deprecation of the `unload` event:
> `[Violation] Permissions policy violation: unload is not allowed in this document.`

Modern Chromium-based browsers (Chrome, Edge) are deprecating and disabling the `unload` event by default in favor of `pagehide` to improve performance and enable bfcache (Back/Forward cache). 

In `CPPlatformWindow+DOM.j`, `registerDOMWindow` was already updated to listen to `pagehide`, but the handler cleanup function was still attempting to call `removeEventListener("unload", ...)`. This triggered the Permissions Policy violation warning when the window teardown logic was registered/executed.