### PR TITLE
ci: Restrict Node.js test matrix to version 24.x

### DIFF
--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 21.x, 22.x, 23.x, 24.x]
+        node-version: [24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/main-branch-publish-manual-tests.yaml
+++ b/.github/workflows/main-branch-publish-manual-tests.yaml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Use Node.js
         uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
 
       - run: echo "${PWD}/dist/cappuccino/bin" >> $GITHUB_PATH
       - run: echo "${PWD}/dist/objective-j/bin" >> $GITHUB_PATH


### PR DESCRIPTION
Modify GitHub Actions workflows to execute strictly against Node.js 24.x.
* Reduced the execution matrix in BuildAndTest.yml to remove deprecated and redundant runtimes (versions 20 through 23).
* Explicitly pinned the setup-node step in main-branch-publish-manual-tests.yaml to version 24.x.

This eliminates unnecessary CI resource consumption. Node 24 is the active LTS, and exhaustive version testing is no longer warranted for the legacy infrastructure given the transition to the native Go toolchain.