### PR TITLE
Fix undeclared _clientView instance variable in CPRulerView

### DIFF
--- a/AppKit/CPTextView/CPRulerView.j
+++ b/AppKit/CPTextView/CPRulerView.j
@@ -215,6 +215,8 @@ CPRulerOrientationVertical = 1;
     CPScrollView        _scrollView             @accessors(property=scrollView);
     CPRulerOrientation  _orientation            @accessors(property=orientation);
 
+    CPView              _clientView;
+
     float               _ruleThickness          @accessors(property=ruleThickness);
     float               _reservedThicknessForMarkers;
     CPArray             _markers;


### PR DESCRIPTION
Declare _clientView within the CPRulerView instance variable block.

This resolves a cold build compilation failure where the Objective-J parser flags assignments to the undeclared variable as illegal global variable creations.